### PR TITLE
Fixes for Price Alerts: Correct Messages, Currency Usage, and Syncing

### DIFF
--- a/Features/PriceAlerts/Sources/ViewModels/PriceAlertItemViewModel.swift
+++ b/Features/PriceAlerts/Sources/ViewModels/PriceAlertItemViewModel.swift
@@ -14,12 +14,9 @@ public struct PriceAlertItemViewModel: ListAssetItemViewable {
     public let data: PriceAlertData
     private let priceModel: PriceViewModel
 
-    public init(
-        data: PriceAlertData,
-        preferences: Preferences = .standard
-    ) {
+    public init(data: PriceAlertData) {
         self.data = data
-        self.priceModel = PriceViewModel(price: data.price, currencyCode: preferences.currency)
+        self.priceModel = PriceViewModel(price: data.price, currencyCode: data.priceAlert.currency)
     }
 
     public var showBalancePrivacy: Binding<Bool> { .constant(false) }

--- a/Gem/Resources/ar.lproj/Localizable.strings
+++ b/Gem/Resources/ar.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "جهات الاتصال";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/de.lproj/Localizable.strings
+++ b/Gem/Resources/de.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Kontakte";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/en.lproj/Localizable.strings
+++ b/Gem/Resources/en.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Contacts";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/es.lproj/Localizable.strings
+++ b/Gem/Resources/es.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Contactos";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/fa.lproj/Localizable.strings
+++ b/Gem/Resources/fa.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "مخاطبین";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/fr.lproj/Localizable.strings
+++ b/Gem/Resources/fr.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Contacts";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/he.lproj/Localizable.strings
+++ b/Gem/Resources/he.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "אנשי קשר";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/hi.lproj/Localizable.strings
+++ b/Gem/Resources/hi.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "संपर्क";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/id.lproj/Localizable.strings
+++ b/Gem/Resources/id.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Kontak";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/it.lproj/Localizable.strings
+++ b/Gem/Resources/it.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Contatti";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/ja.lproj/Localizable.strings
+++ b/Gem/Resources/ja.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "連絡先";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/ko.lproj/Localizable.strings
+++ b/Gem/Resources/ko.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "콘택트 렌즈";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/pl.lproj/Localizable.strings
+++ b/Gem/Resources/pl.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Łączność";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/pt-BR.lproj/Localizable.strings
+++ b/Gem/Resources/pt-BR.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Contatos";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/ru.lproj/Localizable.strings
+++ b/Gem/Resources/ru.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Контакты";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/th.lproj/Localizable.strings
+++ b/Gem/Resources/th.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "ติดต่อเรา";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/tr.lproj/Localizable.strings
+++ b/Gem/Resources/tr.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "İletişim";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/uk.lproj/Localizable.strings
+++ b/Gem/Resources/uk.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Контакти";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/vi.lproj/Localizable.strings
+++ b/Gem/Resources/vi.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "Liên hệ";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Gem/Resources/zh-Hans.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "联系方式";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Gem/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Gem/Resources/zh-Hant.lproj/Localizable.strings
@@ -358,3 +358,4 @@
 "contacts.title" = "聯絡方式";
 "common.percentage" = "Percentage";
 "price_alerts.set_alert.current_price" = "Current price";
+"price_alerts. added_for" = "Price alert added %@";

--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -515,6 +515,10 @@ public enum Localized {
     }
   }
   public enum PriceAlerts {
+    /// Price alert added %@
+    public static func addedFor(_ p1: Any) -> String {
+      return Localized.tr("Localizable", "price_alerts. added_for", String(describing: p1), fallback: "Price alert added %@")
+    }
     /// Price alert disabled for %@
     public static func disabledFor(_ p1: Any) -> String {
       return Localized.tr("Localizable", "price_alerts.disabled_for", String(describing: p1), fallback: "Price alert disabled for %@")

--- a/Services/PriceAlertService/Sources/PriceAlertService.swift
+++ b/Services/PriceAlertService/Sources/PriceAlertService.swift
@@ -50,13 +50,13 @@ public struct PriceAlertService: Sendable {
         let remote = try await getPriceAlerts()
         let local = try store.getPriceAlerts()
         
-        let changes = SyncValues.changes(primary: .local, local: local.asSet(), remote: remote.asSet())
+        let changes = SyncValues.changes(primary: .remote, local: local.asSet(), remote: remote.asSet())
         
         if !changes.delete.isEmpty {
-            try await delete(priceAlerts: changes.delete.asArray())
+            try store.deletePriceAlerts(changes.delete.asArray())
         }
         if !changes.missing.isEmpty {
-            try await add(priceAlerts: changes.missing.asArray())
+            try store.addPriceAlerts(changes.missing.asArray())
         }
     }
 

--- a/Services/PriceAlertService/Sources/SyncValues.swift
+++ b/Services/PriceAlertService/Sources/SyncValues.swift
@@ -20,12 +20,14 @@ public struct SyncValues: Sendable {
         remote: Set<T>
     ) -> SyncResult<T> {
         switch primary {
-        case .local: SyncResult(
-            missing: local.subtracting(remote),
-            delete: remote.subtracting(local)
-        )
-        case .remote: SyncResult(
-            missing: local.subtracting(remote),
+        case .local:
+            SyncResult(
+                missing: local.subtracting(remote),
+                delete: remote.subtracting(local)
+            )
+        case .remote:
+            SyncResult(
+                missing: remote.subtracting(local),
                 delete: local.subtracting(remote)
             )
         }

--- a/Services/PriceAlertService/Tests/SyncValues.swift
+++ b/Services/PriceAlertService/Tests/SyncValues.swift
@@ -13,7 +13,7 @@ struct Test {
         
         let remoteChanges = SyncValues.changes(primary: .remote, local: ["1", "2", "3"], remote: ["2", "4"])
         
-        #expect(remoteChanges.missing == ["3", "1"])
+        #expect(remoteChanges.missing == ["4"])
         #expect(remoteChanges.delete == ["1", "3"])
     }
 }


### PR DESCRIPTION
Pull request contains changes for Price Alerts:
1. Display correct the message when a custom price alert is added
2. Using the currency from PriceAlert for the list item
3. Changed to the remote primary source for syncing local and remote PriceAlert. This is important because the lastNotifiedAt property indicates which price alert has been delivered.