### PR TITLE
Updates swift-tools-version for some packages

### DIFF
--- a/Packages/WalletCore/Package.swift
+++ b/Packages/WalletCore/Package.swift
@@ -1,4 +1,5 @@
-// swift-tools-version:5.3
+// swift-tools-version: 6.0
+
 import PackageDescription
 
 let package = Package(

--- a/Services/WalletConnectorService/Package.swift
+++ b/Services/WalletConnectorService/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 


### PR DESCRIPTION
Migrated from swift-tools-version from 5.3 -> 6 for WalletCore & WalletConnectorService, we are using 6 as primary for all packages