### PR TITLE
Prioritize pinned and enabled assets in default sorting in AssetsRequest

### DIFF
--- a/GemTests/unit_frameworks.xctestplan
+++ b/GemTests/unit_frameworks.xctestplan
@@ -140,7 +140,6 @@
       }
     },
     {
-      "enabled" : false,
       "target" : {
         "containerPath" : "container:Packages\/Store",
         "identifier" : "StoreTests",

--- a/Packages/Store/Package.swift
+++ b/Packages/Store/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
             dependencies: [
                 "Store",
                 "StoreTestKit",
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
             ]
         ),
     ]

--- a/Packages/Store/Sources/Requests/AssetsRequest.swift
+++ b/Packages/Store/Sources/Requests/AssetsRequest.swift
@@ -153,6 +153,8 @@ extension AssetsRequest {
                 TableAlias(name: AccountRecord.databaseTableName)[BalanceRecord.Columns.walletId] == walletId
             )
             .order(
+                TableAlias(name: BalanceRecord.databaseTableName)[BalanceRecord.Columns.isPinned].desc,
+                TableAlias(name: BalanceRecord.databaseTableName)[BalanceRecord.Columns.isEnabled].desc,
                 totalValue.desc,
                 (totalValue == 0).desc,
                 AssetRecord.Columns.rank.desc

--- a/Packages/Store/Tests/StoreTests/Requests/AssetsRequestTests.swift
+++ b/Packages/Store/Tests/StoreTests/Requests/AssetsRequestTests.swift
@@ -1,0 +1,38 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Store
+import StoreTestKit
+import PrimitivesTestKit
+
+struct AssetsRequestTests {
+
+    @Test func testAddAssets() throws {
+        let db = DB.mock()
+        let store = AssetStore(db: db)
+        
+        try db.dbQueue.read { db in
+            let assets = try AssetsRequest.mock().fetch(db)
+            
+            #expect(assets.isEmpty)
+        }
+        
+        try store.add(assets: [.mock()])
+        
+        try db.dbQueue.read { db in
+            let assets = try AssetsRequest.mock(filters: [.priceAlerts]).fetch(db)
+            
+            #expect(assets.count == 1)
+        }
+    }
+}
+
+extension AssetsRequest {
+    static func mock(
+        walletId: String = "",
+        searchBy: String = "",
+        filters: [AssetsRequestFilter] = []
+    ) -> AssetsRequest {
+        AssetsRequest(walletId: walletId, searchBy: searchBy, filters: filters)
+    }
+}

--- a/Packages/Store/Tests/StoreTests/StoreTests.swift
+++ b/Packages/Store/Tests/StoreTests/StoreTests.swift
@@ -1,9 +1,0 @@
-// Copyright (c). Gem Wallet. All rights reserved.
-
-import Testing
-import StoreTestKit
-
-@testable import Store
-
-struct StoreTests {
-}


### PR DESCRIPTION
Fix: https://github.com/gemwalletcom/gem-ios/issues/675

Added sorting by pinned and enabled flags to show such assets at the top of the list, prioritized by balance.