### PR TITLE
Try downloading binary Gemstone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           just install-typeshare && just install-toolchains && just install-swifttools
 
       - name: Build Core
-        run: just install-gemstone-ci
+        run: just install-gemstone
 
       - name: Unit Tests
         run: just test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           just install-typeshare && just install-toolchains && just install-swifttools
 
       - name: Build Core
-        run: just generate-stone
+        run: just install-gemstone-ci
 
       - name: Unit Tests
         run: just test

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ DerivedData/
 Packages/Gemstone/
 .vscode/settings.json
 build
+*.tar.bz2
+.xcframework/

--- a/Gem.xcodeproj/project.pbxproj
+++ b/Gem.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		481152C22B54F46800377C75 /* Gemstone in Frameworks */ = {isa = PBXBuildFile; productRef = 481152C12B54F46800377C75 /* Gemstone */; };
-		481152C82B566AC200377C75 /* Gemstone in Frameworks */ = {isa = PBXBuildFile; productRef = 481152C72B566AC200377C75 /* Gemstone */; };
 		830ED2342C63AE2000B9877C /* FeeUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830ED2332C63AE2000B9877C /* FeeUnit.swift */; };
 		830ED2362C63AE4D00B9877C /* FeeUnitViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830ED2352C63AE4D00B9877C /* FeeUnitViewModel.swift */; };
 		830FDA382C204E07003DA605 /* AddNodeScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830FDA372C204E07003DA605 /* AddNodeScene.swift */; };
@@ -552,6 +550,7 @@
 		DF8421EE2C1526ED003F558C /* GemstonePrimitives in Frameworks */ = {isa = PBXBuildFile; productRef = DF8421ED2C1526ED003F558C /* GemstonePrimitives */; };
 		DF8868892C50F1EB00005AEA /* CalloutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF8868882C50F1EB00005AEA /* CalloutView.swift */; };
 		DF88688B2C50F27D00005AEA /* ShowPrivateKeyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF88688A2C50F27D00005AEA /* ShowPrivateKeyViewModel.swift */; };
+		DF93C4EE2C969F4F00204ABD /* Gemstone in Frameworks */ = {isa = PBXBuildFile; productRef = DF93C4ED2C969F4F00204ABD /* Gemstone */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -897,7 +896,6 @@
 				DF8421EE2C1526ED003F558C /* GemstonePrimitives in Frameworks */,
 				C3CF3BA729B5317300E96586 /* Keystore in Frameworks */,
 				C366791D2A18623800F1D74D /* QRScanner in Frameworks */,
-				481152C22B54F46800377C75 /* Gemstone in Frameworks */,
 				C3A7CB7C29CA5F7000431341 /* Store in Frameworks */,
 				C3A7CB8129CBA31E00431341 /* CSQLite in Frameworks */,
 				C36679162A119C6200F1D74D /* GemAPI in Frameworks */,
@@ -905,7 +903,7 @@
 				C3CF3B7B29A98C7B00E96586 /* Primitives in Frameworks */,
 				C3CF3BDB29BBE45D00E96586 /* Style in Frameworks */,
 				C35DA07C2A9C3B4B008CCEFA /* Settings in Frameworks */,
-				481152C82B566AC200377C75 /* Gemstone in Frameworks */,
+				DF93C4EE2C969F4F00204ABD /* Gemstone in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2219,9 +2217,8 @@
 				C35DA07B2A9C3B4B008CCEFA /* Settings */,
 				D8D203CF2AE078BE00261CA2 /* WalletConnector */,
 				D8D203D22AE0818C00261CA2 /* SwiftHTTPClient */,
-				481152C12B54F46800377C75 /* Gemstone */,
-				481152C72B566AC200377C75 /* Gemstone */,
 				DF8421ED2C1526ED003F558C /* GemstonePrimitives */,
+				DF93C4ED2C969F4F00204ABD /* Gemstone */,
 			);
 			productName = wallet;
 			productReference = C30952B0299C39D70004C0F9 /* Gem.app */;
@@ -3501,14 +3498,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		481152C12B54F46800377C75 /* Gemstone */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Gemstone;
-		};
-		481152C72B566AC200377C75 /* Gemstone */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = Gemstone;
-		};
 		C35DA07B2A9C3B4B008CCEFA /* Settings */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Settings;
@@ -3681,6 +3670,10 @@
 		DF8421ED2C1526ED003F558C /* GemstonePrimitives */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = GemstonePrimitives;
+		};
+		DF93C4ED2C969F4F00204ABD /* Gemstone */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Gemstone;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+export GEMSTONE_VERSION = 0.2.0
+
 list:
     just --list
 
@@ -27,6 +29,10 @@ install-gemstone VERSION:
     rm -rf Packages/Gemstone && mkdir -p Packages/Gemstone
     wget https://github.com/gemwalletcom/core/releases/download/{{VERSION}}/Gemstone-spm.tar.bz2 -O Packages/Gemstone-spm.tar.bz2
     tar -xvjf Gemstone-spm.tar.bz2 -C Packages/Gemstone
