### PR TITLE
Update expired wallet connect sessions

### DIFF
--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionsScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionsScene.swift
@@ -93,6 +93,7 @@ public struct ConnectionsScene: View {
         }
         )
         .navigationTitle(model.title)
+        .taskOnce { model.updateSessions() }
     }
 
     private func connectURI(uri: String) async {

--- a/Features/WalletConnector/Sources/WalletConnector/Services/ConnectionsService.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Services/ConnectionsService.swift
@@ -37,6 +37,10 @@ public final class ConnectionsService: Sendable {
         try await disconnect(sessionId: session.sessionId)
     }
     
+    public func updateSessions() {
+        connector.updateSessions()
+    }
+    
     // MARK: - Private methods
     
     private func configure() async throws {

--- a/Features/WalletConnector/Sources/WalletConnector/ViewModels/ConnectionsViewModel.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/ViewModels/ConnectionsViewModel.swift
@@ -41,4 +41,8 @@ public struct ConnectionsViewModel: Sendable {
     func disconnect(connection: WalletConnection) async throws {
         try await service.disconnect(session: connection.session)
     }
+    
+    func updateSessions() {
+        service.updateSessions()
+    }
 }

--- a/Services/WalletConnectorService/Sources/WCConnectionsInteractor.swift
+++ b/Services/WalletConnectorService/Sources/WCConnectionsInteractor.swift
@@ -14,4 +14,8 @@ final class WCConnectionsInteractor: Sendable {
     var sessionRequestStream: AsyncStream<(request: Request, context: VerifyContext?)> {
         WalletKit.instance.sessionRequestPublisher.asAsyncStream()
     }
+    
+    var sessions: [Session] {
+        WalletKit.instance.getSessions()
+    }
 }

--- a/Services/WalletConnectorService/Sources/WalletConnectorService.swift
+++ b/Services/WalletConnectorService/Sources/WalletConnectorService.swift
@@ -41,7 +41,6 @@ extension WalletConnectorService {
     }
 
     public func setup() async {
-        updateSessions()
         await withTaskGroup(of: Void.self) { group in
             group.addTask { await self.handleSessions() }
             group.addTask { await self.handleSessionProposals() }


### PR DESCRIPTION
Fix: https://github.com/gemwalletcom/gem-ios/issues/572

sessionsPublisher doesn't work when the session has expired, so we need to use getSessions to update local sessions when the App is lounched and after opening the ConnectionsScene