### PR TITLE
iPad UI review

### DIFF
--- a/Features/NFT/Sources/Scenes/CollectibleScene.swift
+++ b/Features/NFT/Sources/Scenes/CollectibleScene.swift
@@ -91,13 +91,18 @@ extension CollectibleScene {
         .textCase(nil)
         .listRowSeparator(.hidden)
         .listRowInsets(EdgeInsets())
-        .contextMenu(
+        .contextMenu([
             .custom(
                 title: Localized.Nft.saveToPhotos,
                 systemImage: SystemImage.gallery,
+                action: onSelectSaveToGallery
+            ),
+            .custom(
+                title: Localized.Nft.setAsAvatar,
+                systemImage: SystemImage.emoji,
                 action: onSelectSetAsAvatar
             )
-        )
+        ])
     }
     
     private var assetInfoSectionView: some View {

--- a/Features/Onboarding/Sources/Scenes/CreateWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/CreateWalletScene.swift
@@ -13,14 +13,33 @@ struct CreateWalletScene: View {
 
     var body: some View {
         VStack(spacing: .medium) {
-            OnboardingHeaderTitle(title: Localized.SecretPhrase.savePhraseSafely, alignment: .center)
-            SecretDataTypeView(type: model.type)
+            List {
+                Section {
+                    OnboardingHeaderTitle(
+                        title: Localized.SecretPhrase.savePhraseSafely,
+                        alignment: .center
+                    )
+                }
+                .cleanListRow()
+                
+                Section {
+                    SecretDataTypeView(
+                        type: model.type
+                    )
+                }
+                .cleanListRow()
 
-            Button(action: copy) {
-                Text(Localized.Common.copy)
+                Section {
+                    Button(action: copy) {
+                        Text(Localized.Common.copy)
+                    }
+                    .buttonStyle(.clear)
+                }
+                .cleanListRow()
             }
-            Spacer()
-            
+            .contentMargins([.top], .extraSmall, for: .scrollContent)
+            .listSectionSpacing(.custom(.medium))
+
             StateButton(
                 text: Localized.Common.continue,
                 styleState: .normal,
@@ -33,6 +52,7 @@ struct CreateWalletScene: View {
             isPresenting: $isPresentingCopyToast
         )
         .padding(.bottom, .scene.bottom)
+        .background(Colors.grayBackground)
         .navigationBarTitle(model.title)
         .taskOnce { model.generateWords() }
     }

--- a/Features/Onboarding/Sources/Scenes/CreateWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/CreateWalletScene.swift
@@ -29,12 +29,12 @@ struct CreateWalletScene: View {
                 }
                 .cleanListRow()
 
-                Section {
-                    Button(action: copy) {
-                        Text(Localized.Common.copy)
-                    }
-                    .buttonStyle(.clear)
-                }
+                ListButton(
+                    title: Localized.Common.copy,
+                    image: Images.System.copy,
+                    action: copy
+                )
+                .frame(maxWidth: .infinity, alignment: .center)
                 .cleanListRow()
             }
             .contentMargins([.top], .extraSmall, for: .scrollContent)

--- a/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
@@ -13,23 +13,37 @@ struct ShowSecretDataScene: View {
     @State private var isPresentingCopyToast = false
 
     var body: some View {
-        VStack(spacing: .medium) {
-            CalloutView.error(
-                title: Localized.SecretPhrase.DoNotShare.title, 
-                subtitle: Localized.SecretPhrase.DoNotShare.description
-            )
-            .padding(.top, .scene.top)
+        VStack {
+            List {
+                Section {
+                    CalloutView.error(
+                        title: Localized.SecretPhrase.DoNotShare.title,
+                        subtitle: Localized.SecretPhrase.DoNotShare.description
+                    )
+                }
+                .cleanListRow()
 
-            SecretDataTypeView(type: model.type)
+                Section {
+                    SecretDataTypeView(
+                        type: model.type
+                    )
+                }
+                .cleanListRow()
 
-            Button {
-                isPresentingCopyToast = true
-            } label: {
-                Text(Localized.Common.copy)
+                Section {
+                    Button {
+                        isPresentingCopyToast = true
+                    } label: {
+                        Text(Localized.Common.copy)
+                    }
+                }
+                .cleanListRow()
             }
-            Spacer()
+            .contentMargins([.top], .extraSmall, for: .scrollContent)
+            .listSectionSpacing(.custom(.medium))
         }
-        .frame(maxWidth: .scene.content.maxWidth)
+        .padding(.bottom, .scene.bottom)
+        .background(Colors.grayBackground)
         .navigationTitle(model.title)
         .copyToast(
             model: model.copyModel,

--- a/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
@@ -18,38 +18,54 @@ struct VerifyPhraseWalletScene: View {
 
     var body: some View {
         VStack(spacing: .medium) {
-            OnboardingHeaderTitle(title: Localized.SecretPhrase.Confirm.QuickTest.title, alignment: .center)
-            
-            SecretPhraseGridView(rows: model.rows, highlightIndex: model.wordsIndex)
-                .padding(.top, .small)
-            
-            Grid(alignment: .center) {
-                ForEach(model.rowsSections, id: \.self) { section in
-                    GridRow(alignment: .center) {
-                        ForEach(section) { row in
-                            if model.isVerified(index: row) {
-                                Button { } label: {
-                                    Text(row.word)
+            List {
+                Section {
+                    OnboardingHeaderTitle(
+                        title: Localized.SecretPhrase.Confirm.QuickTest.title,
+                        alignment: .center
+                    )
+                }
+                .cleanListRow()
+                
+                Section {
+                    SecretPhraseGridView(
+                        rows: model.rows,
+                        highlightIndex: model.wordsIndex
+                    )
+                }
+                .cleanListRow()
+                
+                Section {
+                    Grid(alignment: .center) {
+                        ForEach(model.rowsSections, id: \.self) { section in
+                            GridRow(alignment: .center) {
+                                ForEach(section) { row in
+                                    if model.isVerified(index: row) {
+                                        Button { } label: {
+                                            Text(row.word)
+                                        }
+                                        .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny))
+                                        .disabled(true)
+                                        .fixedSize()
+                                    } else {
+                                        Button {
+                                            model.pickWord(index: row)
+                                        } label: {
+                                            Text(row.word)
+                                        }
+                                        .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny))
+                                        .fixedSize()
+                                    }
                                 }
-                                .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny))
-                                .disabled(true)
-                                .fixedSize()
-                            } else {
-                                Button {
-                                    model.pickWord(index: row)
-                                } label: {
-                                    Text(row.word)
-                                }
-                                .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny))
-                                .fixedSize()
                             }
                         }
                     }
                 }
+                .cleanListRow()
             }
-            .padding(.top, .small)
-            
-            Spacer()
+            .contentMargins([.top], .extraSmall, for: .scrollContent)
+            .listSectionSpacing(.custom(.medium))
+
             StateButton(
                 text: Localized.Common.continue,
                 styleState: model.buttonState,
@@ -58,6 +74,7 @@ struct VerifyPhraseWalletScene: View {
             .frame(maxWidth: .scene.button.maxWidth)
         }
         .padding(.bottom, .scene.bottom)
+        .background(Colors.grayBackground)
         .navigationTitle(model.title)
         .alert(item: $isPresentingErrorMessage) {
             Alert(title: Text(Localized.Errors.createWallet("")), message: Text($0))

--- a/Gem/Asset/Navigation/AssetNavigationView.swift
+++ b/Gem/Asset/Navigation/AssetNavigationView.swift
@@ -45,22 +45,22 @@ struct AssetNavigationView: View {
             systemImage: model.priceAlertsSystemImage
         )
         .confirmationDialog(
-            "",
-            isPresented: $model.isPresentingOptions,
-            titleVisibility: .hidden
-        ) {
-            Button(model.viewAddressOnTitle) {
-                model.onSelect(url: model.addressExplorerUrl)
-            }
-            if let title = model.viewTokenOnTitle {
-                Button(title) {
-                    model.onSelect(url: model.tokenExplorerUrl)
+            model.title,
+            presenting: $model.isPresentingOptions,
+            actions: { _ in
+                Button(model.viewAddressOnTitle) {
+                    model.onSelect(url: model.addressExplorerUrl)
+                }
+                if let title = model.viewTokenOnTitle {
+                    Button(title) {
+                        model.onSelect(url: model.tokenExplorerUrl)
+                    }
+                }
+                Button(Localized.Common.share) {
+                    model.onSelectShareAsset()
                 }
             }
-            Button(Localized.Common.share) {
-                model.onSelectShareAsset()
-            }
-        }
+        )
         .sheet(item: $model.isPresentingAssetSheet) {
             switch $0 {
             case let .info(type):

--- a/Gem/Asset/ViewModels/AssetSceneViewModel.swift
+++ b/Gem/Asset/ViewModels/AssetSceneViewModel.swift
@@ -34,7 +34,7 @@ final class AssetSceneViewModel: Sendable {
 
     private var isPresentingAssetSelectedInput: Binding<SelectedAssetInput?>
 
-    var isPresentingOptions = false
+    var isPresentingOptions: Bool?
     var isPresentingToastMessage: String?
     var isPresentingAssetSheet: AssetSheetType?
 

--- a/Gem/Root/Views/MainTabView.swift
+++ b/Gem/Root/Views/MainTabView.swift
@@ -111,6 +111,7 @@ struct MainTabView: View {
             }
             .tag(TabItem.settings)
         }
+        .adaptiveContentMargins()
         .onChange(of: model.walletId, onWalletIdChange)
         .onChange(
             of: notificationHandler.notifications,

--- a/Packages/Components/Sources/Extensions/SwiftUIView.swift
+++ b/Packages/Components/Sources/Extensions/SwiftUIView.swift
@@ -68,55 +68,6 @@ public extension View {
     }
 }
 
-// MARK: - Confirmation Dialog
-
-public extension View {
-    func confirmationDialog<S, A, T, M>(
-        _ title: S,
-        presenting data: Binding<T?>,
-        sensoryFeedback: SensoryFeedback? = nil,
-        @ViewBuilder actions: (T) -> A,
-        @ViewBuilder message: () -> M = { EmptyView() }
-    )
-    -> some View where S: StringProtocol, A: View, M: View {
-        let isPresented: Binding<Bool> = Binding(
-            get: { data.wrappedValue != nil },
-            set: { newValue in
-                guard !newValue else { return }
-                data.wrappedValue = nil
-            }
-        )
-        // confiramtion dialog works good only for iPhone, for different devices use an alert
-        let iPhone = UIDevice.current.userInterfaceIdiom == .phone
-
-        return ifElse(iPhone) {
-            $0.confirmationDialog(
-                    title,
-                    isPresented: isPresented,
-                    titleVisibility: .visible,
-                    presenting: data.wrappedValue,
-                    actions: actions,
-                    message: { _ in
-                        message()
-                    }
-                )
-        } elseContent: {
-            $0.alert(
-                    title,
-                    isPresented: isPresented,
-                    presenting: data.wrappedValue,
-                    actions: actions,
-                    message: { _ in
-                        message()
-                    }
-                )
-        }
-        .ifLet(sensoryFeedback) { view, value in
-            view.sensoryFeedback(value, trigger: isPresented.wrappedValue) { $1 }
-        }
-    }
-}
-
 // MARK: - Sheet
 
 public extension View {

--- a/Packages/Components/Sources/ViewModifiers/AdaptiveContentMarginsModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/AdaptiveContentMarginsModifier.swift
@@ -34,7 +34,7 @@ struct AdaptiveContentMargins: ViewModifier {
 }
 
 public extension View {
-    func adaptiveContentMargins(maxContentWidth: CGFloat = 700) -> some View {
+    func adaptiveContentMargins(maxContentWidth: CGFloat = 720) -> some View {
         self.modifier(AdaptiveContentMargins(maxContentWidth: maxContentWidth))
     }
 }

--- a/Packages/Components/Sources/ViewModifiers/AdaptiveContentMarginsModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/AdaptiveContentMarginsModifier.swift
@@ -1,0 +1,40 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import SwiftUICore
+import Style
+import UIKit
+
+struct AdaptiveContentMargins: ViewModifier {
+    let maxContentWidth: CGFloat
+
+    func body(content: Content) -> some View {
+        GeometryReader { geometry in
+            switch UIDevice.current.userInterfaceIdiom {
+            case .pad:
+                let horizontalMargin = max((geometry.size.width - maxContentWidth) / 2, 0)
+                content
+                    .contentMargins(
+                        .horizontal,
+                        EdgeInsets(
+                            top: .zero,
+                            leading: horizontalMargin,
+                            bottom: .zero,
+                            trailing: horizontalMargin
+                        ),
+                        for: .scrollContent
+                    )
+            case .phone, .tv, .carPlay, .mac, .vision, .unspecified:
+                content
+            @unknown default:
+                content
+            }
+        }
+    }
+}
+
+public extension View {
+    func adaptiveContentMargins(maxContentWidth: CGFloat = 700) -> some View {
+        self.modifier(AdaptiveContentMargins(maxContentWidth: maxContentWidth))
+    }
+}

--- a/Packages/PrimitivesComponents/Sources/Components/SecretPhraseGridView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/SecretPhraseGridView.swift
@@ -35,7 +35,7 @@ public struct SecretPhraseGridView: View {
                         }
                         .padding(.small)
                         .frame(maxWidth: (.scene.content.maxWidth / 2) - (.small * 2))
-                        .background(Colors.grayVeryLight)
+                        .background(Colors.listStyleColor)
                         .cornerRadius(10)
                         .overlay {
                             if highlightIndex == word.index {

--- a/Packages/PrimitivesComponents/Sources/Extensions/View+ConfirmationDialog.swift
+++ b/Packages/PrimitivesComponents/Sources/Extensions/View+ConfirmationDialog.swift
@@ -1,0 +1,58 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Localization
+
+public extension View {
+    func confirmationDialog<S, A, T, M>(
+        _ title: S,
+        presenting data: Binding<T?>,
+        sensoryFeedback: SensoryFeedback? = nil,
+        @ViewBuilder actions: (T) -> A,
+        @ViewBuilder message: () -> M = { EmptyView() }
+    )
+    -> some View where S: StringProtocol, A: View, M: View {
+        let isPresented: Binding<Bool> = Binding(
+            get: { data.wrappedValue != nil },
+            set: { newValue in
+                guard !newValue else { return }
+                data.wrappedValue = nil
+            }
+        )
+        // confirmation dialog works good only for iPhone, for different devices use an alert
+        let iPhone = UIDevice.current.userInterfaceIdiom == .phone
+
+        return ifElse(iPhone) {
+            $0.confirmationDialog(
+                    title,
+                    isPresented: isPresented,
+                    titleVisibility: .visible,
+                    presenting: data.wrappedValue,
+                    actions: actions,
+                    message: { _ in
+                        message()
+                    }
+                )
+        } elseContent: {
+            $0.alert(
+                    title,
+                    isPresented: isPresented,
+                    presenting: data.wrappedValue,
+                    actions: { value in
+                        VStack {
+                            actions(value)
+                            Button(Localized.Common.cancel, role: .cancel) {
+                                isPresented.wrappedValue = false
+                            }
+                        }
+                    },
+                    message: { _ in
+                        message()
+                    }
+                )
+        }
+        .ifLet(sensoryFeedback) { view, value in
+            view.sensoryFeedback(value, trigger: isPresented.wrappedValue) { $1 }
+        }
+    }
+}


### PR DESCRIPTION
Close: https://github.com/gemwalletcom/gem-ios/issues/703

In .confirmationDialog on iPad, if the buttons Han no role and action. the native alert wouldn't include a Cancel button. As result, the alert couldn't be dismissed without selecting one of the actions.

![359a9025-c3e7-4133-a313-22e6e4523150](https://github.com/user-attachments/assets/bf654d16-8159-445a-bfe3-1937e54ab162)

Additionally, the white background in the create\export flow has been changed to gray for consistency
