### PR TITLE
Privacy text adjusted "asterisk" to "asterisk operator" style

### DIFF
--- a/Packages/Components/Sources/Privacy/PrivacyText.swift
+++ b/Packages/Components/Sources/Privacy/PrivacyText.swift
@@ -12,7 +12,7 @@ public struct PrivacyText: View {
     public init(
         _ text: String,
         isEnabled: Binding<Bool>,
-        placeholder: String = "*****"
+        placeholder: String = "∗∗∗∗∗"
     ) {
         self.text = text
         self.placeholder = placeholder


### PR DESCRIPTION
images:
![image](https://github.com/user-attachments/assets/06f8a1f2-5aab-4efc-a4c6-c754d388828e)
