### PR TITLE
Refactor SwapChangeView to use pairSelector and AssetId bindings. Fix 443

### DIFF
--- a/Features/Swap/Sources/Views/SwapChangeView.swift
+++ b/Features/Swap/Sources/Views/SwapChangeView.swift
@@ -3,15 +3,16 @@
 import Foundation
 import SwiftUI
 import Style
+import Primitives
 
 public struct SwapChangeView: View {
     
-    @Binding var fromId: String?
-    @Binding var toId: String?
+    @Binding var fromId: AssetId?
+    @Binding var toId: AssetId?
     
     public init(
-        fromId: Binding<String?> = .constant(.none),
-        toId: Binding<String?> = .constant(.none)
+        fromId: Binding<AssetId?> = .constant(.none),
+        toId: Binding<AssetId?> = .constant(.none)
     ) {
         _fromId = fromId
         _toId = toId

--- a/Gem/Swap/Scenes/SwapScene.swift
+++ b/Gem/Swap/Scenes/SwapScene.swift
@@ -103,7 +103,10 @@ extension SwapScene {
             Text(model.swapFromTitle)
                 .listRowInsets(.horizontalMediumInsets)
         } footer: {
-            SwapChangeView(fromId: $model.fromAssetRequest.assetId, toId: $model.toAssetRequest.assetId)
+            SwapChangeView(
+                fromId: $model.pairSelectorModel.fromAssetId,
+                toId: $model.pairSelectorModel.toAssetId
+            )
                 .padding(.top, .small)
                 .frame(maxWidth: .infinity)
                 .disabled(model.isSwitchAssetButtonDisabled)


### PR DESCRIPTION
Fix: https://github.com/gemwalletcom/gem-ios/issues/443

When you press the switch from Pay to Receive, the id are changed directly in requests while pairSelector still contains the old values.