### PR TITLE
Migrate away from using pairing topic in WalletConnect

### DIFF
--- a/Packages/Store/Sources/Migrations.swift
+++ b/Packages/Store/Sources/Migrations.swift
@@ -62,6 +62,10 @@ public struct Migrations {
             try PriceAlertRecord.create(db: db)
         }
 
+        migrator.registerMigration("Clear deprecated pairing WalletConnect sessions") { db in
+            try WalletConnectionRecord.deleteAll(db)
+        }
+
         try migrator.migrate(dbQueue)
     }
 }

--- a/Packages/WalletConnector/Sources/WalletConnector.swift
+++ b/Packages/WalletConnector/Sources/WalletConnector.swift
@@ -307,7 +307,7 @@ extension Chain {
 extension Session {
     var asSession: Primitives.WalletConnectionSession {
         WalletConnectionSession(
-            id: pairingTopic,
+            id: peer.metadata.url,
             sessionId: topic,
             state: .active,
             chains: [],


### PR DESCRIPTION
Replace pairing id with dapp url in meta, `ConnectionsStore` delete method has this filter

```swift
.filter(ids.contains(Columns.Connection.id) || ids.contains(Columns.Connection.sessionId) )
```
will test if it works expected