### PR TITLE
Square frame for View

### DIFF
--- a/Packages/Components/Sources/Extensions/SwiftUIView.swift
+++ b/Packages/Components/Sources/Extensions/SwiftUIView.swift
@@ -150,7 +150,7 @@ public extension View {
 // MARK: - Syntactic sugar
 
 extension View {
-    func frame(size: CGFloat) -> some View {
-        frame(width: size, height: size)
+    func frame(size: CGFloat, alignment: Alignment = .center) -> some View {
+        frame(width: size, height: size, alignment: alignment)
     }
 }

--- a/Packages/Components/Sources/Extensions/SwiftUIView.swift
+++ b/Packages/Components/Sources/Extensions/SwiftUIView.swift
@@ -146,3 +146,11 @@ public extension View {
         }
     }
 }
+
+// MARK: - Syntactic sugar
+
+extension View {
+    func frame(size: CGFloat) -> some View {
+        frame(width: size, height: size)
+    }
+}


### PR DESCRIPTION
We often use `.frame(width: .list.image, height: .list.image)` to make a square frame. This extension provides a simpler way to write it