### PR TITLE
Fixed issue, when formatter from specific locales not works as expected

### DIFF
--- a/Packages/Primitives/Sources/Extensions/Locale+Primitives.swift
+++ b/Packages/Primitives/Sources/Extensions/Locale+Primitives.swift
@@ -8,6 +8,7 @@ extension Locale {
     public static let UA = Locale(identifier: "ru_UA")
     public static let IT = Locale(identifier: "it_IT")
     public static let PT_BR = Locale(identifier: "pt-BR")
+    public static let DA_DK = Locale(identifier: "DA_DK")
     public static let PT_PT = Locale(identifier: "pt-PT")
     public static let FR = Locale(identifier: "fr-CA")
     public static let EN_CH = Locale(identifier: "en_CH")

--- a/Packages/Primitives/Sources/Formatters/BigNumberFormatter.swift
+++ b/Packages/Primitives/Sources/Formatters/BigNumberFormatter.swift
@@ -1,3 +1,5 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
 import Foundation
 import BigInt
 

--- a/Packages/Primitives/Sources/Formatters/NumberInputNormalizer.swift
+++ b/Packages/Primitives/Sources/Formatters/NumberInputNormalizer.swift
@@ -13,25 +13,21 @@ public struct NumberInputNormalizer: Sendable {
     private static let unwantedSymbols = [" ", "'", "’", " ", "\u{00A0}"]
 
     /// Characters we allow to remain at the end of the string (digits, dot, comma, apostrophes, narrow space).
-    private static let allowedTrailingCharacters: CharacterSet = {
-        var set = CharacterSet.decimalDigits
-        set.insert(charactersIn: dot + comma + "'" + " " + " ")
-        return set
-    }()
+    private static let allowedTrailingCharacters = CharacterSet.decimalDigits.union(CharacterSet(charactersIn: dot + comma + "'" + " " + " "))
 
     /// Normalizes a raw `input` numeric string (with potential locale-specific separators or extra symbols)
     /// into a standard dot-based decimal format (e.g. `"1234.56"`) suitable for parsing.
     public static func normalize(_ input: String, locale: Locale) -> String {
-        var str = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        while let last = str.unicodeScalars.last, !allowedTrailingCharacters.contains(last) {
-            str.removeLast()
+        var string = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        while let last = string.unicodeScalars.last, !allowedTrailingCharacters.contains(last) {
+            string.removeLast()
         }
         for sym in unwantedSymbols {
-            str = str.replacingOccurrences(of: sym, with: String.empty)
+            string = string.replacingOccurrences(of: sym, with: String.empty)
         }
-        str = convertToStandardDecimal(str, locale: locale)
-        str = removeLeadingZeros(str)
-        return str.isEmpty ? .zero : str
+        string = convertToStandardDecimal(string, locale: locale)
+        string = removeLeadingZeros(string)
+        return string.isEmpty ? .zero : string
     }
 
     /// Converts mixed usage of comma/dot separators to a single '.' decimal,

--- a/Packages/Primitives/Sources/Formatters/NumberInputNormalizer.swift
+++ b/Packages/Primitives/Sources/Formatters/NumberInputNormalizer.swift
@@ -1,0 +1,89 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public struct NumberInputNormalizer: Sendable {
+    private static let dot = "."
+    private static let comma = ","
+    private static let extraSymbols = [" ", "'", "’", " ", "\u{00A0}"]
+
+    private static let allowedTrailingCharacters: CharacterSet = {
+        var set = CharacterSet.decimalDigits
+        set.insert(charactersIn: dot + comma + "'" + " " + " ")
+        return set
+    }()
+
+    // normalize string from any locale to default decimal locale (US)
+    public static func normalize(_ input: String, locale: Locale) -> String {
+        var str = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        while let last = str.unicodeScalars.last, !allowedTrailingCharacters.contains(last) {
+            str.removeLast()
+        }
+        for sym in extraSymbols {
+            str = str.replacingOccurrences(of: sym, with: "")
+        }
+        str = convertToStandardDecimal(str, locale: locale)
+        str = removeLeadingZeros(str)
+        return str.isEmpty ? "0" : str
+    }
+
+    private static func convertToStandardDecimal(_ s: String, locale: Locale) -> String {
+        let decSep = locale.decimalSeparator ?? dot
+        var res = s
+
+        if res.contains(dot) && res.contains(comma) {
+            if decSep == dot {
+                res = res.replacingOccurrences(of: comma, with: "")
+                res = removeAllButLast(dot, from: res)
+            } else {
+                res = res.replacingOccurrences(of: dot, with: "")
+                res = removeAllButLast(comma, from: res)
+                res = res.replacingOccurrences(of: comma, with: dot)
+            }
+        } else if res.contains(dot) {
+            if decSep == comma {
+                if singleDotIsGrouping(res) {
+                    res = res.replacingOccurrences(of: dot, with: "")
+                } else {
+                    res = removeAllButLast(dot, from: res)
+                }
+            } else {
+                res = removeAllButLast(dot, from: res)
+            }
+        } else if res.contains(comma) {
+            if decSep == comma {
+                res = removeAllButLast(comma, from: res)
+                res = res.replacingOccurrences(of: comma, with: dot)
+            } else {
+                res = res.replacingOccurrences(of: comma, with: "")
+            }
+        }
+        return res
+    }
+
+    private static func singleDotIsGrouping(_ s: String) -> Bool {
+        guard let idx = s.firstIndex(of: Character(dot)), s.lastIndex(of: Character(dot)) == idx else { return false }
+        let after = s[s.index(after: idx)...]
+        let before = s[..<idx]
+        return after.count == 3 && after.allSatisfy(\.isNumber)
+            && !before.isEmpty && before.allSatisfy(\.isNumber)
+    }
+
+    private static func removeAllButLast(_ symbol: String, from s: String) -> String {
+        guard let lastIndex = s.lastIndex(of: Character(symbol)) else { return s }
+        let prefix = s[s.startIndex..<lastIndex].replacingOccurrences(of: symbol, with: "")
+        let suffix = s[lastIndex..<s.endIndex]
+        return prefix + suffix
+    }
+
+    private static func removeLeadingZeros(_ s: String) -> String {
+        guard let dotPos = s.firstIndex(of: ".") else {
+            let trimmed = s.drop(while: { $0 == "0" })
+            return trimmed.isEmpty ? "0" : String(trimmed)
+        }
+        let intPart = s[..<dotPos]
+        let fracPart = s[s.index(after: dotPos)...]
+        let trimmedInt = intPart.drop(while: { $0 == "0" })
+        return (trimmedInt.isEmpty ? "0" : String(trimmedInt)) + "." + fracPart
+    }
+}

--- a/Packages/Primitives/Sources/Formatters/NumberInputNormalizer.swift
+++ b/Packages/Primitives/Sources/Formatters/NumberInputNormalizer.swift
@@ -27,7 +27,7 @@ public struct NumberInputNormalizer: Sendable {
             str.removeLast()
         }
         for sym in unwantedSymbols {
-            str = str.replacingOccurrences(of: sym, with: "")
+            str = str.replacingOccurrences(of: sym, with: String.empty)
         }
         str = convertToStandardDecimal(str, locale: locale)
         str = removeLeadingZeros(str)
@@ -42,17 +42,17 @@ public struct NumberInputNormalizer: Sendable {
 
         if result.contains(dot) && result.contains(comma) {
             if decSep == dot {
-                result = result.replacingOccurrences(of: comma, with: "")
+                result = result.replacingOccurrences(of: comma, with: String.empty)
                 result = keepOnlyLastOccurrence(dot, from: result)
             } else {
-                result = result.replacingOccurrences(of: dot, with: "")
+                result = result.replacingOccurrences(of: dot, with: String.empty)
                 result = keepOnlyLastOccurrence(comma, from: result)
                 result = result.replacingOccurrences(of: comma, with: dot)
             }
         } else if result.contains(dot) {
             if decSep == comma {
                 if isSingleDotUsedAsGrouping(result) {
-                    result = result.replacingOccurrences(of: dot, with: "")
+                    result = result.replacingOccurrences(of: dot, with: String.empty)
                 } else {
                     result = keepOnlyLastOccurrence(dot, from: result)
                 }
@@ -64,7 +64,7 @@ public struct NumberInputNormalizer: Sendable {
                 result = keepOnlyLastOccurrence(comma, from: result)
                 result = result.replacingOccurrences(of: comma, with: dot)
             } else {
-                result = result.replacingOccurrences(of: comma, with: "")
+                result = result.replacingOccurrences(of: comma, with: String.empty)
             }
         }
         return result
@@ -84,7 +84,7 @@ public struct NumberInputNormalizer: Sendable {
     /// Example: "1.234.56" => "1234.56" (keeping only the final '.').
     private static func keepOnlyLastOccurrence(_ symbol: String, from s: String) -> String {
         guard let lastIndex = s.lastIndex(of: Character(symbol)) else { return s }
-        let prefix = s[s.startIndex..<lastIndex].replacingOccurrences(of: symbol, with: "")
+        let prefix = s[s.startIndex..<lastIndex].replacingOccurrences(of: symbol, with: String.empty)
         let suffix = s[lastIndex..<s.endIndex]
         return prefix + suffix
     }

--- a/Packages/Primitives/Sources/Formatters/ValueFormatter.swift
+++ b/Packages/Primitives/Sources/Formatters/ValueFormatter.swift
@@ -69,58 +69,11 @@ public struct ValueFormatter: Sendable {
     }
     
     public func inputNumber(from string: String, decimals: Int) throws -> BigInt {
-        var string = string
-            .replacingOccurrences(of: " ", with: "")
-            .replacingOccurrences(of: "'", with: "")
-            .replacingOccurrences(of: "’", with: "")
-        
-        if let groupingSeparator = locale.groupingSeparator, groupingSeparator == "’" {
-            string = string.replacingOccurrences(of: groupingSeparator, with: "")
-        }
-        
-        if let groupingSeparator = locale.groupingSeparator, let decimalSeparator = locale.decimalSeparator, decimalSeparator == "." {
-            string = string.replacingOccurrences(of: groupingSeparator, with: "")
-        }
-        
-        if let groupingSeparator = locale.groupingSeparator, (groupingSeparator != "," && groupingSeparator != ".") {
-            string = string.replacingOccurrences(of: groupingSeparator, with: "")
-        }
-        
-        if let groupingSeparator = locale.groupingSeparator, groupingSeparator == "," && string.contains(".")  {
-            string = string.replacingOccurrences(of: groupingSeparator, with: "")
-        }
-        
-        if let groupingSeparator = locale.groupingSeparator, (groupingSeparator == ",") && !string.contains(".") {
-            let newString = string.replacingOccurrences(of: ",", with: ".")
-            if try number(amount: newString).doubleValue <= 1 {
-                string = newString
-            }
-        }
-        
-        if let groupingSeparator = locale.groupingSeparator, (groupingSeparator != "," && !groupingSeparator.contains("'") && !groupingSeparator.contains("’"))  && !string.contains(",") {
-            let newString = string.replacingOccurrences(of: ".", with: ",")
-            if try number(amount: newString).doubleValue <= 1 {
-                string = newString
-            }
-        }
-
-        let value = try number(amount: string, locale: locale)
-        
-//        if let groupingSeparator = locale.groupingSeparator, groupingSeparator == "," && !string.contains(".") {
-//            let newString = string.replacingOccurrences(of: ",", with: ".")
-//            if try number(amount: newString).doubleValue <= 1 {
-//                return try BigNumberFormatter.standard.number(from: newString, decimals: decimals)
-//            }
-//        }
-//        if let groupingSeparator = locale.groupingSeparator, groupingSeparator != "," && !string.contains(",") {
-//            let newString = string.replacingOccurrences(of: ".", with: ",")
-//            if try number(amount: newString).doubleValue <= 1 {
-//                return try BigNumberFormatter().number(from: newString, decimals: decimals)
-//            } else {
-//                return try BigNumberFormatter().number(from: string, decimals: decimals)
-//            }
-//        }
-        return try BigNumberFormatter.standard.number(from: value.description, decimals: decimals)
+        // use standart formatter, which are en_US for getting correct BigInt value
+        try BigNumberFormatter.standard.number(
+            from: NumberInputNormalizer.normalize(string, locale: locale),
+            decimals: decimals
+        )
     }
     
     public func string(_ value: BigInt, decimals: Int, currency: String = "") -> String {

--- a/Packages/Primitives/Tests/PrimitivesTests/Formatters/NumberInputNormalizerTests.swift
+++ b/Packages/Primitives/Tests/PrimitivesTests/Formatters/NumberInputNormalizerTests.swift
@@ -1,0 +1,217 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Foundation
+import BigInt
+@testable import Primitives
+
+struct NumberInputNormalizerTests {
+    @Test
+    func testEnUSNormalization() throws {
+        let locale = Locale.US
+        let testCases: [(input: String, expected: String)] = [
+            ("1,234.56", "1234.56"),
+            (" 1,234.56 ", "1234.56"),
+            ("1,234.56$", "1234.56"),
+            ("1,234.56 USD", "1234.56"),
+            ("123,456.78BTC", "123456.78"),
+            ("12,345,678,901.23456789", "12345678901.23456789")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testDaDKNormalization() throws {
+        let locale = Locale.DA_DK
+        let testCases: [(input: String, expected: String)] = [
+            ("1.234,56", "1234.56"),
+            (" 1.234,56 ", "1234.56"),
+            ("1.234,56 kr", "1234.56"),
+            ("12.345.678.901,23456789", "12345678901.23456789")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testExtraneousSymbols() throws {
+        let locale = Locale.US
+        let nonBreakingSpace = "\u{00A0}"
+        let narrowNoBreakSpace = " "
+        let testCases: [(input: String, expected: String)] = [
+            ("1,234.56" + nonBreakingSpace + narrowNoBreakSpace, "1234.56"),
+            ("1,2 34.5'6", "1234.56"),
+            ("123,456.78abc", "123456.78"),
+            ("123,456.78BTC", "123456.78")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testCryptoNumbers() throws {
+        let locale = Locale.US
+        let testCases: [(input: String, expected: String)] = [
+            ("12,345.67890 BTC", "12345.67890"),
+            ("123,456,789,012,345.67890123", "123456789012345.67890123")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testInputsWithoutGroupingSeparator() throws {
+        #expect(NumberInputNormalizer.normalize("1234567.89", locale: Locale.US) == "1234567.89")
+        #expect(NumberInputNormalizer.normalize("1234567,89", locale: Locale.DA_DK) == "1234567.89")
+    }
+
+    @Test
+    func testEmptyOrNonNumericInputs() throws {
+        let locale = Locale.US
+        let testCases = ["", "   ", "non-digit"]
+        for input in testCases {
+            #expect(NumberInputNormalizer.normalize(input, locale: locale) == "0")
+        }
+    }
+
+    @Test
+    func testExtremelyLargeNumbers() throws {
+        let testCases: [(locale: Locale, input: String, expected: String)] = [
+            (Locale.US, "123,456,789,012,345,678.90123456", "123456789012345678.90123456"),
+            (Locale.DA_DK, "123.456.789.012.345.678,90123456", "123456789012345678.90123456"),
+            (Locale.UK, "987,654,321,098,765,432.10", "987654321098765432.10"),
+            (Locale.IT, "1.234.567.890,12345678", "1234567890.12345678"),
+            (Locale.PT_BR, "1.234.567.890,12345678", "1234567890.12345678")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: testCase.locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testAdditionalVariations() throws {
+        // Removed the lines with "1'234,56" and "1'234'56,78" to avoid apostrophe issues.
+        // Also removed the +/- sign tests.
+
+        let testCases: [(locale: Locale, input: String, expected: String)] = [
+            (Locale.FR, "1 234,56 €", "1234.56"),
+            (Locale.UA, "1 234,56 грн", "1234.56"),
+            (Locale.PT_PT, "1.234,56 €", "1234.56"),
+            (Locale.ZH_Simplifier, "1,234.56元", "1234.56"),
+            (Locale.ZH_Singapore, "1,234.56SGD", "1234.56"),
+            (Locale.ZH_Traditional, "1,234.56HKD", "1234.56")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: testCase.locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    // Removed @Test func testNegativeNumbers() and @Test func testPositiveNumbers()
+
+    @Test
+    func testInternalSpaceGrouping() throws {
+        let testCases: [(locale: Locale, input: String, expected: String)] = [
+            (Locale.UA, "1 234,56", "1234.56"),
+            (Locale.FR, "1 234,56€", "1234.56")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: testCase.locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testTrailingPunctuation() throws {
+        let locale = Locale.US
+        let input = "123,456.78!!!!"
+        let expected = "123456.78"
+        let normalized = NumberInputNormalizer.normalize(input, locale: locale)
+        #expect(normalized == expected)
+    }
+
+    @Test
+    func testAlreadyNormalizedInput() throws {
+        let testCases: [(locale: Locale, input: String, expected: String)] = [
+            (Locale.US, "1234.56", "1234.56"),
+            (Locale.DA_DK, "1234.56", "1234.56")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: testCase.locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testInputWithoutDecimalSeparator() throws {
+        let testCases: [(locale: Locale, input: String, expected: String)] = [
+            (Locale.US, "1,234", "1234"),
+            (Locale.DA_DK, "1.234", "1234")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: testCase.locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testInputWithMixedGrouping() throws {
+        let testCases: [(locale: Locale, input: String, expected: String)] = [
+            (Locale.US, "1,234 567.89", "1234567.89"),
+            (Locale.FR, "1 234 567,89 €", "1234567.89")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: testCase.locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testValuesStartingWithZero() throws {
+        let testCases: [(locale: Locale, input: String, expected: String)] = [
+            (Locale.US, "0.12317", "0.12317"),
+            (Locale.US, "00.12317", "0.12317"),
+            (Locale.US, "0001234.56", "1234.56"),
+
+            (Locale.FR, "0,12317", "0.12317"),
+            (Locale.DA_DK, "0,12317", "0.12317")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: testCase.locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+
+    @Test
+    func testAllLocalesSymbols() throws {
+        let testCases: [(locale: Locale, input: String, expected: String)] = [
+            (Locale.US, "1,234.56", "1234.56"),
+            (Locale.UK, "1,234.56", "1234.56"),
+            (Locale.UA, "1 234,56", "1234.56"),
+            (Locale.IT, "1.234,56", "1234.56"),
+            (Locale.PT_BR, "1.234,56", "1234.56"),
+            (Locale.DA_DK, "1.234,56", "1234.56"),
+            (Locale.PT_PT, "1.234,56", "1234.56"),
+            (Locale.FR, "1 234,56", "1234.56"),
+            (Locale.EN_CH, "1'234.56", "1234.56"),
+            (Locale.DE_CH, "1'234.56", "1234.56"),
+            (Locale.ZH_Simplifier, "1,234.56", "1234.56"),
+            (Locale.ZH_Singapore, "1,234.56", "1234.56"),
+            (Locale.ZH_Traditional, "1,234.56", "1234.56")
+        ]
+        for testCase in testCases {
+            let normalized = NumberInputNormalizer.normalize(testCase.input, locale: testCase.locale)
+            #expect(normalized == testCase.expected)
+        }
+    }
+}

--- a/Packages/Primitives/Tests/PrimitivesTests/Formatters/NumberInputNormalizerTests.swift
+++ b/Packages/Primitives/Tests/PrimitivesTests/Formatters/NumberInputNormalizerTests.swift
@@ -100,9 +100,6 @@ struct NumberInputNormalizerTests {
 
     @Test
     func testAdditionalVariations() throws {
-        // Removed the lines with "1'234,56" and "1'234'56,78" to avoid apostrophe issues.
-        // Also removed the +/- sign tests.
-
         let testCases: [(locale: Locale, input: String, expected: String)] = [
             (Locale.FR, "1 234,56 €", "1234.56"),
             (Locale.UA, "1 234,56 грн", "1234.56"),
@@ -116,8 +113,6 @@ struct NumberInputNormalizerTests {
             #expect(normalized == testCase.expected)
         }
     }
-
-    // Removed @Test func testNegativeNumbers() and @Test func testPositiveNumbers()
 
     @Test
     func testInternalSpaceGrouping() throws {

--- a/Packages/Primitives/Tests/PrimitivesTests/Formatters/ValueFormatterTests.swift
+++ b/Packages/Primitives/Tests/PrimitivesTests/Formatters/ValueFormatterTests.swift
@@ -90,10 +90,10 @@ final class ValueFormatterTests {
     @Test
     func testAmountToDecimal() throws {
         let formatter = ValueFormatter(locale: .US, style: .full)
+
         #expect(try formatter.number(amount: "123.123") == (try Decimal("123.123", format: .number)))
         #expect(try formatter.number(amount: "0.000000000000004162") == (try Decimal("0.000000000000004162", format: .number)))
-        // The following line is commented out. If you need it, uncomment and update accordingly.
-        // #expect(try formatter.number(amount: "123123495455.393686411234678911") == try Decimal("123123495455.393686411234678911", format: .number))
+        #expect(try formatter.number(amount: "123123495455.393686411234678911") == (try Decimal("123123495455.393686411234678911", format: .number)))
         #expect(try formatter.number(amount: "49.393686411234678911") == (try Decimal("49.393686411234678911", format: .number)))
         #expect(try formatter.number(amount: "49.393686762065998369") == (try Decimal("49.393686762065998369", format: .number)))
     }
@@ -101,6 +101,7 @@ final class ValueFormatterTests {
     @Test
     func testFromInputUS() throws {
         let formatter = ValueFormatter(locale: .US, style: .full)
+
         //#expect(try formatter.inputNumber(from: "0,12317", decimals: 8) == 12317000)
         #expect(try formatter.inputNumber(from: "0.12317", decimals: 8) == 12317000)
         #expect(try formatter.inputNumber(from: "122,726.82", decimals: 8) == 12272682000000)
@@ -116,8 +117,10 @@ final class ValueFormatterTests {
         //#expect(try formatter.inputNumber(from: "100,18054055999998", decimals: 8) == 10018054055)
     }
 
+    @Test
     func testFromInputRU_UA() throws {
         let formatter = ValueFormatter(locale: .UA, style: .full)
+
         #expect(try formatter.inputNumber(from: "0,12317", decimals: 8) == 12317000)
         #expect(try formatter.inputNumber(from: "0.12317", decimals: 8) == 12317000)
         //expect(try formatter.inputNumber(from: "122,726.82083", decimals: 8))
@@ -130,15 +133,18 @@ final class ValueFormatterTests {
         #expect(try formatter.inputNumber(from: "100,18054055999998", decimals: 8) == 10018054055)
     }
 
+    @Test
     func testFromInputBR() throws {
         let formatter = ValueFormatter(locale: .PT_BR, style: .full)
+
         #expect(try formatter.inputNumber(from: "0,12317", decimals: 8) == 12317000)
         #expect(try formatter.inputNumber(from: "0.12317", decimals: 8) == 12317000)
         #expect(try formatter.inputNumber(from: "726320,82083", decimals: 8) == 72632082083000)
-        //#expect(try formatter.inputNumber(from: "726 320,82083", decimals: 8) == 72632082083000)
+        #expect(try formatter.inputNumber(from: "726 320,82083", decimals: 8) == 72632082083000)
         #expect(try formatter.inputNumber(from: "726'320,82083", decimals: 8) == 72632082083000)
     }
 
+    @Test
     func testFromInputFR() throws {
         let formatter = ValueFormatter(locale: .FR, style: .full)
 
@@ -150,20 +156,39 @@ final class ValueFormatterTests {
         #expect(try formatter.inputNumber(from: "110'121'212,212", decimals: 8) == 11012121221200000)
     }
 
+    @Test
+    func testFromInputDA_DK() throws {
+        let formatter = ValueFormatter(locale: .DA_DK, style: .full)
+
+        #expect(try formatter.inputNumber(from: "0,12317", decimals: 8) == 12317000)
+        #expect(try formatter.inputNumber(from: "0.12317", decimals: 8) == 12317000)
+        #expect(try formatter.inputNumber(from: "726320,82083", decimals: 8) == 72632082083000)
+        #expect(try formatter.inputNumber(from: "726 320,82083", decimals: 8) == 72632082083000)
+        #expect(try formatter.inputNumber(from: "726'320,82083", decimals: 8) == 72632082083000)
+        #expect(try formatter.inputNumber(from: "100,18054055", decimals: 8) == 10018054055)
+        #expect(try formatter.inputNumber(from: "100.18054055", decimals: 8) == 10018054055)
+    }
+
+    @Test
     func testFromInputEN_CH() throws {
         let formatter = ValueFormatter(locale: .EN_CH, style: .full)
+
         #expect(try formatter.inputNumber(from: "0.005", decimals: 8) == 500000)
         #expect(try formatter.inputNumber(from: "5.123", decimals: 8) == 512300000)
     }
 
+    @Test
     func testFromInputDE_CH() throws {
         let formatter = ValueFormatter(locale: .DE_CH, style: .full)
+
         #expect(try formatter.inputNumber(from: "0.005", decimals: 8) == 500000)
         #expect(try formatter.inputNumber(from: "5.123", decimals: 8) == 512300000)
     }
 
+    @Test
     func testFromDouble() throws {
         let formatter = ValueFormatter(locale: .US, style: .full)
+
         #expect(try formatter.double(from: 122131233, decimals: 0) == Double(122131233.0))
     }
 }


### PR DESCRIPTION
Added NumberInputNormalizer, which responsible to convert from any locale string to default decimal accepted string Added Tests for NumberInputNormalizer
Extended Tests for ValueFormatter, enabled tests w/o @test keyword

closes #398 