### PR TITLE
Max button align fix

### DIFF
--- a/Gem/Transfer/Scenes/AmountScene.swift
+++ b/Gem/Transfer/Scenes/AmountScene.swift
@@ -125,7 +125,7 @@ struct AmountScene: View {
                                 AnyView(
                                     HStack {
                                         Button(Localized.Transfer.max, action: useMax)
-                                            .buttonStyle(ColorButton.lightGray(paddingHorizontal: 16, paddingVertical: 8))
+                                            .buttonStyle(ColorButton.lightGray(paddingHorizontal: Spacing.medium, paddingVertical: Spacing.small))
                                             .fixedSize()
                                     }
                                 )

--- a/Gem/Transfer/Scenes/AmountScene.swift
+++ b/Gem/Transfer/Scenes/AmountScene.swift
@@ -7,11 +7,11 @@ import Components
 import Primitives
 
 struct AmountScene: View {
-    
+
     @StateObject var model: AmounViewModel
-    
+
     @Environment(\.nodeService) private var nodeService
-    
+
     @State var amount: String = ""
     @State private var isPresentingErrorMessage: String?
 
@@ -21,14 +21,14 @@ struct AmountScene: View {
         var id: String { String(rawValue) }
     }
     @FocusState private var focusedField: Field?
-    
+
     // next scene
     @State var transferData: TransferData?
     @State var delegation: DelegationValidator?
-    
+
     var body: some View {
         UITextField.appearance().clearButtonMode = .never
-        
+
         return VStack {
             List {
                 Section { } header: {
@@ -48,7 +48,7 @@ struct AmountScene: View {
                                 .padding(.trailing, 8)
                                 .fixedSize(horizontal: true, vertical: false)
                                 .disabled(model.isInputDisabled)
-                            
+
                             Text(model.assetSymbol)
                                 .font(.system(size: 52))
                                 .fontWeight(.semibold)
@@ -56,7 +56,7 @@ struct AmountScene: View {
                                 .foregroundColor(Colors.black)
                                 .fixedSize()
                         }
-                        
+
                         ZStack {
                             Text(model.fiatAmount(amount: amount))
                                 .font(Font.system(size: 16))
@@ -72,13 +72,15 @@ struct AmountScene: View {
                 .textCase(nil)
                 .listRowSeparator(.hidden)
                 .listRowInsets(EdgeInsets())
-                
+
                 if let validator = model.currentValidator  {
                     Section(Localized.Stake.validator) {
                         //TODO: Use this, other option does not work for some reason
-//                        NavigationLink(value: Scenes.Validators()) {
-//                            ListItemView(title: validator.name, subtitle: .none)
-//                        }
+                        /*
+                        NavigationLink(value: Scenes.Validators()) {
+                            ListItemView(title: validator.name, subtitle: .none)
+                        }
+                         */
                         if model.isSelectValidatorEnabled {
                             NavigationCustomLink(with:
                                 HStack {
@@ -104,7 +106,7 @@ struct AmountScene: View {
                 }
                 if model.isBalanceViewEnabled {
                     Section {
-                        VStack(alignment: .center) {
+                        VStack {
                             AssetListItemView {
                                 AssetImageView(assetImage: model.assetImage)
                             } primary: {
@@ -121,19 +123,21 @@ struct AmountScene: View {
                                 )
                             } secondary: {
                                 AnyView(
-                                    Button(Localized.Transfer.max, action: useMax)
-                                        .buttonStyle(ColorButton.lightGray(paddingHorizontal: 16, paddingVertical: 8))
-                                        .fixedSize()
+                                    HStack {
+                                        Button(Localized.Transfer.max, action: useMax)
+                                            .buttonStyle(ColorButton.lightGray(paddingHorizontal: 16, paddingVertical: 8))
+                                            .fixedSize()
+                                    }
                                 )
                             }
                         }
-                        .frame(maxWidth: Spacing.scene.button.maxWidth)
+                        .frame(maxWidth: .infinity)
                     }
                 }
             }
-            
+
             Spacer()
-            
+
             Button(Localized.Common.continue, action: {
                 Task { await next() }
             })
@@ -183,10 +187,10 @@ struct AmountScene: View {
             Alert(title: Text(""), message: Text($0))
         }
     }
-    
+
     func next() async {
         //TODO: Move validation per field on demand
-        
+
         do {
             let value = try model.isValidAmount(amount: amount)
             let transfer = try model.getTransferData(value: value)
@@ -195,10 +199,10 @@ struct AmountScene: View {
             isPresentingErrorMessage = error.localizedDescription
         }
     }
-    
+
     func useMax() {
         amount = model.maxBalance
-        
+
         focusedField = .none
     }
 }

--- a/Packages/Components/Sources/AssetListView.swift
+++ b/Packages/Components/Sources/AssetListView.swift
@@ -82,7 +82,7 @@ public struct AssetListItemView: View {
     public var body: some View {
         HStack {
             imageView
-            HStack(alignment: .center) {
+            HStack {
                 primary
                 Spacer(minLength: 2)
                 secondary
@@ -180,7 +180,7 @@ public struct AssetListView: View {
                 }
             )
         }
-        .onChange(of: toggleValue) { newValue in
+        .onChange(of: toggleValue) { _, newValue in
             model.action?(.enabled(newValue))
         }
     }


### PR DESCRIPTION
[f] Improve Max button position #11 <https://github.com/gemwalletcom/gem-ios/issues/11>
[~] re-indent

[~] small refactor assetlistview, removed unused alignment: .center -> center by default
[u] updated onChange iin assetlistview, old one was deprecated

attached images: 
![Simulator Screenshot - iPad (10th generation) - 2024-06-05 at 15 45 01](https://github.com/gemwalletcom/gem-ios/assets/171273137/39032509-89ce-468f-8206-e4a753236a61)
![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-05 at 15 19 39](https://github.com/gemwalletcom/gem-ios/assets/171273137/b11cf0a8-e309-4eac-94d3-dbb2f371971d)
