### PR TITLE
Refine participant field logic in TransactionDetailViewModel

### DIFF
--- a/Features/Transactions/Sources/ViewModels/TransactionDetailViewModel.swift
+++ b/Features/Transactions/Sources/ViewModels/TransactionDetailViewModel.swift
@@ -59,15 +59,18 @@ struct TransactionDetailViewModel {
     
     var participantField: String? {
         switch model.transaction.transaction.type {
-        case .transfer, .transferNFT, .tokenApproval, .smartContractCall:
+        case .transfer, .transferNFT:
             switch model.transaction.transaction.direction {
             case .incoming:
                 return Localized.Transaction.sender
             case .outgoing, .selfTransfer:
                 return Localized.Transaction.recipient
             }
+        case .tokenApproval, .smartContractCall:
+            return Localized.Asset.contract
+        case .stakeDelegate:
+            return Localized.Stake.validator
         case .swap,
-            .stakeDelegate,
             .stakeUndelegate,
             .stakeRedelegate,
             .stakeRewards,
@@ -79,10 +82,9 @@ struct TransactionDetailViewModel {
     
     var participant: String? {
         switch model.transaction.transaction.type {
-        case .transfer, .transferNFT, .tokenApproval, .smartContractCall:
+        case .transfer, .transferNFT, .tokenApproval, .smartContractCall, .stakeDelegate:
             return model.participant
         case .swap,
-            .stakeDelegate,
             .stakeUndelegate,
             .stakeRedelegate,
             .stakeRewards,

--- a/Features/Transactions/Tests/TransactionsTests/TransactionDetailViewModelTests.swift
+++ b/Features/Transactions/Tests/TransactionsTests/TransactionDetailViewModelTests.swift
@@ -1,0 +1,68 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Localization
+import Primitives
+import Preferences
+import PreferencesTestKit
+import PrimitivesComponents
+
+@testable import Transactions
+@testable import Store
+
+struct TransactionDetailViewModelTests {
+
+    @Test
+    func participantField_transfer() {
+        #expect(TransactionDetailViewModel.mock(type: .transfer, direction: .incoming).participantField == Localized.Transaction.sender)
+        #expect(TransactionDetailViewModel.mock(type: .transfer, direction: .outgoing).participantField == Localized.Transaction.recipient)
+        #expect(TransactionDetailViewModel.mock(type: .transferNFT, direction: .incoming).participantField == Localized.Transaction.sender)
+        #expect(TransactionDetailViewModel.mock(type: .transferNFT, direction: .outgoing).participantField == Localized.Transaction.recipient)
+    }
+
+    @Test
+    func participantField_contract() {
+        #expect(TransactionDetailViewModel.mock(type: .tokenApproval).participantField == Localized.Asset.contract)
+        #expect(TransactionDetailViewModel.mock(type: .smartContractCall).participantField == Localized.Asset.contract)
+    }
+
+    @Test
+    func participantField_stakeDelegate() {
+        #expect(TransactionDetailViewModel.mock(type: .stakeDelegate).participantField == Localized.Stake.validator)
+    }
+
+    @Test
+    func participantField_isNilForOthers() {
+        let nilTypes: [TransactionType] = [.swap, .stakeUndelegate, .stakeRedelegate, .stakeRewards, .stakeWithdraw, .assetActivation]
+        for type in nilTypes {
+            #expect(TransactionDetailViewModel.mock(type: type).participantField == nil)
+        }
+    }
+
+    @Test
+    func participant_returnsValue() {
+        let participantTypes: [TransactionType] = [.transfer, .transferNFT, .tokenApproval, .smartContractCall, .stakeDelegate]
+
+        for type in participantTypes {
+            #expect(TransactionDetailViewModel.mock(type: type).participant == "participant_address")
+        }
+    }
+
+    @Test
+    func participant_isNilForOthers() {
+        let nilTypes: [TransactionType] = [.swap, .stakeUndelegate, .stakeRedelegate, .stakeRewards, .stakeWithdraw, .assetActivation]
+        for type in nilTypes {
+            #expect(TransactionDetailViewModel.mock(type: type).participant == nil)
+        }
+    }
+}
+
+extension TransactionDetailViewModel {
+    static func mock(
+        type: TransactionType,
+        direction: TransactionDirection = .outgoing,
+        participant: String = "participant_address"
+    ) -> TransactionDetailViewModel {
+        TransactionDetailViewModel(model: TransactionViewModel.mock(type: type, direction: direction, participant: participant))
+    }
+}

--- a/Features/Transactions/Tests/TransactionsTests/TransactionViewModelTests.swift
+++ b/Features/Transactions/Tests/TransactionsTests/TransactionViewModelTests.swift
@@ -35,7 +35,10 @@ final class TransactionViewModelTests {
 extension TransactionViewModel {
     static func mock(
         fromValue: String = "",
-        toValue: String = ""
+        toValue: String = "",
+        type: TransactionType = .swap,
+        direction: TransactionDirection = .incoming,
+        participant: String = ""
     ) -> TransactionViewModel {
         let fromAsset = Asset.mockEthereum()
         let toAsset = Asset.mockEthereumUSDT()
@@ -51,7 +54,9 @@ extension TransactionViewModel {
         )
         
         let transaction = Transaction.mock(
-            type: .swap,
+            type: type,
+            direction: direction,
+            to: participant,
             value: "1000000000000000000",
             metadata: swapMetadata
         )

--- a/Packages/Primitives/TestKit/Transaction+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/Transaction+PrimitivesTestKit.swift
@@ -8,6 +8,7 @@ public extension Transaction {
         type: TransactionType = .transfer,
         state: TransactionState = .confirmed,
         direction: TransactionDirection = .incoming,
+        to: String = "",
         value: String = "",
         metadata: TransactionMetadata? = nil
     ) -> Transaction {
@@ -16,7 +17,7 @@ public extension Transaction {
             hash: "2",
             assetId: .mock(),
             from: "",
-            to: "",
+            to: to,
             contract: .none,
             type: type,
             state: state,


### PR DESCRIPTION
Close: https://github.com/gemwalletcom/gem-ios/issues/847

Updated the participantField and participant computed properties to more accurately reflect transaction types. Stake-related transaction types now return the validator label, and contract-related types return the contract label. This improves clarity and correctness in transaction detail displays.

![367cbf58-00dc-4521-b7bd-c7f26d9265e6](https://github.com/user-attachments/assets/63844b61-8785-4155-ada3-1cf93728c48f)
![3621e22c-f0ff-4cff-bfbb-aead6fc7a63c](https://github.com/user-attachments/assets/992e7c2a-2583-4ff3-a7fc-6264d2d59dae)
