### PR TITLE
SetPriceAlertScene background color fix

### DIFF
--- a/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
+++ b/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
@@ -25,19 +25,24 @@ public struct SetPriceAlertScene: View {
     
     public var body: some View {
         VStack(spacing: .zero) {
-            Text(model.alertDirectionTitle)
-                .textStyle(.subheadline)
-                .padding(.bottom, Spacing.tiny)
-            
-            CurrencyInputView(
-                text: $model.state.amount,
-                config: model.currencyInputConfig(for: assetData)
-            )
-            .focused($focusedField)
-            
-            if model.showPercentagePreselectedPicker {
-                preselectedPercentagePickerView
-                    .padding(.top, Spacing.medium)
+            List {
+                Section {
+                    Text(model.alertDirectionTitle)
+                        .textStyle(.subheadline)
+                        .padding(.bottom, Spacing.tiny)
+                    
+                    CurrencyInputView(
+                        text: $model.state.amount,
+                        config: model.currencyInputConfig(for: assetData)
+                    )
+                    .focused($focusedField)
+                    
+                    if model.showPercentagePreselectedPicker {
+                        preselectedPercentagePickerView
+                            .padding(.top, Spacing.medium)
+                    }
+                }
+                .cleanListRow()
             }
             
             Spacer()
@@ -50,6 +55,7 @@ public struct SetPriceAlertScene: View {
             .frame(maxWidth: Spacing.scene.button.maxWidth)
         }
         .padding(.bottom, Spacing.scene.bottom)
+        .background(Colors.grayBackground)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 alertTypePickerView


### PR DESCRIPTION
Fix: https://github.com/gemwalletcom/gem-ios/issues/677

![price_alert_collage](https://github.com/user-attachments/assets/5061fd64-1827-4466-afec-5e96606e1c33)
![collage_result_price_alert_light](https://github.com/user-attachments/assets/0f8f94a8-4650-4769-a537-6da5847c3cf7)
