### PR TITLE
Added listRowinsets for Wallet & Transactions & Asset transactions

### DIFF
--- a/Features/Transactions/Sources/Scenes/TransactionsScene.swift
+++ b/Features/Transactions/Sources/Scenes/TransactionsScene.swift
@@ -22,6 +22,7 @@ public struct TransactionsScene: View {
                 explorerService: model.explorerService,
                 model.transactions
             )
+            .listRowInsets(.assetListRowInsets)
         }
         .listSectionSpacing(.compact)
         .refreshable(action: model.fetch)

--- a/Features/WalletTab/Sources/Scenes/WalletScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletScene.swift
@@ -91,6 +91,7 @@ public struct WalletScene: View {
                         currencyCode: preferences.preferences.currency,
                         showBalancePrivacy: $preferences.isHideBalanceEnabled
                     )
+                    .listRowInsets(.assetListRowInsets)
                 } header: {
                     HStack {
                         model.pinImage
@@ -114,6 +115,7 @@ public struct WalletScene: View {
                     currencyCode: preferences.preferences.currency,
                     showBalancePrivacy: $preferences.isHideBalanceEnabled
                 )
+                .listRowInsets(.assetListRowInsets)
             } footer: {
                 ListButton(
                     title: model.manageTokenTitle,

--- a/Gem/Asset/Scenes/AssetScene.swift
+++ b/Gem/Asset/Scenes/AssetScene.swift
@@ -139,6 +139,7 @@ struct AssetScene: View {
                     explorerService: model.explorerService,
                     transactions
                 )
+                .listRowInsets(.assetListRowInsets)
             } else {
                 EmptyContentView(model: model.emptyConentModel)
                     .cleanListRow(topOffset: .extraLarge)

--- a/Gem/Assets/Scenes/SelectAssetScene.swift
+++ b/Gem/Assets/Scenes/SelectAssetScene.swift
@@ -102,6 +102,7 @@ struct SelectAssetScene: View {
                         Text(Localized.Common.popular)
                     }
                 }
+                .listRowInsets(.assetListRowInsets)
             }
             
             if !sections.pinned.isEmpty {
@@ -113,11 +114,13 @@ struct SelectAssetScene: View {
                         Text(Localized.Common.pinned)
                     }
                 }
+                .listRowInsets(.assetListRowInsets)
             }
             
             Section {
                 assetsList(assets: sections.assets)
             }
+            .listRowInsets(.assetListRowInsets)
         }
     }
     

--- a/Packages/Components/Sources/Extensions/EdgeInsets+Components.swift
+++ b/Packages/Components/Sources/Extensions/EdgeInsets+Components.swift
@@ -6,4 +6,10 @@ import SwiftUI
 public extension EdgeInsets {
     static let zero = EdgeInsets()
     static let horizontalMediumInsets = EdgeInsets(top: .zero, leading: .medium, bottom: .zero, trailing: .medium)
+    static let assetListRowInsets = EdgeInsets(
+        top: .small + .space4,
+        leading: .small + .space4,
+        bottom: .small + .space4,
+        trailing: .small + .space4
+    )
 }


### PR DESCRIPTION
images:

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/e4f70566-de42-4788-9bd0-3a2398512d48" style="width: 33%;" /></td>
    <td><img src="https://github.com/user-attachments/assets/556570a0-362f-4202-aeed-afb7bc6ff42a" style="width: 33%;" /></td>
    <td><img src="https://github.com/user-attachments/assets/42445aa8-333e-4df7-8885-df2be7491008" style="width: 33%;" /></td>
  </tr>
</table>
