### PR TITLE
Avatar fix

### DIFF
--- a/Services/AvatarService/Sources/AvatarService.swift
+++ b/Services/AvatarService/Sources/AvatarService.swift
@@ -48,9 +48,9 @@ public struct AvatarService: Sendable {
     // MARK: - FileManager Private Methods
     
     private func preparePath(for walletId: String) throws -> URL {
-        let folderPath = try folderPath(for: walletId)
-        try removeIfExist(at: folderPath)
-        return folderPath.appendingPathComponent(UUID().uuidString + ".png")
+        try removeIfExist(at: try folderPath(for: walletId))
+        let rootPath = try folderPath(for: walletId)
+        return rootPath.appendingPathComponent(UUID().uuidString + ".png")
     }
     
     private func folderPath(for walletId: String) throws -> URL {

--- a/Services/AvatarService/Sources/AvatarService.swift
+++ b/Services/AvatarService/Sources/AvatarService.swift
@@ -49,8 +49,8 @@ public struct AvatarService: Sendable {
     
     private func preparePath(for walletId: String) throws -> URL {
         try removeIfExist(at: try folderPath(for: walletId))
-        let rootPath = try folderPath(for: walletId)
-        return rootPath.appendingPathComponent(UUID().uuidString + ".png")
+        let folderPath = try folderPath(for: walletId)
+        return folderPath.appendingPathComponent(UUID().uuidString + ".png")
     }
     
     private func folderPath(for walletId: String) throws -> URL {


### PR DESCRIPTION
One variable cannot be used here to delete and write. The previous avatar is deleted by the folder name = walletId. Also try folderPath(for: walletId) creates this folder if necessary.