### PR TITLE
Refactor ImportWalletScene to use observable view model

### DIFF
--- a/Features/Onboarding/Sources/Navigation/ImportWalletNavigationStack.swift
+++ b/Features/Onboarding/Sources/Navigation/ImportWalletNavigationStack.swift
@@ -36,8 +36,8 @@ public struct ImportWalletNavigationStack: View {
             .navigationDestination(for: ImportWalletType.self) { type in
                 ImportWalletScene(
                     model: ImportWalletViewModel(
-                        type: type,
                         walletService: model.walletService,
+                        type: type,
                         onFinish: {
                             model.acceptTerms()
                             isPresentingWallets = false

--- a/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
@@ -7,41 +7,34 @@ import Components
 import QRScanner
 import Localization
 import NameResolver
-import struct Keystore.Mnemonic
 
 struct ImportWalletScene: View {
-    
     enum Field: Int, Hashable {
         case name, input
     }
-    @State private var name: String = ""
-    @State private var wordsSuggestion: [String] = []
-
-    @State private var importType: WalletImportType = .phrase
-    @State private var input: String = ""
-
-    @State private var isPresentingErrorMessage: String?
-    @State private var isPresentingScanner = false
     @FocusState private var focusedField: Field?
-    @State var nameResolveState: NameRecordState = .none
-    
-    @StateObject var model: ImportWalletViewModel
+
+    @State private var model: ImportWalletViewModel
 
     init(model: ImportWalletViewModel) {
-        _model = StateObject(wrappedValue: model)
+        _model = State(initialValue: model)
     }
 
     var body: some View {
         VStack {
             Form {
                 Section {
-                    FloatTextField(Localized.Wallet.name, text: $name, allowClean: focusedField == .name)
-                        .focused($focusedField, equals: .name)
+                    FloatTextField(
+                        model.walletFieldTitle,
+                        text: $model.name,
+                        allowClean: focusedField == .name
+                    )
+                    .focused($focusedField, equals: .name)
                 }
                 Section {
                     VStack {
                         if model.showImportTypes {
-                            Picker("", selection: $importType) {
+                            Picker("", selection: $model.importType) {
                                 ForEach(model.importTypes) { type in
                                     Text(type.title).tag(type)
                                 }
@@ -49,52 +42,58 @@ struct ImportWalletScene: View {
                             .pickerStyle(.segmented)
                         }
                         HStack {
-                            TextField(importType.description, text: $input, axis: .vertical)
-                                .autocorrectionDisabled(true)
-                                .textInputAutocapitalization(.never)
-                                .lineLimit(8)
-                                .keyboardType(.asciiCapable)
-                                .frame(minHeight: 80, alignment: .top)
-                                .focused($focusedField, equals: .input)
-                                .toolbar {
-                                    if importType.showToolbar {
-                                        ToolbarItem(placement: .keyboard) {
-                                            WordSuggestionView(words: wordsSuggestion, selectWord: selectWord)
-                                        }
+                            TextField(
+                                model.importType.description,
+                                text: $model.input,
+                                axis: .vertical
+                            )
+                            .autocorrectionDisabled(true)
+                            .textInputAutocapitalization(.never)
+                            .lineLimit(8)
+                            .keyboardType(.asciiCapable)
+                            .frame(minHeight: 80, alignment: .top)
+                            .focused($focusedField, equals: .input)
+                            .toolbar {
+                                if model.importType.showToolbar {
+                                    ToolbarItem(placement: .keyboard) {
+                                        WordSuggestionView(
+                                            words: model.wordsSuggestion,
+                                            selectWord: model.onSelectWord
+                                        )
                                     }
                                 }
-                                .padding(.top, .small + .tiny)
-                            
-                                if let chain = model.chain, importType == .address {
-                                    NameRecordView(
-                                        model: NameRecordViewModel(chain: chain),
-                                        state: $nameResolveState,
-                                        address: $input
-                                    )
+                            }
+                            .padding(.top, .small + .tiny)
+
+                            if let chain = model.chain, model.importType == .address {
+                                NameRecordView(
+                                    model: NameRecordViewModel(chain: chain),
+                                    state: $model.nameResolveState,
+                                    address: $model.input
+                                )
                             }
                         }
-                        HStack(alignment: .center, spacing: 16) {
+
+                        HStack(alignment: .center, spacing: .medium) {
                             ListButton(
-                                title: Localized.Common.paste,
-                                image: Images.System.paste,
-                                action: paste
+                                title: model.pasteButtonTitle,
+                                image: model.pasteButtonImage,
+                                action: model.onPaste
                             )
                             if model.type != .multicoin {
                                 ListButton(
-                                    title: Localized.Wallet.scan,
-                                    image: Images.System.qrCode,
-                                    action: scanQR
+                                    title: model.qrButtonTitle,
+                                    image: model.qrButtonImage,
+                                    action: model.onSelectScanQR
                                 )
                             }
                         }
                     }
                     .listRowBackground(Colors.white)
                 } footer: {
-                    if let text = model.footerText(type: importType) {
+                    if let text = model.footerText {
                         Text(text)
-                    } else {
-                        EmptyView()
-                    }
+                    } 
                 }
             }
             .listSectionSpacing(.compact)
@@ -103,141 +102,27 @@ struct ImportWalletScene: View {
             StateButton(
                 text: Localized.Wallet.Import.action,
                 type: .primary(model.buttonState),
-                action: onImportWallet
+                action: model.onSelectActionButton
             )
             .frame(maxWidth: .scene.button.maxWidth)
         }
         .contentMargins(.top, .scene.top, for: .scrollContent)
         .padding(.bottom, .scene.bottom)
         .background(Colors.grayBackground)
-        .alert(item: $isPresentingErrorMessage) {
-            Alert(title: Text(Localized.Errors.validation("")), message: Text($0))
-        }
-        .sheet(isPresented: $isPresentingScanner) {
-            ScanQRCodeNavigationStack(action: onHandleScan(_:))
-        }
-        .onChange(of: input) { oldValue, newValue in
-            wordsSuggestion = model.wordSuggestionCalculate(value: newValue)
-        }
-        .onChange(of: importType) { (_, _) in
-            input = ""
-        }
         .navigationBarTitle(model.title)
+        .alert(
+            model.alertTitle,
+            isPresented: $model.isPresentingErrorMessage.mappedToBool(),
+            actions: {},
+            message: { Text(model.isPresentingErrorMessage ?? "")}
+        )
+        .sheet(isPresented: $model.isPresentingScanner) {
+            ScanQRCodeNavigationStack(action: model.onHandleScan)
+        }
+        .onChange(of: model.input, model.onChangeInput)
+        .onChange(of: model.importType, model.onChangeImportType)
         .taskOnce {
-            name = model.name
-            importType = model.importTypes.first!
             focusedField = .input
-        }
-    }
-
-    func selectWord(word: String) {
-        input = model.selectWordCalculate(input: input, word: word)
-    }
-    
-    func onHandleScan(_ result: String) {
-        input = result
-    }
-
-    func validateForm(type: WalletImportType, address: String, words: [String]) throws  -> Bool {
-        guard !name.isEmpty else {
-            throw WalletImportError.emptyName
-        }
-        switch type {
-        case .phrase:
-            for word in words {
-                if !Mnemonic.isValidWord(word) {
-                    throw WalletImportError.invalidSecretPhraseWord(word: word)
-                }
-            }
-            guard Mnemonic.isValidWords(words) else {
-                throw WalletImportError.invalidSecretPhrase
-            }
-        case .privateKey:
-            return !words.joined().isEmpty
-        case .address:
-            guard model.chain!.isValidAddress(address) else {
-                throw WalletImportError.invalidAddress
-            }
-        }
-        return true
-    }
-    
-    func paste() {
-        guard let string = UIPasteboard.general.string else {
-            UINotificationFeedbackGenerator().notificationOccurred(.error)
-            return
-        }
-        input = string.trim()
-    }
-    
-    func scanQR() {
-        isPresentingScanner = true
-    }
-}
-
-extension String: @retroactive Identifiable {
-    public var id: String { self }
-}
-
-// MARK: - Actions
-
-extension ImportWalletScene {
-    func onImportWallet() {
-        model.buttonState = .loading(showProgress: true)
-
-        Task {
-            try await Task.sleep(for: .milliseconds(50))
-            do {
-                try await MainActor.run {
-                    try importWallet()
-                }
-            } catch {
-                await MainActor.run {
-                    isPresentingErrorMessage = error.localizedDescription
-                    model.buttonState = .normal
-                }
-            }
-        }
-    }
-
-    func importWallet() throws {
-        let recipient: RecipientImport = {
-            if let result = nameResolveState.result {
-                return RecipientImport(name: result.name, address: result.address)
-            }
-            return RecipientImport(name: name, address: input)
-        }()
-        switch importType {
-        case .phrase:
-            let words = input.split(separator: " ").map{String($0)}
-            guard try validateForm(type: importType, address: recipient.address, words: words) else {
-                return
-            }
-            switch model.type {
-            case .multicoin:
-                try model.importWallet(
-                    name: recipient.name,
-                    keystoreType: .phrase(words: words, chains: AssetConfiguration.allChains)
-                )
-            case .chain(let chain):
-                try model.importWallet(
-                    name: recipient.name,
-                    keystoreType: .single(words: words, chain: chain)
-                )
-            }
-        case .privateKey:
-            guard try validateForm(type: importType, address: recipient.address, words: [input]) else {
-                return
-            }
-            try model.importWallet(name: recipient.name, keystoreType: .privateKey(text: input, chain: model.chain!))
-        case .address:
-            guard try validateForm(type: importType, address: recipient.address, words: []) else {
-                return
-            }
-            let chain = model.chain!
-            let address = chain.checksumAddress(recipient.address)
-            
-            try model.importWallet(name: recipient.name, keystoreType: .address(chain: chain, address: address))
         }
     }
 }

--- a/Features/Onboarding/Sources/Views/WordSuggestionView.swift
+++ b/Features/Onboarding/Sources/Views/WordSuggestionView.swift
@@ -25,3 +25,7 @@ struct WordSuggestionView: View {
         }
     }
 }
+
+extension String: @retroactive Identifiable {
+    public var id: String { self }
+}

--- a/Features/Onboarding/Sources/ViewsModels/ImportWalletViewModel.swift
+++ b/Features/Onboarding/Sources/ViewsModels/ImportWalletViewModel.swift
@@ -3,50 +3,67 @@ import Primitives
 import Style
 import Localization
 import WalletService
+import NameResolver
+import SwiftUI
 import enum Keystore.KeystoreImportType
+import struct Keystore.Mnemonic
 
-// TODO: - migrate to @observable macro
-class ImportWalletViewModel: ObservableObject {
+@Observable
+@MainActor
+final class ImportWalletViewModel {
+    private let walletService: WalletService
+    private let wordSuggester = WordSuggester()
 
     let type: ImportWalletType
-    let walletService: WalletService
-    let wordSuggester = WordSuggester()
-    let onFinish: (() -> Void)?
 
-    @Published var buttonState = ButtonState.normal
+    var name: String
+    var input: String = ""
+    var wordsSuggestion: [String] = []
+    var importType: WalletImportType = .phrase
+    var nameResolveState: NameRecordState = .none
+    var buttonState = ButtonState.normal
+
+    var isPresentingScanner = false
+    var isPresentingErrorMessage: String?
+
+    private let onFinish: (() -> Void)?
 
     init(
-        type: ImportWalletType,
         walletService: WalletService,
+        type: ImportWalletType,
         onFinish: (() -> Void)?
     ) {
-        self.type = type
         self.walletService = walletService
+        self.type = type
+        self.name = WalletNameGenerator(type: type, walletService: walletService).name
         self.onFinish = onFinish
     }
-    
+
     var title: String {
         switch type {
         case .multicoin: Localized.Wallet.multicoin
         case .chain(let chain): Asset(chain).name
         }
     }
-    
-    var name: String {
-        WalletNameGenerator(type: type, walletService: walletService).name
-    }
-    
+
+    var walletFieldTitle: String { Localized.Wallet.name }
+
+    var pasteButtonTitle: String { Localized.Common.paste }
+    var pasteButtonImage: Image { Images.System.paste }
+
+    var qrButtonTitle: String { Localized.Wallet.scan }
+    var qrButtonImage: Image { Images.System.qrCode }
+
+    var alertTitle: String { Localized.Errors.validation("") }
+
     var chain: Chain? {
         switch type {
         case .multicoin: .none
         case .chain(let chain): chain
         }
     }
-    
-    var showImportTypes: Bool {
-        importTypes.count > 1
-    }
-    
+
+    var showImportTypes: Bool { importTypes.count > 1 }
     var importTypes: [WalletImportType] {
         switch type {
         case .multicoin:
@@ -58,32 +75,135 @@ class ImportWalletViewModel: ObservableObject {
             return [.phrase, .privateKey, .address]
         }
     }
-    
-    func footerText(type: WalletImportType) -> AttributedString? {
-        switch type {
+
+    var footerText: AttributedString? {
+        switch importType {
         case .phrase, .privateKey: .none
         case .address: try? AttributedString(markdown: Localized.Wallet.importAddressWarning)
         }
     }
+}
 
-    var keyEncodingTypes: [EncodingType] {
-        chain?.keyEncodingTypes ?? []
+// MARK: - Business Logic
+
+extension ImportWalletViewModel {
+
+    func onChangeImportType(_: WalletImportType, _: WalletImportType) {
+        input = ""
     }
 
-    var importPrivateKeyPlaceholder: String {
-        keyEncodingTypes.map { $0.rawValue }.joined(separator: " / ")
+    func onChangeInput(_: String, newValue: String) {
+        wordsSuggestion = wordSuggester.wordSuggestionCalculate(value: newValue)
     }
 
-    func importWallet(name: String, keystoreType: KeystoreImportType) throws {
+    func onSelectActionButton() {
+        buttonState = .loading(showProgress: true)
+
+        Task {
+            try await Task.sleep(for: .milliseconds(50))
+            do {
+                try importWallet()
+            } catch {
+                isPresentingErrorMessage = error.localizedDescription
+                buttonState = .normal
+            }
+        }
+    }
+
+    func onSelectScanQR() {
+        isPresentingScanner = true
+    }
+
+    func onHandleScan(_ result: String) {
+        input = result
+    }
+
+    func onSelectWord(_ word: String) {
+        input = wordSuggester.selectWordCalculate(
+            input: input,
+            word: word
+        )
+    }
+
+    func onPaste() {
+        guard let string = UIPasteboard.general.string else {
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+            return
+        }
+        input = string.trim()
+    }
+}
+
+// MARK: - Private
+
+extension ImportWalletViewModel {
+    private func importWallet() throws {
+        let recipient: RecipientImport = {
+            if let result = nameResolveState.result {
+                return RecipientImport(name: result.name, address: result.address)
+            }
+            return RecipientImport(name: name, address: input)
+        }()
+        switch importType {
+        case .phrase:
+            let words = input.split(separator: " ").map{String($0)}
+            guard try validateForm(type: importType, address: recipient.address, words: words) else {
+                return
+            }
+            switch type {
+            case .multicoin:
+                try importWallet(
+                    name: recipient.name,
+                    keystoreType: .phrase(words: words, chains: AssetConfiguration.allChains)
+                )
+            case .chain(let chain):
+                try importWallet(
+                    name: recipient.name,
+                    keystoreType: .single(words: words, chain: chain)
+                )
+            }
+        case .privateKey:
+            guard try validateForm(type: importType, address: recipient.address, words: [input]) else {
+                return
+            }
+            try importWallet(name: recipient.name, keystoreType: .privateKey(text: input, chain: chain!))
+        case .address:
+            guard try validateForm(type: importType, address: recipient.address, words: []) else {
+                return
+            }
+            let chain = chain!
+            let address = chain.checksumAddress(recipient.address)
+
+            try importWallet(name: recipient.name, keystoreType: .address(chain: chain, address: address))
+        }
+    }
+
+    private func importWallet(name: String, keystoreType: KeystoreImportType) throws {
         try walletService.importWallet(name: name, type: keystoreType)
         onFinish?()
     }
-    
-    func wordSuggestionCalculate(value: String) -> [String] {
-        wordSuggester.wordSuggestionCalculate(value: value)
-    }
-    
-    func selectWordCalculate(input: String, word: String) -> String {
-        wordSuggester.selectWordCalculate(input: input, word: word)
+
+    private func validateForm(type: WalletImportType, address: String, words: [String]) throws  -> Bool {
+        guard !name.isEmpty else {
+            throw WalletImportError.emptyName
+        }
+        switch type {
+        case .phrase:
+            for word in words {
+                if !Mnemonic.isValidWord(word) {
+                    throw WalletImportError.invalidSecretPhraseWord(word: word)
+                }
+            }
+            guard Mnemonic.isValidWords(words) else {
+                throw WalletImportError.invalidSecretPhrase
+            }
+        case .privateKey:
+            return !words.joined().isEmpty
+        case .address:
+            guard chain!.isValidAddress(address) else {
+                throw WalletImportError.invalidAddress
+            }
+        }
+        return true
     }
 }


### PR DESCRIPTION
Migrates ImportWalletScene to use a single Observable ImportWalletViewModel, moving all business logic, state, and actions into the view model. 
Simplifies the view by binding directly to model properties and methods, and removes duplicated state and logic from the view.
Also adds missing Identifiable conformance for String in WordSuggestionView.

closes #892 