### PR TITLE
Display additional info section logic. Unit test

### DIFF
--- a/Features/Swap/Sources/Scenes/SwapScene.swift
+++ b/Features/Swap/Sources/Scenes/SwapScene.swift
@@ -86,7 +86,9 @@ extension SwapScene {
         List {
             swapFromSectionView
             swapToSectionView
-            additionalInfoSectionView
+            if model.shouldShowAdditionalInfo {
+                additionalInfoSectionView
+            }
 
             if let error = model.swapState.error {
                 ListItemErrorView(errorTitle: model.errorTitle, error: error)

--- a/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
+++ b/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
@@ -149,6 +149,10 @@ public final class SwapSceneViewModel {
     var isSwitchAssetButtonDisabled: Bool {
         swapState.isLoading
     }
+    
+    var shouldShowAdditionalInfo: Bool {
+        swapState.isLoading == false
+    }
 
     var isLoading: Bool {
         swapState.quotes.isLoading

--- a/Features/Swap/Tests/SwapTests/SwapSceneViewModelTests.swift
+++ b/Features/Swap/Tests/SwapTests/SwapSceneViewModelTests.swift
@@ -48,6 +48,17 @@ struct SwapSceneViewModelTests {
         #expect(model.rateText == "1 USDT ≈ 0.000004 ETH")
     }
     
+    @Test
+    func additionalInfoVisibility() async {
+        let model = SwapSceneViewModel.mock()
+
+        model.swapState.quotes = .loading
+        #expect(model.shouldShowAdditionalInfo == false)
+
+        model.swapState.quotes = .data([.mock()])
+        #expect(model.shouldShowAdditionalInfo)
+    }
+    
     // MARK: - Private methods
     
     private func model(


### PR DESCRIPTION
This PR introduces the logic for displaying an "additional info" section and includes accompanying unit tests to ensure its functionality.