### PR TITLE
Fix fee rates selector visibility logic and add tests

### DIFF
--- a/Features/Transfer/Sources/ViewModels/NetworkFeeSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/NetworkFeeSceneViewModel.swift
@@ -28,7 +28,7 @@ public final class NetworkFeeSceneViewModel {
     public var doneTitle: String { Localized.Common.done }
     public var infoIcon: String { Localized.FeeRates.info }
 
-    public var showFeeRatesSelector: Bool { rates.isNotEmpty }
+    public var showFeeRatesSelector: Bool { rates.count > 1 }
 
     public var feeRatesViewModels: [FeeRateViewModel] {
         rates.map {

--- a/Features/Transfer/Tests/ViewModels/NetworkFeeSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/NetworkFeeSceneViewModelTests.swift
@@ -1,0 +1,22 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Primitives
+@testable import Transfer
+
+@MainActor
+struct NetworkFeeSceneViewModelTests {
+    @Test
+    func showFeeRatesSelector() {
+        let model = NetworkFeeSceneViewModel(
+            chain: .ethereum,
+            priority: .normal
+        )
+        
+        model.update(rates: [.defaultRate()])
+        #expect(model.showFeeRatesSelector == false)
+        
+        model.update(rates: [.defaultRate(), .defaultRate()])
+        #expect(model.showFeeRatesSelector)
+    }
+}


### PR DESCRIPTION
Fix: https://github.com/gemwalletcom/gem-ios/issues/863

Updated the logic for showing the fee rates selector to require more than one rate instead of any non-empty list. Added unit tests to verify the correct behavior of the selector visibility.