### PR TITLE
Fiat Scene. Invalid position of fiat symbol fix

### DIFF
--- a/Features/FiatConnect/Sources/ViewModels/FiatQuoteViewModel.swift
+++ b/Features/FiatConnect/Sources/ViewModels/FiatQuoteViewModel.swift
@@ -30,21 +30,14 @@ public struct FiatQuoteViewModel {
 
     public var amountText: String {
         switch quote.type {
-        case .buy: "\(amount) \(asset.symbol)"
-        case .sell: "\(amount) $"
+        case .buy: formatter.string(decimal: Decimal(quote.cryptoAmount), symbol: asset.symbol)
+        case .sell: formatter.string(quote.fiatAmount)
         }
     }
 
     public var rateText: String {
         let amount = quote.fiatAmount / quote.cryptoAmount
         return formatter.string(amount)
-    }
-
-    private var amount: String {
-        switch quote.type {
-        case .buy: formatter.string(decimal: Decimal(quote.cryptoAmount))
-        case .sell: formatter.string(decimal: Decimal(quote.fiatAmount))
-        }
     }
     
     private var isSelected: Bool {

--- a/Features/FiatConnect/Tests/FiatQuoteViewModelTests.swift
+++ b/Features/FiatConnect/Tests/FiatQuoteViewModelTests.swift
@@ -20,9 +20,9 @@ struct FiatQuoteViewModelTests {
 
     @Test
     func testSellAmount() async throws {
-        #expect(FiatQuoteViewModel(asset: .mock(), quote: .mock(type: .sell), formatter: usFormatter).amountText == "0.00 $")
-        #expect(FiatQuoteViewModel(asset: .mock(), quote: .mock(fiatAmount: 10.123, cryptoAmount: 15.12, type: .sell), formatter: usFormatter).amountText == "10.12 $")
-        #expect(FiatQuoteViewModel(asset: .mock(), quote: .mock(fiatAmount: 10, cryptoAmount: 15, type: .sell), formatter: usFormatter).amountText == "10.00 $")
+        #expect(FiatQuoteViewModel(asset: .mock(), quote: .mock(type: .sell), formatter: usFormatter).amountText == "$0.00")
+        #expect(FiatQuoteViewModel(asset: .mock(), quote: .mock(fiatAmount: 10.123, cryptoAmount: 15.12, type: .sell), formatter: usFormatter).amountText == "$10.12")
+        #expect(FiatQuoteViewModel(asset: .mock(), quote: .mock(fiatAmount: 10, cryptoAmount: 15, type: .sell), formatter: usFormatter).amountText == "$10.00")
     }
 
     @Test


### PR DESCRIPTION
Fix: https://github.com/gemwalletcom/gem-ios/issues/576

Tests already implemented 

![resized_80_percent_sell_provider](https://github.com/user-attachments/assets/de3ad24c-695f-4518-b016-554b3e38efce)
