### PR TITLE
Dynamic directory path for wallet image

### DIFF
--- a/Features/ManageWallets/Sources/ViewModels/WalletIDetailViewModel.swift
+++ b/Features/ManageWallets/Sources/ViewModels/WalletIDetailViewModel.swift
@@ -59,21 +59,14 @@ public class WalletDetailViewModel {
     }
     
     func avatarAssetImage(for dbWallet: Wallet) -> AssetImage {
-        guard let imageUrl = dbWallet.imageUrl else {
-            return AssetImage(
-                imageURL: nil,
-                placeholder: WalletViewModel(wallet: dbWallet).image,
-                chainPlaceholder: Images.Wallets.editFilled
-            )
-        }
+        let avatar = WalletViewModel(wallet: dbWallet).avatarImage
         return AssetImage(
-            type: .empty,
-            imageURL: imageUrl.asURL,
-            placeholder: nil,
+            type: avatar.type,
+            imageURL: avatar.imageURL,
+            placeholder: avatar.placeholder,
             chainPlaceholder: Images.Wallets.editFilled
         )
     }
-        
 }
 
 // MARK: - Business Logic

--- a/Features/WalletAvatar/Sources/Scenes/WalletImageScene.swift
+++ b/Features/WalletAvatar/Sources/Scenes/WalletImageScene.swift
@@ -36,6 +36,9 @@ public struct WalletImageScene: View {
             avatar
                 .padding(.top, Spacing.medium)
                 .padding(.bottom, Spacing.extraLarge)
+                .onTapGesture {
+                    model.setDefaultAvatar()
+                }
             
             pickerView
                 .padding(.bottom, Spacing.medium)
@@ -45,15 +48,6 @@ public struct WalletImageScene: View {
         }
         .navigationTitle(model.title)
         .background(Colors.grayBackground)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(Localized.Filter.clear) {
-                    model.setDefaultAvatar()
-                }
-                .bold()
-                .disabled(dbWallet?.imageUrl == nil)
-            }
-        }
     }
     
     private var avatar: some View {

--- a/Packages/Components/Sources/AssetImageView.swift
+++ b/Packages/Components/Sources/AssetImageView.swift
@@ -41,30 +41,26 @@ public struct AssetImageView: View {
     }
 
     public var body: some View {
-        ZStack {
+        CachedAsyncImage(url: assetImage.imageURL, scale: UIScreen.main.scale) {
+            $0.resizable()
+                .animation(.default)
+        } placeholder: {
             if let image = assetImage.placeholder {
                 image.resizable()
-                .cornerRadius(cornerRadius)
-            } else {
-                CachedAsyncImage(url: assetImage.imageURL, scale: UIScreen.main.scale) {
-                    $0.resizable()
-                        .animation(.default)
-                } placeholder: {
-                    if let type = assetImage.type {
-                        ZStack {
-                            Text(type)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.3)
-                                .padding(4)
-                        }
-                        .frame(width: imageSize, height: imageSize)
-                        .cornerRadius(cornerRadius)
-                        .background(Colors.grayBackground)
-                    }
+                    .cornerRadius(cornerRadius)
+            } else if let type = assetImage.type {
+                ZStack {
+                    Text(type)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.3)
+                        .padding(4)
                 }
+                .frame(width: imageSize, height: imageSize)
                 .cornerRadius(cornerRadius)
+                .background(Colors.grayBackground)
             }
         }
+        .cornerRadius(cornerRadius)
         .overlay(
             assetImage.chainPlaceholder?
                 .resizable()

--- a/Packages/PrimitivesComponents/Sources/ViewModels/WalletViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/WalletViewModel.swift
@@ -44,19 +44,24 @@ public struct WalletViewModel {
     }
     
     public var avatarImage: AssetImage {
-        guard let imageUrl = wallet.imageUrl else {
-            return AssetImage(
-                imageURL: nil,
-                placeholder: image,
-                chainPlaceholder: subImage
-            )
-        }
-        return AssetImage(
-            type: .empty,
-            imageURL: imageUrl.asURL,
-            placeholder: nil,
-            chainPlaceholder: WalletViewModel(wallet: wallet).subImage
+        AssetImage(
+            type: wallet.name,
+            imageURL: imageUrl(),
+            placeholder: image,
+            chainPlaceholder: subImage
         )
+    }
+    
+    // MARK: - Private methods
+    
+    private func imageUrl() -> URL? {
+        guard let imageUrl = wallet.imageUrl else {
+            return nil
+        }
+        if let url = URL(string: imageUrl), url.scheme != nil {
+            return url
+        }
+        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent(imageUrl)
     }
 }
 

--- a/Packages/Store/Sources/Migrations.swift
+++ b/Packages/Store/Sources/Migrations.swift
@@ -220,15 +220,6 @@ public struct Migrations {
                 $0.add(column: Columns.Wallet.updatedAt.name, .date)
             }
         }
-        
-        #if DEBUG
-        // Clears the imageUrl field in the database when running in Debug mode,
-        // because the file path changes on the simulator, preventing the wallet avatar from loading.
-        let _ = try? dbQueue.write { db in
-            try? WalletRecord
-                .updateAll(db, Columns.Wallet.imageUrl.set(to: nil))
-        }
-        #endif
 
         try migrator.migrate(dbQueue)
     }

--- a/Packages/Store/Sources/Stores/WalletStore.swift
+++ b/Packages/Store/Sources/Stores/WalletStore.swift
@@ -113,10 +113,10 @@ public struct WalletStore: Sendable {
         return SubscriptionsObserver(dbQueue: db)
     }
     
-    public func setWalletAvatar(_ walletId: String, url: URL?) throws {
+    public func setWalletAvatar(_ walletId: String, path: String?) throws {
         let _ = try db.write { db in
             let assignments = [
-                Columns.Wallet.imageUrl.set(to: url),
+                Columns.Wallet.imageUrl.set(to: path),
                 Columns.Wallet.updatedAt.set(to: Date.now)
             ]
             return try WalletRecord

--- a/Packages/Store/Sources/Types/WalletRecordInfo.swift
+++ b/Packages/Store/Sources/Types/WalletRecordInfo.swift
@@ -22,7 +22,7 @@ extension WalletRecordInfo {
             accounts: accounts.map { $0.mapToAccount() },
             order: wallet.order.asInt32,
             isPinned: wallet.isPinned,
-            imageUrl: imageUrl()
+            imageUrl: wallet.imageUrl
         )
     }
 }
@@ -38,17 +38,5 @@ extension WalletConnectionInfo {
             session: connection.session,
             wallet: wallet.mapToWallet()
         )
-    }
-}
-
-fileprivate extension WalletRecordInfo {
-    func imageUrl() -> String? {
-        guard let imageUrl = wallet.imageUrl else {
-            return nil
-        }
-        if let url = URL(string: imageUrl), url.scheme != nil {
-            return url.absoluteString
-        }
-        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent(imageUrl).absoluteString
     }
 }

