### PR TITLE
Updates background color for nft scene

### DIFF
--- a/Features/NFT/Sources/Scenes/NFTScene.swift
+++ b/Features/NFT/Sources/Scenes/NFTScene.swift
@@ -67,7 +67,7 @@ public struct NFTScene: View {
             }
         }
         .padding(.horizontal, Spacing.medium)
-        .background(Colors.grayBackground)
+        .background(Colors.insetGroupedListStyle)
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(model.title)
         .taskOnce(fetch)

--- a/Packages/Style/Sources/Colors.swift
+++ b/Packages/Style/Sources/Colors.swift
@@ -18,6 +18,8 @@ public struct Colors {
     public static let grayDarkBackground = Color.dynamicColor("#E6E6F0", dark: "#1C1C1E")
     public static let secondaryText = Color.dynamicColor("#818181")
     public static let listStyleColor = UIColor.dynamicColor(UIColor.systemBackground.color, dark: UIColor.secondarySystemBackground.color)
+    public static let insetGroupedListStyle = UIColor.dynamicColor(UIColor.systemGroupedBackground.color, dark: UIColor.black.color
+    )
 }
 
 #Preview {
@@ -39,6 +41,7 @@ public struct Colors {
         ("Gray Dark Background", Colors.grayDarkBackground),
         ("Secondary Text", Colors.secondaryText),
         ("List style color", Colors.listStyleColor),
+        ("Inset Gropued List style color", Colors.insetGroupedListStyle),
 
     ]
     return List {


### PR DESCRIPTION
closes #395 
images:
OLD:
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/41b2e949-c8f0-4936-aa9d-b7fa29e489ed" style="width: 50%;" /></td>
        <td><img src="https://github.com/user-attachments/assets/38e04eed-7740-43af-acd2-fdc746ee9fff" style="width: 50%;" /></td>
  </tr>
</table>
NEW:
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/8012acab-0381-4406-b378-2b6ca5a23ec6" style="width: 50%;" /></td>
    <td><img src="https://github.com/user-attachments/assets/38e04eed-7740-43af-acd2-fdc746ee9fff" style="width: 50%;" /></td>
  </tr>
</table>