### PR TITLE
Update asset badge background style to list style color

### DIFF
--- a/Packages/Components/Sources/AssetImageView.swift
+++ b/Packages/Components/Sources/AssetImageView.swift
@@ -78,7 +78,7 @@ public struct AssetImageView: View {
                 .aspectRatio(contentMode: .fit)
                 .frame(width: overlaySize, height: overlaySize)
                 .padding(overlayPadding)
-                .background(Colors.grayBackground)
+                .background(Colors.listStyleColor)
                 .clipShape(Circle())
                 .offset(x: overlayOffset + (size / overlaySize), y: overlayOffset + (size / overlaySize))
         }


### PR DESCRIPTION
closes #575 
images:
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/4c50ffc9-0f89-45d8-9cd9-0b4bf01d6394" style="width: 45%;" /></td>
    <td><img src="https://github.com/user-attachments/assets/a3302f01-0ec0-4eab-8b48-75aa17ac9b4b" style="width: 45%;" /></td>
  </tr>
</table>