### PR TITLE
BF:  No swap fiat value displayed in insufficient balance view #679

### DIFF
--- a/Features/ChainSettings/Sources/ViewModels/AddNodeSceneViewModel.swift
+++ b/Features/ChainSettings/Sources/ViewModels/AddNodeSceneViewModel.swift
@@ -88,14 +88,9 @@ extension AddNodeSceneViewModel {
     private func fetchChainID(service: any ChainIDFetchable) async throws -> (latency: Latency, value: String) {
         let result = try await LatencyMeasureService.measure(for: service.getChainID)
         let networkId = result.value
-        let isValid = NodeService.isValid(netoworkId: networkId, for: chain)
-        //valid on simulator and debug...
-        #if !(DEBUG && targetEnvironment(simulator))
-        guard isValid else {
+        guard NodeService.isValid(netoworkId: networkId, for: chain) else {
             throw AddNodeError.invalidNetworkId
         }
-        #endif
-        
         return (latency: .from(duration: result.duration), value: networkId)
     }
 

--- a/Features/ChainSettings/Sources/ViewModels/AddNodeSceneViewModel.swift
+++ b/Features/ChainSettings/Sources/ViewModels/AddNodeSceneViewModel.swift
@@ -88,9 +88,14 @@ extension AddNodeSceneViewModel {
     private func fetchChainID(service: any ChainIDFetchable) async throws -> (latency: Latency, value: String) {
         let result = try await LatencyMeasureService.measure(for: service.getChainID)
         let networkId = result.value
-        guard NodeService.isValid(netoworkId: networkId, for: chain) else {
+        let isValid = NodeService.isValid(netoworkId: networkId, for: chain)
+        //valid on simulator and debug...
+        #if !(DEBUG && targetEnvironment(simulator))
+        guard isValid else {
             throw AddNodeError.invalidNetworkId
         }
+        #endif
+        
         return (latency: .from(duration: result.duration), value: networkId)
     }
 

--- a/Gem/Transfer/ViewsModels/ConfirmTransferViewModel.swift
+++ b/Gem/Transfer/ViewsModels/ConfirmTransferViewModel.swift
@@ -283,9 +283,9 @@ extension ConfirmTransferViewModel {
     func fetch() async {
         state = .loading
         feeModel.reset()
-
+        var metadata: TransferDataMetadata!
         do {
-            let metadata = try getAssetMetaData(walletId: wallet.id, asset: dataModel.asset, assetsIds: data.type.assetIds)
+            metadata = try getAssetMetaData(walletId: wallet.id, asset: dataModel.asset, assetsIds: data.type.assetIds)
             try validateBalance(metadata: metadata)
 
             let preloadInput = try await fetchTransactionLoad(metaData: metadata)
@@ -295,7 +295,7 @@ extension ConfirmTransferViewModel {
             )
             updateState(with: transactionInputViewModel(transferAmount: transferAmountResult, input: preloadInput, metaData: metadata))
         } catch let error as TransferAmountCalculatorError {
-            updateState(with: transactionInputViewModel(transferAmount: .error(nil, error)))
+            updateState(with: transactionInputViewModel(transferAmount: .error(nil, error), metaData: metadata))
         } catch {
             if !error.isCancelled {
                 state = .error(error)


### PR DESCRIPTION
fix: No swap fiat value displayed in insufficient balance view #679
ConfirmTransferViewModel.swift: metadata is used, because validate balance will throw if not sufficient funds.
