### PR TITLE
Fix Solana message signing

### DIFF
--- a/Packages/Keystore/Sources/Extensions/SignDigest+Keystore.swift
+++ b/Packages/Keystore/Sources/Extensions/SignDigest+Keystore.swift
@@ -19,6 +19,12 @@ extension SignMessage {
             }
             return EthereumAbi.encodeTyped(messageJson: jsonString)
         case .base58:
+            guard
+                let string = String(data: data, encoding: .utf8),
+                let data = Base58.decodeNoCheck(string: string)
+            else {
+                return Data()
+            }
             return data
         }
     }

--- a/Packages/Keystore/Sources/LocalKeystore.swift
+++ b/Packages/Keystore/Sources/LocalKeystore.swift
@@ -202,7 +202,7 @@ public final class LocalKeystore: Keystore {
     
     public func sign(wallet: Primitives.Wallet, message: SignMessage, chain: Chain) throws -> Data {
         let password = try keystorePassword.getPassword()
-        return try walletKeyStore.sign(message: message, walletId: wallet.id, password: password, chain: chain)
+        return try walletKeyStore.sign(message: message, walletId: wallet.id, type: wallet.type, password: password, chain: chain)
     }
     
     public func destroy() throws {

--- a/Packages/Keystore/Sources/Store/WalletKeyStore.swift
+++ b/Packages/Keystore/Sources/Store/WalletKeyStore.swift
@@ -159,10 +159,12 @@ public struct WalletKeyStore {
         return MnemonicFormatter.toArray(string: hdwallet.mnemonic)
     }
     
-    public func sign(message: SignMessage, walletId: String, password: String, chain: Chain) throws -> Data {
-        let wallet = try getWallet(id: walletId)
-        let key = try wallet.privateKey(password: password, coin: chain.coinType)
-        guard var signature = key.sign(digest: message.hash, curve: chain.coinType.curve) else {
+    public func sign(message: SignMessage, walletId: String, type: Primitives.WalletType, password: String, chain: Chain) throws -> Data {
+        let key = try getPrivateKey(id: walletId, type: type, chain: chain, password: password)
+        guard
+            let privateKey = PrivateKey(data: key),
+            var signature = privateKey.sign(digest: message.hash, curve: chain.coinType.curve)
+        else {
             throw AnyError("no data signed")
         }
         switch message.type {

--- a/Packages/Keystore/Tests/KeystoreTests/LocalKeystoreTests.swift
+++ b/Packages/Keystore/Tests/KeystoreTests/LocalKeystoreTests.swift
@@ -83,9 +83,7 @@ final class LocalKeystoreTests {
 
     @Test
     func testSignSolanaMessage() throws {
-        let words = "stick legend attitude middle cave habit shy hobby round thing tilt ostrich alter sad mad moon weekend sport reflect wheat another pyramid captain broom".split(separator: " ").map(String.init)
         let keystore = LocalKeystore.mock()
-        let base58 = "5bFXeAgaUCGcCYYF1W4JgLtSk9msXeo6ponmZfZWJV5UtYZ8xsJQVaRWRwVWsn6KxUqF4Jg26DzZ8FGojZ6PHpzK"
         let wallet = try keystore.importWallet(name: "Test Solana", type: .phrase(words: words, chains: [.solana]))
 
         let text = "5A2EYggC6hiAAuRArnkAANGySDyqQUGrbBHXfKQD9DQ5XcSkReDswnRqb7x3KRrnie9qSL"
@@ -93,7 +91,7 @@ final class LocalKeystoreTests {
         let signature = try keystore.sign(wallet: wallet, message: message, chain: .solana)
         let encoded = Base58.encodeNoCheck(data: signature)
 
-        #expect(encoded == "3hLxQP3sV5k8Lats7Ao8tvViZzGnPgdaaxMfrQnvmNx3hj9BNDXq2w1ES7ZWMtNwxYzZ6ojim4hK9FgbVXnLpETb")
+        #expect(encoded == "5ZRaXVuDePowJjZmKaMjfcuqBVZet6e8QiCjTkGXBn7xhCvoEswUKXiGs2wmPxcqTfJUH28eCC91J1vLSjANNM9v")
     }
 
     @Test

--- a/Packages/Keystore/Tests/KeystoreTests/LocalKeystoreTests.swift
+++ b/Packages/Keystore/Tests/KeystoreTests/LocalKeystoreTests.swift
@@ -83,16 +83,17 @@ final class LocalKeystoreTests {
 
     @Test
     func testSignSolanaMessage() throws {
+        let words = "stick legend attitude middle cave habit shy hobby round thing tilt ostrich alter sad mad moon weekend sport reflect wheat another pyramid captain broom".split(separator: " ").map(String.init)
         let keystore = LocalKeystore.mock()
-        let base58 = "4UzFMkVbk1q6ApxvDS8inUxg4cMBxCQRVXRx5msqQyktbi1QkJkt574Jda6BjZThSJi54CHfVoLFdVFX8XFn233L" // 0xae2f9a10cac1ce71c7be3585a9af1f38de358abde0d875ad0a95352d49fbedf6
-        let wallet = try keystore.importWallet(name: "Test Solana", type: .privateKey(text: base58, chain: .solana))
+        let base58 = "5bFXeAgaUCGcCYYF1W4JgLtSk9msXeo6ponmZfZWJV5UtYZ8xsJQVaRWRwVWsn6KxUqF4Jg26DzZ8FGojZ6PHpzK"
+        let wallet = try keystore.importWallet(name: "Test Solana", type: .phrase(words: words, chains: [.solana]))
 
         let text = "5A2EYggC6hiAAuRArnkAANGySDyqQUGrbBHXfKQD9DQ5XcSkReDswnRqb7x3KRrnie9qSL"
         let message = SignMessage(type: .base58, data: Data(text.utf8))
         let signature = try keystore.sign(wallet: wallet, message: message, chain: .solana)
         let encoded = Base58.encodeNoCheck(data: signature)
 
-        #expect(encoded == "4XW3xB7PxuUhboDUzX3qsfkB7v7XN6HaieE8KhtidzgF22wZsY5qFonCStxvpmnAMP4R9dxeFUuMcd2NJo7QeGNw")
+        #expect(encoded == "3hLxQP3sV5k8Lats7Ao8tvViZzGnPgdaaxMfrQnvmNx3hj9BNDXq2w1ES7ZWMtNwxYzZ6ojim4hK9FgbVXnLpETb")
     }
 
     @Test

--- a/Packages/Keystore/Tests/KeystoreTests/LocalKeystoreTests.swift
+++ b/Packages/Keystore/Tests/KeystoreTests/LocalKeystoreTests.swift
@@ -87,11 +87,12 @@ final class LocalKeystoreTests {
         let base58 = "4UzFMkVbk1q6ApxvDS8inUxg4cMBxCQRVXRx5msqQyktbi1QkJkt574Jda6BjZThSJi54CHfVoLFdVFX8XFn233L" // 0xae2f9a10cac1ce71c7be3585a9af1f38de358abde0d875ad0a95352d49fbedf6
         let wallet = try keystore.importWallet(name: "Test Solana", type: .privateKey(text: base58, chain: .solana))
 
-        let text = "Linking wallet to email: annex_deviator960@simplelogin.com"
-        let message = SignMessage(type: .base58, data: text.data(using: .utf8)!)
+        let text = "5A2EYggC6hiAAuRArnkAANGySDyqQUGrbBHXfKQD9DQ5XcSkReDswnRqb7x3KRrnie9qSL"
+        let message = SignMessage(type: .base58, data: Data(text.utf8))
         let signature = try keystore.sign(wallet: wallet, message: message, chain: .solana)
+        let encoded = Base58.encodeNoCheck(data: signature)
 
-        #expect(signature.hexString == "1e8c381e97b78d1cc76367713a6c1587509ea5f8ce67344cefa5907d248db53b9b5f20e3bb268b119e93f7ad4381b3612a74e9100077a03722468f7da2624f0d")
+        #expect(encoded == "4XW3xB7PxuUhboDUzX3qsfkB7v7XN6HaieE8KhtidzgF22wZsY5qFonCStxvpmnAMP4R9dxeFUuMcd2NJo7QeGNw")
     }
 
     @Test

--- a/Packages/Keystore/Tests/KeystoreTests/LocalKeystoreTests.swift
+++ b/Packages/Keystore/Tests/KeystoreTests/LocalKeystoreTests.swift
@@ -82,6 +82,19 @@ final class LocalKeystoreTests {
     }
 
     @Test
+    func testSignSolanaMessage() throws {
+        let keystore = LocalKeystore.mock()
+        let base58 = "4UzFMkVbk1q6ApxvDS8inUxg4cMBxCQRVXRx5msqQyktbi1QkJkt574Jda6BjZThSJi54CHfVoLFdVFX8XFn233L" // 0xae2f9a10cac1ce71c7be3585a9af1f38de358abde0d875ad0a95352d49fbedf6
+        let wallet = try keystore.importWallet(name: "Test Solana", type: .privateKey(text: base58, chain: .solana))
+
+        let text = "Linking wallet to email: annex_deviator960@simplelogin.com"
+        let message = SignMessage(type: .base58, data: text.data(using: .utf8)!)
+        let signature = try keystore.sign(wallet: wallet, message: message, chain: .solana)
+
+        #expect(signature.hexString == "1e8c381e97b78d1cc76367713a6c1587509ea5f8ce67344cefa5907d248db53b9b5f20e3bb268b119e93f7ad4381b3612a74e9100077a03722468f7da2624f0d")
+    }
+
+    @Test
     func testImportWIF() {
         #expect(throws: Never.self) {
             let wif = "L1NGZutRxaVotZSfRzGnFYUj42LjEL66ZdAeSDA8CbyASZWizHLA"


### PR DESCRIPTION
Changes:
1. Use `getPrivateKey` same as tx signing
2. Add a signing test with recovery phrase import (private key worked)

How to test:
- Go to https://jupuary.jup.ag/ and link a wallet