### PR TITLE
Refactor toast messages to use ToastMessage type

### DIFF
--- a/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -32,7 +32,7 @@ public final class AssetSceneViewModel: Sendable {
 
     private var isPresentingAssetSelectedInput: Binding<SelectedAssetInput?>
 
-    public var isPresentingToastMessage: String?
+    public var isPresentingToastMessage: ToastMessage?
     public var isPresentingAssetSheet: AssetSheetType?
 
     public var input: AssetSceneInput
@@ -79,16 +79,20 @@ public final class AssetSceneViewModel: Sendable {
     var pinText: String {
         assetData.metadata.isPinned ? Localized.Common.unpin : Localized.Common.pin
     }
+    var pinSystemImage: String {
+        assetData.metadata.isPinned ? SystemImage.unpin : SystemImage.pin
+    }
     var pinImage: Image {
-        assetData.metadata.isPinned ? Image(systemName: SystemImage.unpin) : Image(systemName: SystemImage.pin)
+        Image(systemName: pinSystemImage)
     }
     var enableText: String {
         assetData.metadata.isEnabled ? Localized.Asset.hideFromWallet : Localized.Asset.addToWallet
     }
     var enableImage: Image {
-        assetData.metadata.isEnabled ? Image(systemName: SystemImage.minusCircle) : Image(
-            systemName: SystemImage.plusCircle
-        )
+        Image(systemName: enableSystemImage)
+    }
+    var enableSystemImage: String {
+        assetData.metadata.isEnabled ? SystemImage.minusCircle : SystemImage.plusCircle
     }
     
     var reservedBalanceUrl: URL? { assetModel.asset.chain.accountActivationFeeUrl }
@@ -264,7 +268,7 @@ extension AssetSceneViewModel {
 
     public func onSetPriceAlertComplete(message: String) {
         isPresentingAssetSheet = .none
-        isPresentingToastMessage = message
+        isPresentingToastMessage = ToastMessage(title: message, image: priceAlertsSystemImage)
     }
 
     public func onSelectSetPriceAlerts() {
@@ -274,10 +278,16 @@ extension AssetSceneViewModel {
     public func onTogglePriceAlert() {
         Task {
             if assetData.isPriceAlertsEnabled {
-                isPresentingToastMessage = Localized.PriceAlerts.disabledFor(assetData.asset.name)
+                isPresentingToastMessage = ToastMessage(
+                    title: Localized.PriceAlerts.disabledFor(assetData.asset.name),
+                    image: priceAlertsSystemImage
+                )
                 await disablePriceAlert()
             } else {
-                isPresentingToastMessage = Localized.PriceAlerts.enabledFor(assetData.asset.name)
+                isPresentingToastMessage = ToastMessage(
+                    title: Localized.PriceAlerts.enabledFor(assetData.asset.name),
+                    image: priceAlertsSystemImage
+                )
                 await enablePriceAlert()
             }
         }
@@ -290,7 +300,7 @@ extension AssetSceneViewModel {
     public func onSelectPin() {
         do {
             let isPinned = !assetData.metadata.isPinned
-            //isPresentingToastMessage = ToastMessage(title: pinText, image: pinImage)
+            isPresentingToastMessage = ToastMessage(title: pinText, image: pinSystemImage)
             try walletsService.setPinned(isPinned, walletId: wallet.walletId, assetId: asset.id)
             if !assetData.metadata.isEnabled {
                 onSelectEnable()
@@ -303,7 +313,7 @@ extension AssetSceneViewModel {
     public func onSelectEnable() {
         Task {
             let isEnabled = !assetData.metadata.isEnabled
-            //isPresentingToastMessage = ToastMessage(title: enableText, image: enableImage)
+            isPresentingToastMessage = ToastMessage(title: enableText, image: enableSystemImage)
             do {
                 await walletsService.enableAssets(walletId: wallet.walletId, assetIds: [asset.id], enabled: isEnabled)
             }

--- a/Features/NFT/Sources/Scenes/CollectibleScene.swift
+++ b/Features/NFT/Sources/Scenes/CollectibleScene.swift
@@ -45,18 +45,8 @@ public struct CollectibleScene: View {
                actions: {},
                message: {
             Text(model.isPresentingErrorMessage ?? "")
-        }
-        )
-        .toast(
-            isPresenting: $model.isPresentingSaveToPhotosToast,
-            title: Localized.Nft.saveToPhotos,
-            systemImage: SystemImage.checkmark
-        )
-        .toast(
-            isPresenting: $model.isPresentingSetAsAvatarToast,
-            title: Localized.Nft.setAsAvatar,
-            systemImage: SystemImage.checkmark
-        )
+        })
+        .toast(message: $model.isPresentingToast)
     }
 }
 

--- a/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
+++ b/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
@@ -21,8 +21,7 @@ public final class CollectibleViewModel {
 
     var isPresentingPhotoPermissionMessage: Bool = false
     var isPresentingErrorMessage: String?
-    var isPresentingSaveToPhotosToast = false
-    var isPresentingSetAsAvatarToast = false
+    var isPresentingToast: ToastMessage?
 
     public init(
         wallet: Wallet,
@@ -123,7 +122,7 @@ extension CollectibleViewModel {
         Task {
             do {
                 try await saveImageToGallery()
-                isPresentingSaveToPhotosToast = true
+                isPresentingToast = ToastMessage(title: Localized.Nft.saveToPhotos, image: SystemImage.checkmark)
             } catch let error as ImageGalleryServiceError {
                 switch error {
                 case .wrongURL, .invalidData, .invalidResponse, .unexpectedStatusCode, .urlSessionError:
@@ -139,7 +138,7 @@ extension CollectibleViewModel {
         Task {
             do {
                 try await setWalletAvatar()
-                isPresentingSetAsAvatarToast = true
+                isPresentingToast = ToastMessage(title: Localized.Nft.setAsAvatar, image: SystemImage.checkmark)
             } catch {
                 NSLog("Set nft avatar error: \(error)")
             }

--- a/Gem/Navigation/Assets/AssetNavigationView.swift
+++ b/Gem/Navigation/Assets/AssetNavigationView.swift
@@ -44,10 +44,7 @@ struct AssetNavigationView: View {
                 )
             }
         }
-        .toast(
-            message: $model.isPresentingToastMessage,
-            systemImage: model.priceAlertsSystemImage
-        )
+        .toast(message: $model.isPresentingToastMessage)
         .sheet(item: $model.isPresentingAssetSheet) {
             switch $0 {
             case let .info(type):

--- a/Gem/Navigation/Price Alerts/PriceAlertsNavigationView.swift
+++ b/Gem/Navigation/Price Alerts/PriceAlertsNavigationView.swift
@@ -7,6 +7,7 @@ import PriceAlerts
 import Assets
 import Localization
 import Primitives
+import Components
 
 struct PriceAlertsNavigationView: View {
     @Environment(\.dismiss) private var dismiss
@@ -17,7 +18,7 @@ struct PriceAlertsNavigationView: View {
     @Environment(\.walletService) private var walletService
 
     @State private var isPresentingAddAsset: Bool = false
-    @State private var isPresentingToastMessage: String?
+    @State private var isPresentingToastMessage: ToastMessage?
     @State private var assetPriceAlertsNavigationPath = NavigationPath()
 
     let model: PriceAlertsViewModel
@@ -45,14 +46,11 @@ struct PriceAlertsNavigationView: View {
                 )
             )
         }
-        .toast(
-            message: $isPresentingToastMessage,
-            systemImage: SystemImage.bellFill
-        )
+        .toast(message: $isPresentingToastMessage)
     }
     
     private func onSelectAsset(asset: Asset) {
         isPresentingAddAsset = false
-        isPresentingToastMessage = Localized.PriceAlerts.enabledFor(asset.name)
+        isPresentingToastMessage = ToastMessage(title: Localized.PriceAlerts.enabledFor(asset.name), image: SystemImage.bellFill)
     }
 }

--- a/Gem/Scenes/RootScene.swift
+++ b/Gem/Scenes/RootScene.swift
@@ -7,6 +7,7 @@ import GemstonePrimitives
 import Primitives
 import Onboarding
 import PriceService
+import Components
 
 struct RootScene: View {
     @State private var model: RootSceneViewModel
@@ -75,8 +76,10 @@ struct RootScene: View {
         )
         .toast(
             isPresenting: $model.isPresentingConnectorBar,
-            title: "\(Localized.WalletConnect.brandName)...",
-            systemImage: SystemImage.network
+            message: ToastMessage(
+                title: "\(Localized.WalletConnect.brandName)...",
+                image: SystemImage.network
+            )
         )
     }
 }

--- a/Packages/Components/Sources/Types/ToastMessage.swift
+++ b/Packages/Components/Sources/Types/ToastMessage.swift
@@ -1,0 +1,25 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import SwiftUI
+
+public struct ToastMessage: Identifiable {
+    public var id: String { title + image }
+    
+    public let title: String
+    public let image: String
+    
+    public init(
+        title: String,
+        image: String
+    ) {
+        self.title = title
+        self.image = image
+    }
+}
+
+extension ToastMessage {
+    static func empty() -> ToastMessage {
+        ToastMessage(title: "", image: "")
+    }
+}

--- a/Packages/Components/Sources/ViewModifiers/ToastModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/ToastModifier.swift
@@ -7,17 +7,14 @@ import Style
 struct ToastModifier: ViewModifier {
     private var isPresenting: Binding<Bool>
 
-    private let value: String
-    private let systemImage: String
+    private let message: ToastMessage
 
     init(
         isPresenting: Binding<Bool>,
-        value: String,
-        systemImage: String
+        message: ToastMessage
     ) {
         self.isPresenting = isPresenting
-        self.value = value
-        self.systemImage = systemImage
+        self.message = message
     }
 
     func body(content: Content) -> some View {
@@ -25,16 +22,15 @@ struct ToastModifier: ViewModifier {
             .toast(isPresenting: isPresenting) {
                 AlertToast(
                     displayMode: .banner(.pop),
-                    type: .systemImage(systemImage, Colors.black),
-                    title: value
+                    type: .systemImage(message.image, Colors.black),
+                    title: message.title
                 )
             }
     }
 }
 
 private struct OptionalMessageToastModifier: ViewModifier {
-    @Binding var message: String?
-    let systemImage: String
+    @Binding var message: ToastMessage?
 
     func body(content: Content) -> some View {
         content.modifier(
@@ -45,8 +41,7 @@ private struct OptionalMessageToastModifier: ViewModifier {
                         if showing == false { message = nil }
                     }
                 ),
-                value: message ?? "",
-                systemImage: systemImage
+                message: message ?? .empty()
             )
         )
     }
@@ -55,21 +50,11 @@ private struct OptionalMessageToastModifier: ViewModifier {
 // MARK: - View Modifier
 
 public extension View {
-    func toast(isPresenting: Binding<Bool>, title: String, systemImage: String) -> some View {
-        self.modifier(
-            ToastModifier(
-                isPresenting: isPresenting,
-                value: title,
-                systemImage: systemImage)
-        )
+    func toast(isPresenting: Binding<Bool>, message: ToastMessage) -> some View {
+        modifier(ToastModifier(isPresenting: isPresenting, message: message))
     }
 
-    func toast(message: Binding<String?>, systemImage: String) -> some View {
-        self.modifier(
-            OptionalMessageToastModifier(
-                message: message,
-                systemImage: systemImage
-            )
-        )
+    func toast(message: Binding<ToastMessage?>) -> some View {
+        modifier(OptionalMessageToastModifier(message: message))
     }
 }

--- a/Packages/PrimitivesComponents/Sources/Extensions/View+CopyToast.swift
+++ b/Packages/PrimitivesComponents/Sources/Extensions/View+CopyToast.swift
@@ -10,16 +10,12 @@ public extension View {
         isPresenting: Binding<Bool>,
         feedbackGenerator: UINotificationFeedbackGenerator = UINotificationFeedbackGenerator()
     ) -> some View {
-        self.toast(
-            isPresenting: isPresenting,
-            title: model.message,
-            systemImage: model.systemImage
-        )
-        .onChange(of: isPresenting.wrappedValue, initial: true) { oldValue, newValue in
-            if newValue {
-                model.copy()
-                feedbackGenerator.notificationOccurred(.success)
+        toast(isPresenting: isPresenting, message: ToastMessage(title: model.message, image: model.systemImage))
+            .onChange(of: isPresenting.wrappedValue, initial: true) { oldValue, newValue in
+                if newValue {
+                    model.copy()
+                    feedbackGenerator.notificationOccurred(.success)
+                }
             }
-        }
     }
 }


### PR DESCRIPTION
Close: https://github.com/gemwalletcom/gem-ios/issues/898

Replaces plain String-based toast messages with a new ToastMessage struct that includes both title and image. Updates all relevant view models, views, and toast modifiers to use the new type, improving consistency and flexibility for toast notifications across the app.