+
+install-gemstone-ci:
+    @echo "==> Install binary Gemstone on CI"
+    just install-gemstone {{GEMSTONE_VERSION}}
 
 setup-git:
     @echo "==> Setup git submodules"

--- a/justfile
+++ b/justfile
@@ -17,14 +17,14 @@ install-swifttools:
     @echo "==> Install SwiftGen and SwiftFormat"
     @brew install swiftgen swiftformat
 
-bootstrap: install install-gemstone-ci
+bootstrap: install install-gemstone
     @echo "<== Bootstrap done."
 
-install-wallet-core VERSION:
+download-wallet-core VERSION:
     @echo "==> Install wallet-core {{VERSION}}"
     wget https://github.com/trustwallet/wallet-core/releases/download/{{VERSION}}/Package.swift -O Packages/WalletCore/Package.swift
 
-install-gemstone VERSION:
+download-gemstone VERSION:
     #!/usr/bin/env bash
     echo "==> Install binary Gemstone {{VERSION}}"
     rm -rf Packages/Gemstone && mkdir -p Packages/Gemstone
@@ -33,8 +33,8 @@ install-gemstone VERSION:
     tar -xvjf Gemstone-spm.tar.bz2
     rm Gemstone-spm.tar.bz2
 
-install-gemstone-ci:
-    @echo "==> Install binary Gemstone on CI"
+install-gemstone:
+    @echo "==> Install binary Gemstone {{GEMSTONE_VERSION}}"
     just install-gemstone {{GEMSTONE_VERSION}}
 
 setup-git:

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-export GEMSTONE_VERSION = 0.2.0
+export GEMSTONE_VERSION := "v0.2.0"
 
 list:
     just --list
@@ -57,7 +57,7 @@ localize:
     just generate-model
     just generate-swiftgen
 
-generate: generate-model generate-stone generate-swiftgen
+generate: generate-model generate-swiftgen
 
 generate-model:
     @echo "==> Generate typeshare for iOS"

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ install-swifttools:
     @echo "==> Install SwiftGen and SwiftFormat"
     @brew install swiftgen swiftformat
 
-bootstrap: install generate
+bootstrap: install install-gemstone-ci
     @echo "<== Bootstrap done."
 
 install-wallet-core VERSION:
@@ -25,10 +25,13 @@ install-wallet-core VERSION:
     wget https://github.com/trustwallet/wallet-core/releases/download/{{VERSION}}/Package.swift -O Packages/WalletCore/Package.swift
 
 install-gemstone VERSION:
-    @echo "==> Install binary Gemstone {{VERSION}}"
+    #!/usr/bin/env bash
+    echo "==> Install binary Gemstone {{VERSION}}"
     rm -rf Packages/Gemstone && mkdir -p Packages/Gemstone
-    wget https://github.com/gemwalletcom/core/releases/download/{{VERSION}}/Gemstone-spm.tar.bz2 -O Packages/Gemstone-spm.tar.bz2
-    tar -xvjf Gemstone-spm.tar.bz2 -C Packages/Gemstone
+    cd Packages/Gemstone
+    wget https://github.com/gemwalletcom/core/releases/download/{{VERSION}}/Gemstone-spm.tar.bz2
+    tar -xvjf Gemstone-spm.tar.bz2
+    rm Gemstone-spm.tar.bz2
 
 install-gemstone-ci:
     @echo "==> Install binary Gemstone on CI"

--- a/justfile
+++ b/justfile
@@ -18,6 +18,16 @@ install-swifttools:
 bootstrap: install generate
     @echo "<== Bootstrap done."
 
+install-wallet-core VERSION:
+    @echo "==> Install wallet-core {{VERSION}}"
+    wget https://github.com/trustwallet/wallet-core/releases/download/{{VERSION}}/Package.swift -O Packages/WalletCore/Package.swift
+
+install-gemstone VERSION:
+    @echo "==> Install binary Gemstone {{VERSION}}"
+    rm -rf Packages/Gemstone && mkdir -p Packages/Gemstone
+    wget https://github.com/gemwalletcom/core/releases/download/{{VERSION}}/Gemstone-spm.tar.bz2 -O Packages/Gemstone-spm.tar.bz2
+    tar -xvjf Gemstone-spm.tar.bz2 -C Packages/Gemstone
+
 setup-git:
     @echo "==> Setup git submodules"
     @git submodule update --init --recursive


### PR DESCRIPTION
Add a few commands to `justfile`: 
- `download-wallet-core VERSION`, easier way to update wallet core
- `download-gemstone VERSION`
- `install-gemstone`, install default version defined in `justfile`

If you still need to build local Gemstone, run `just generate-stone` it will override the downloaded binary framework, make sure tag new version in core and update `GEMSTONE_VERSION` in `justfile` if you need to change core, otherwise CI might fail.