--- a/Packages/Store/Sources/Types/WalletRecordInfo.swift
+++ b/Packages/Store/Sources/Types/WalletRecordInfo.swift
@@ -22,7 +22,7 @@ extension WalletRecordInfo {
             accounts: accounts.map { $0.mapToAccount() },
             order: wallet.order.asInt32,
             isPinned: wallet.isPinned,
-            imageUrl: wallet.imageUrl
+            imageUrl: imageUrl()
         )
     }
 }
@@ -38,5 +38,17 @@ extension WalletConnectionInfo {
             session: connection.session,
             wallet: wallet.mapToWallet()
         )
+    }
+}
+
+fileprivate extension WalletRecordInfo {
+    func imageUrl() -> String? {
+        guard let imageUrl = wallet.imageUrl else {
+            return nil
+        }
+        if let url = URL(string: imageUrl), url.scheme != nil {
+            return url.absoluteString
+        }
+        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent(imageUrl).absoluteString
     }
 }

--- a/Services/AvatarService/Sources/AvatarService.swift
+++ b/Services/AvatarService/Sources/AvatarService.swift
@@ -7,8 +7,11 @@ import UIKit
 
 public struct AvatarService: Sendable {
     private let store: WalletStore
+    private static let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
     
-    public init(store: WalletStore) {
+    public init(
+        store: WalletStore
+    ) {
         self.store = store
     }
     
@@ -28,7 +31,7 @@ public struct AvatarService: Sendable {
     }
     
     public func remove(for walletId: String) throws {
-        let path = try folder(for: walletId)
+        let path = try folderPath(for: walletId)
         try removeIfExist(at: path)
         try store.setWalletAvatar(walletId, path: nil)
     }
@@ -39,30 +42,30 @@ public struct AvatarService: Sendable {
         let path = try preparePath(for: walletId)
         try data.write(to: path, options: .atomic)
 
-        try store.setWalletAvatar(walletId, path: folderPath(for: walletId) + path.lastPathComponent)
+        try store.setWalletAvatar(walletId, path: avatarsPath(for: walletId) + path.lastPathComponent)
     }
     
     // MARK: - FileManager Private Methods
     
     private func preparePath(for walletId: String) throws -> URL {
-        try removeIfExist(at: try folder(for: walletId))
-        let rootPath = try folder(for: walletId)
-        return rootPath.appendingPathComponent(UUID().uuidString + ".png")
+        let folderPath = try folderPath(for: walletId)
+        try removeIfExist(at: folderPath)
+        return folderPath.appendingPathComponent(UUID().uuidString + ".png")
     }
     
-    private func folder(for walletId: String) throws -> URL {
-        guard let documentsDirectory = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+    private func folderPath(for walletId: String) throws -> URL {
+        guard let documentsDirectory = Self.documentsDirectory else {
             throw AnyError("Unable to fetch URLs for the specified common directory in the requested domains.")
         }
-        
-        let dataPath = documentsDirectory.appendingPathComponent(folderPath(for: walletId))
-        if !FileManager.default.fileExists(atPath: dataPath.path) {
-            try FileManager.default.createDirectory(atPath: dataPath.path, withIntermediateDirectories: true, attributes: nil)
+        let fileManager = FileManager.default
+        let dataPath = documentsDirectory.appendingPathComponent(avatarsPath(for: walletId))
+        if !fileManager.fileExists(atPath: dataPath.path) {
+            try fileManager.createDirectory(atPath: dataPath.path, withIntermediateDirectories: true, attributes: nil)
         }
         return dataPath
     }
     
-    private func folderPath(for walletId: String) -> String {
+    private func avatarsPath(for walletId: String) -> String {
         "Avatars/\(walletId)/"
     }
     

--- a/Services/AvatarService/Sources/AvatarService.swift
+++ b/Services/AvatarService/Sources/AvatarService.swift
@@ -19,26 +19,27 @@ public struct AvatarService: Sendable {
         guard let data = image.compress() else {
             throw AnyError("Compression image failed")
         }
-        
-        let path = try preparePath(for: walletId)
-        try data.write(to: path, options: .atomic)
-
-        try store.setWalletAvatar(walletId, path: folderPath(for: walletId) + path.lastPathComponent)
+        try write(data: data, for: walletId)
     }
     
     public func save(url: URL, for walletId: String) async throws {
         let (data, _) = try await URLSession.shared.data(from: url)
-        
-        let path = try preparePath(for: walletId)
-        try data.write(to: path, options: .atomic)
-
-        try store.setWalletAvatar(walletId, path: folderPath(for: walletId) + path.lastPathComponent)
+        try write(data: data, for: walletId)
     }
     
     public func remove(for walletId: String) throws {
         let path = try folder(for: walletId)
         try removeIfExist(at: path)
         try store.setWalletAvatar(walletId, path: nil)
+    }
+    
+    // MARK: - Private methods
+    
+    private func write(data: Data, for walletId: String) throws {
+        let path = try preparePath(for: walletId)
+        try data.write(to: path, options: .atomic)
+
+        try store.setWalletAvatar(walletId, path: folderPath(for: walletId) + path.lastPathComponent)
     }
     
     // MARK: - FileManager Private Methods

--- a/Services/AvatarService/Sources/AvatarService.swift
+++ b/Services/AvatarService/Sources/AvatarService.swift
@@ -22,7 +22,8 @@ public struct AvatarService: Sendable {
         
         let path = try preparePath(for: walletId)
         try data.write(to: path, options: .atomic)
-        try store.setWalletAvatar(walletId, url: path)
+
+        try store.setWalletAvatar(walletId, path: folderPath(for: walletId) + path.lastPathComponent)
     }
     
     public func save(url: URL, for walletId: String) async throws {
@@ -30,13 +31,14 @@ public struct AvatarService: Sendable {
         
         let path = try preparePath(for: walletId)
         try data.write(to: path, options: .atomic)
-        try store.setWalletAvatar(walletId, url: path)
+
+        try store.setWalletAvatar(walletId, path: folderPath(for: walletId) + path.lastPathComponent)
     }
     
     public func remove(for walletId: String) throws {
         let path = try folder(for: walletId)
         try removeIfExist(at: path)
-        try store.setWalletAvatar(walletId, url: nil)
+        try store.setWalletAvatar(walletId, path: nil)
     }
     
     // MARK: - FileManager Private Methods
@@ -52,11 +54,15 @@ public struct AvatarService: Sendable {
             throw AnyError("Unable to fetch URLs for the specified common directory in the requested domains.")
         }
         
-        let dataPath = documentsDirectory.appendingPathComponent("Avatars/\(walletId)")
+        let dataPath = documentsDirectory.appendingPathComponent(folderPath(for: walletId))
         if !FileManager.default.fileExists(atPath: dataPath.path) {
             try FileManager.default.createDirectory(atPath: dataPath.path, withIntermediateDirectories: true, attributes: nil)
         }
         return dataPath
+    }
+    
+    private func folderPath(for walletId: String) -> String {
+        "Avatars/\(walletId)/"
     }
     
     private func removeIfExist(at url: URL) throws {


### PR DESCRIPTION
After updating the app via the App Store, I encountered an issue where avatars disappeared. iOS does not guarantee the persistence of file system paths during an update. Therefore, for avatars, only the endpoint was stored, while the file system path is dynamic.