### PR TITLE
Add deep link support for social links

### DIFF
--- a/Gem.xcodeproj/project.pbxproj
+++ b/Gem.xcodeproj/project.pbxproj
@@ -579,7 +579,6 @@
 				D829BF2B2CBDB82600DEB2E8 /* Localization */,
 				83518CCC2D1C998300B339E5 /* PrimitivesComponents */,
 				8311A89A2DF9D35D00598C43 /* Validators */,
-				B69C56DA2DEF2E1700BBD95D /* Keychain */,
 			);
 			path = Packages;
 			sourceTree = "<group>";

--- a/Gem/Resources/Info.plist
+++ b/Gem/Resources/Info.plist
@@ -51,6 +51,12 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>tg</string>
+		<string>twitter</string>
+		<string>youtube</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/Packages/PrimitivesComponents/Package.swift
+++ b/Packages/PrimitivesComponents/Package.swift
@@ -42,8 +42,9 @@ let package = Package(
         .testTarget(
             name: "PrimitivesComponentsTests",
             dependencies: [
-                "PrimitivesComponents",
                 .product(name: "PrimitivesTestKit", package: "Primitives"),
+                "PrimitivesComponents",
+                "GemstonePrimitives",
             ]
         ),
     ]

--- a/Packages/PrimitivesComponents/Sources/Components/SocialLinksView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/SocialLinksView.swift
@@ -12,12 +12,19 @@ public struct SocialLinksView: View {
 
     public var body: some View {
         ForEach(model.links) { link in
-            SafariNavigationLink(url: link.url) {
-                ListItemView(
-                    title: link.title,
-                    subtitle: link.subtitle,
-                    imageStyle: .settings(assetImage: link.image)
-                )
+            let view = ListItemView(
+                title: link.title,
+                subtitle: link.subtitle,
+                imageStyle: .settings(assetImage: link.image)
+            )
+            if let deepLink = link.deepLink, UIApplication.shared.canOpenURL(deepLink) {
+                NavigationCustomLink(with: view) {
+                    UIApplication.shared.open(deepLink)
+                }
+            } else {
+                SafariNavigationLink(url: link.url) {
+                    view
+                }
             }
         }
     }

--- a/Packages/PrimitivesComponents/Sources/Types/InsightLink.swift
+++ b/Packages/PrimitivesComponents/Sources/Types/InsightLink.swift
@@ -9,17 +9,20 @@ public struct InsightLink {
     public let title: String
     public let subtitle: String?
     public var url: URL
+    public let deepLink: URL?
     public let image: AssetImage
     
     public init(
         title: String,
         subtitle: String?,
         url: URL,
+        deepLink: URL?,
         image: AssetImage
     ) {
         self.title = title
         self.subtitle = subtitle
         self.url = url
+        self.deepLink = deepLink
         self.image = image
     }
 }

--- a/Packages/PrimitivesComponents/Sources/ViewModels/AssetLinkViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/AssetLinkViewModel.swift
@@ -22,6 +22,7 @@ public struct AssetLinkViewModel {
             title: name,
             subtitle: host,
             url: url,
+            deepLink: deepLink,
             image: AssetImage.image(image)
         )
     }
@@ -68,6 +69,16 @@ public struct AssetLinkViewModel {
     
     public var url: URL? {
         assetLink.url.asURL
+    }
+    
+    public var deepLink: URL? {
+        switch assetLink.linkType {
+        case .telegram: URL(string: "tg://resolve?domain=gemwallet")
+        case .x: URL(string: "twitter://user?screen_name=GemWalletApp")
+        case .youTube: URL(string: "youtube://www.youtube.com/@gemwallet")
+        case .none, .discord, .reddit, .gitHub, .facebook, .website, .coingecko, .openSea, .instagram, .magicEden, .coinMarketCap, .tikTok:
+            nil
+        }
     }
     
     public var host: String? {

--- a/Packages/PrimitivesComponents/Sources/ViewModels/AssetLinkViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/AssetLinkViewModel.swift
@@ -72,13 +72,7 @@ public struct AssetLinkViewModel {
     }
     
     public var deepLink: URL? {
-        switch assetLink.linkType {
-        case .telegram: URL(string: "tg://resolve?domain=gemwallet")
-        case .x: URL(string: "twitter://user?screen_name=GemWalletApp")
-        case .youTube: URL(string: "youtube://www.youtube.com/@gemwallet")
-        case .none, .discord, .reddit, .gitHub, .facebook, .website, .coingecko, .openSea, .instagram, .magicEden, .coinMarketCap, .tikTok:
-            nil
-        }
+        DeepLinkViewModel(assetLink).deepLink
     }
     
     public var host: String? {

--- a/Packages/PrimitivesComponents/Sources/ViewModels/DeepLinkViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/DeepLinkViewModel.swift
@@ -1,0 +1,26 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+
+struct DeepLinkViewModel {
+    public let assetLink: AssetLink
+    
+    public init(_ assetLink: AssetLink) {
+        self.assetLink = assetLink
+    }
+    
+    public var deepLink: URL? {
+        guard let path = assetLink.url.asURL?.path().trimmingPrefix("/") else { return nil }
+        
+        return switch assetLink.linkType {
+        case .telegram: URL(string: "tg://resolve?domain=\(path)")
+        case .x: URL(string: "twitter://user?screen_name=\(path)")
+        case .youTube: URL(string: "youtube://www.youtube.com/\(path)")
+        case .discord: URL(string: "https://discord.gg/\(path)")
+        case .gitHub: URL(string: "https://github.com/\(path)")
+        case .none, .reddit, .facebook, .website, .coingecko, .openSea, .instagram, .magicEden, .coinMarketCap, .tikTok:
+            nil
+        }
+    }
+}

--- a/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/DeepLinkViewModelTests.swift
+++ b/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/DeepLinkViewModelTests.swift
@@ -1,0 +1,31 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Primitives
+import GemstonePrimitives
+import Gemstone
+
+@testable import PrimitivesComponents
+
+struct DeepLinkViewModelTests {
+    @Test
+    func deepLinks() {
+        #expect(DeepLinkViewModel.mock(.telegram)?.deepLink?.absoluteString == "tg://resolve?domain=gemwallet")
+        #expect(DeepLinkViewModel.mock(.x)?.deepLink?.absoluteString == "twitter://user?screen_name=GemWalletApp")
+        #expect(DeepLinkViewModel.mock(.youTube)?.deepLink?.absoluteString == "youtube://www.youtube.com/@gemwallet")
+        #expect(DeepLinkViewModel.mock(.discord)?.deepLink?.absoluteString == "https://discord.gg/aWkq5sj7SY")
+        #expect(DeepLinkViewModel.mock(.gitHub)?.deepLink?.absoluteString == "https://github.com/gemwalletcom")
+    }
+}
+
+extension DeepLinkViewModel {
+    static func mock(_ url: SocialUrl) -> DeepLinkViewModel? {
+        guard let socialUrl = Social.url(url) else { return nil }
+        return DeepLinkViewModel(
+            AssetLink(
+                name: url.linkType.rawValue,
+                url: socialUrl.absoluteString
+            )
+        )
+    }
+}


### PR DESCRIPTION
Close: https://github.com/gemwalletcom/gem-ios/issues/805

Introduces deep link URLs for supported social platforms (Telegram, Twitter, YouTube) in InsightLink and AssetLinkViewModel. Updates SocialLinksView to prefer opening deep links when available and permitted, falling back to Safari otherwise. Also updates Info.plist to allow querying these URL schemes.


https://github.com/user-attachments/assets/d0ec3e7e-fb25-4cd5-8bcc-08e2aa2bc722


https://github.com/user-attachments/assets/99683e69-9b03-4686-b196-a0561fce0f71


https://github.com/user-attachments/assets/26bc17bb-3bcb-4fd4-8374-c98a48da7d16

