### PR TITLE
Buy state button

### DIFF
--- a/Gem/Fiat/Scenes/BuyAssetScene.swift
+++ b/Gem/Fiat/Scenes/BuyAssetScene.swift
@@ -39,6 +39,7 @@ struct BuyAssetScene: View {
             StateButton(
                 text: model.actionButtonTitle,
                 viewState: model.state,
+                showProgressIndicator: false,
                 action: onSelectContinue
             )
             .frame(maxWidth: Spacing.scene.button.maxWidth)

--- a/Gem/Onboarding/Scenes/ImportWalletScene.swift
+++ b/Gem/Onboarding/Scenes/ImportWalletScene.swift
@@ -173,7 +173,7 @@ extension String: @retroactive Identifiable {
 
 extension ImportWalletScene {
     func onImportWallet() {
-        model.buttonState = .loading
+        model.buttonState = .loading(showProgress: true)
 
         Task {
             try await Task.sleep(for: .milliseconds(50))

--- a/Gem/Onboarding/Scenes/VerifyPhraseWalletScene.swift
+++ b/Gem/Onboarding/Scenes/VerifyPhraseWalletScene.swift
@@ -69,7 +69,7 @@ struct VerifyPhraseWalletScene: View {
 
 extension VerifyPhraseWalletScene {
     func onImportWallet() {
-        model.buttonState = .loading
+        model.buttonState = .loading(showProgress: true)
 
         Task {
             try await Task.sleep(for: .milliseconds(50))

--- a/Packages/Components/Sources/Buttons/StateButton.swift
+++ b/Packages/Components/Sources/Buttons/StateButton.swift
@@ -83,15 +83,14 @@ public struct StateButton: View {
                 action: action,
                 label: {
                     HStack {
-                        Group {
-                            if let image {
-                                image
-                            }
-                            Text(textValue.text)
+                        if let image {
+                            image
+                                .foregroundStyle(textValue.style.color)
                         }
-                        .foregroundStyle(textValue.style.color)
-                        .font(textValue.style.font)
+                        Text(textValue.text)
+                            .foregroundStyle(textValue.style.color)
                     }
+                    .font(textValue.style.font)
                 }
             )
             .disabled(isDisabled)

--- a/Packages/Components/Sources/Buttons/StateButton.swift
+++ b/Packages/Components/Sources/Buttons/StateButton.swift
@@ -83,12 +83,15 @@ public struct StateButton: View {
                 action: action,
                 label: {
                     HStack {
-                        if let image {
-                            image
+                        Group {
+                            if let image {
+                                image
+                            }
+                            Text(textValue.text)
                         }
-                        Text(textValue.text)
+                        .foregroundStyle(textValue.style.color)
+                        .font(textValue.style.font)
                     }
-                    .font(textValue.style.font)
                 }
             )
             .disabled(isDisabled)

--- a/Packages/Components/Sources/Buttons/StateButton.swift
+++ b/Packages/Components/Sources/Buttons/StateButton.swift
@@ -17,6 +17,7 @@ public struct StateButton: View {
         text: String,
         textStyle: TextStyle = StateButton.defaultTextStyle,
         viewState: StateViewType<T>,
+        showProgressIndicator: Bool = true,
         image: Image? = nil,
         infoTitle: String? = nil,
         infoTitleStyle: TextStyle = .calloutSecondary,
@@ -29,7 +30,7 @@ public struct StateButton: View {
             case .noData:
                 return .disabled
             case .loading:
-                return .loading
+                return .loading(showProgress: showProgressIndicator)
             case .loaded:
                 return .normal
             case .error:
@@ -41,7 +42,14 @@ public struct StateButton: View {
             }
         }()
 
-        self.init(text: text, textStyle: textStyle, styleState: styleState, image: image, infoTitle: infoTitle, infoTitleStyle: infoTitleStyle, action: action)
+        self.init(text: text,
+                  textStyle: textStyle,
+                  styleState: styleState,
+                  image: image,
+                  infoTitle: infoTitle,
+                  infoTitleStyle: infoTitleStyle,
+                  action: action
+        )
     }
 
     public init(
@@ -55,25 +63,7 @@ public struct StateButton: View {
     ) {
         self.textValue = TextValue(text: text, style: textStyle)
         self.styleState = styleState
-        if let infoTitle {
-            self.infoTextValue = TextValue(text: infoTitle, style: infoTitleStyle)
-        } else {
-            self.infoTextValue = nil
-        }
-        self.action = action
-        self.image = image
-    }
-
-    public init(
-        textValue: TextValue,
-        styleState: StateButtonStyle.State,
-        infoTextValue: TextValue? = nil,
-        image: Image? = nil,
-        action: @escaping () -> Void
-    ) {
-        self.textValue = textValue
-        self.styleState = styleState
-        self.infoTextValue = infoTextValue
+        self.infoTextValue = infoTitle.map({ TextValue(text: $0, style: infoTitleStyle) })
         self.action = action
         self.image = image
     }
@@ -95,12 +85,10 @@ public struct StateButton: View {
                     HStack {
                         if let image {
                             image
-                                .font(textValue.style.font)
-                                .foregroundStyle(textValue.style.color)
                         }
                         Text(textValue.text)
-                            .textStyle(textValue.style)
                     }
+                    .font(textValue.style.font)
                 }
             )
             .disabled(isDisabled)
@@ -124,7 +112,7 @@ public struct StateButton: View {
         }
 
         Section(header: Text("Loading State")) {
-            StateButton(text: "Submit", styleState: .loading, image: Image(systemName: SystemImage.faceid), action: {})
+            StateButton(text: "Submit", styleState: .loading(showProgress: true), image: Image(systemName: SystemImage.faceid), action: {})
         }
 
         Section(header: Text("Disabled State")) {


### PR DESCRIPTION
Added show progress option to loading state ( if disabled - we change background to indicate progress, if enabled - current flow )
BuyAsset scene removed progress from state button

images:
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/6faab285-65b5-48c4-ba4e-4ef71cc1a37b" style="width: 45%;" /></td>
    <td><img src="https://github.com/user-attachments/assets/463b4f6f-bc8b-4f7a-b459-ca5fd8f00ba5" style="width: 45%;" /></td>
  </tr>
</table>