### PR TITLE
Switching assets button fix. Swap scene

### DIFF
--- a/Gem/Swap/Scenes/SwapScene.swift
+++ b/Gem/Swap/Scenes/SwapScene.swift
@@ -101,19 +101,20 @@ extension SwapScene {
             }
         } header: {
             Text(model.swapFromTitle)
+                .listRowInsets(.horizontalMediumInsets)
         } footer: {
             SwapChangeView(fromId: $model.fromAssetRequest.assetId, toId: $model.toAssetRequest.assetId)
-                .offset(y: .small + .tiny)
+                .padding(.top, .small)
                 .frame(maxWidth: .infinity)
                 .disabled(model.isSwitchAssetButtonDisabled)
                 .textCase(nil)
                 .listRowSeparator(.hidden)
-                .listRowInsets(.zero)
+                .listRowInsets(.horizontalMediumInsets)
         }
     }
     
     private var swapToSectionView: some View {
-        Section(model.swapToTitle) {
+        Section {
             if let swapModel = model.swapTokenModel(type: .receive(chains: [], assetIds: [])) {
                 SwapTokenView(
                     model: swapModel,
@@ -130,6 +131,9 @@ extension SwapScene {
                     onSelectAssetAction: model.onSelectAssetReceive
                 )
             }
+        } header: {
+            Text(model.swapToTitle)
+                .listRowInsets(.horizontalMediumInsets)
         }
     }
     

--- a/Packages/Components/Sources/Extensions/EdgeInsets+Components.swift
+++ b/Packages/Components/Sources/Extensions/EdgeInsets+Components.swift
@@ -3,6 +3,7 @@
 import Foundation
 import SwiftUI
 
-extension EdgeInsets {
-    public static let zero = EdgeInsets()
+public extension EdgeInsets {
+    static let zero = EdgeInsets()
+    static let horizontalMediumInsets = EdgeInsets(top: .zero, leading: .medium, bottom: .zero, trailing: .medium)
 }


### PR DESCRIPTION
The switch asset button from Pay to Receive was partially hidden in the Receive section and was now tappable from the bottom. This PR fixes the issue and provides more space on the Swap scene

Before/After
![collage](https://github.com/user-attachments/assets/a6a82165-ce59-43b0-aad5-f344f25f85d7)

Before/After
![collage_screenshots](https://github.com/user-attachments/assets/c89f4b16-41d7-46ad-975f-a2c25d7b765b)
