### PR TITLE
Allow clean recipient field

### DIFF
--- a/Features/Transfer/Sources/Scenes/RecipientScene.swift
+++ b/Features/Transfer/Sources/Scenes/RecipientScene.swift
@@ -29,7 +29,7 @@ struct RecipientScene: View {
                     InputValidationField(
                         model: $model.addressInputModel,
                         placeholder: model.recipientField,
-                        allowClean: false,
+                        allowClean: true,
                         trailingView: {
                             HStack(spacing: .large/2) {
                                 NameRecordView(


### PR DESCRIPTION
Fix: https://github.com/gemwalletcom/gem-ios/issues/862

![cd599eb3-563f-4390-b5e7-a5bb1d971866](https://github.com/user-attachments/assets/8d9e7ab8-47d0-47ed-88d4-ec17bcc7faa8)
