### PR TITLE
Refactor asset discovery to use a stream and exclude defaults

### DIFF
--- a/GemTests/unit_frameworks.xctestplan
+++ b/GemTests/unit_frameworks.xctestplan
@@ -72,7 +72,6 @@
       }
     },
     {
-      "enabled" : false,
       "target" : {
         "containerPath" : "container:Services\/DiscoverAssetsService",
         "identifier" : "DiscoverAssetsServiceTests",

--- a/Packages/Primitives/Sources/Extensions/AsyncStream+Just.swift
+++ b/Packages/Primitives/Sources/Extensions/AsyncStream+Just.swift
@@ -1,0 +1,12 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public extension AsyncStream {
+    static func just(_ value: Element) -> AsyncStream<Element> where Element: Sendable {
+        AsyncStream { continuation in
+            continuation.yield(value)
+            continuation.finish()
+        }
+    }
+}

--- a/Services/BalanceService/Sources/BalanceService.swift
+++ b/Services/BalanceService/Sources/BalanceService.swift
@@ -53,12 +53,12 @@ extension BalanceService {
     }
 
     @discardableResult
-    public func updateBalance(walletId: String, asset: AssetId, address: String) async throws -> AssetBalanceChange? {
+    public func updateBalance(walletId: String, asset: AssetId, address: String) async throws -> [AssetBalanceChange] {
         switch asset.type {
         case .native:
-            await updateCoinBalance(walletId: walletId, asset: asset, address: address).first
+            await updateCoinBalance(walletId: walletId, asset: asset, address: address)
         case .token:
-            await updateTokenBalances(walletId: walletId, chain: asset.chain, tokenIds: [asset], address: address).first
+            await updateTokenBalances(walletId: walletId, chain: asset.chain, tokenIds: [asset], address: address)
         }
     }
 

--- a/Services/BalanceService/Sources/Protocols/BalanceUpdater.swift
+++ b/Services/BalanceService/Sources/Protocols/BalanceUpdater.swift
@@ -4,5 +4,5 @@ import Foundation
 import Primitives
 
 public protocol BalancerUpdater: Sendable {
-    func updateBalance(walletId: String, asset: AssetId, address: String) async throws -> AssetBalanceChange?
+    func updateBalance(walletId: String, asset: AssetId, address: String) async throws -> [AssetBalanceChange]
 }

--- a/Services/BalanceService/TestKit/BalancerUpdater+TestKit.swift
+++ b/Services/BalanceService/TestKit/BalancerUpdater+TestKit.swift
@@ -6,7 +6,7 @@ import Primitives
 
 public struct BalancerUpdaterMock: BalancerUpdater {
     public init() {}
-    public func updateBalance(walletId: String, asset: AssetId, address: String) async throws -> AssetBalanceChange? {
-        return nil
+    public func updateBalance(walletId: String, asset: AssetId, address: String) async throws -> [AssetBalanceChange] {
+        []
     }
 }

--- a/Services/DiscoverAssetsService/Package.swift
+++ b/Services/DiscoverAssetsService/Package.swift
@@ -31,7 +31,10 @@ let package = Package(
         ),
         .testTarget(
             name: "DiscoverAssetsServiceTests",
-            dependencies: ["DiscoverAssetsService"]
+            dependencies: [
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
+                "DiscoverAssetsService"
+            ]
         ),
     ]
 )

--- a/Services/DiscoverAssetsService/Sources/DiscoverAssetsService.swift
+++ b/Services/DiscoverAssetsService/Sources/DiscoverAssetsService.swift
@@ -42,7 +42,7 @@ public struct DiscoverAssetsService: Sendable {
     public func updateCoins(wallet: Wallet) -> AsyncStream<AssetUpdate> {
         guard wallet.isMultiCoins else { return AsyncStream.just(AssetUpdate(walletId: wallet.walletId, assetIds: [])) }
         
-        let coinAddressIds: [(AssetId, String)] = wallet.accounts.map {
+        let coinAddressIds: [(AssetId, String)] = wallet.accounts.excludeDefaultAccounts().map {
             ($0.chain.assetId, $0.address)
         }
 
@@ -86,6 +86,14 @@ public struct DiscoverAssetsService: Sendable {
             continuation.onTermination = { _ in
                 task.cancel()
             }
+        }
+    }
+}
+
+extension Array where Element == Account {
+    func excludeDefaultAccounts() -> [Account] {
+        filter { account in
+            !AssetConfiguration.enabledByDefault.contains(where: { $0.chain == account.chain })
         }
     }
 }

--- a/Services/DiscoverAssetsService/Sources/DiscoverAssetsService.swift
+++ b/Services/DiscoverAssetsService/Sources/DiscoverAssetsService.swift
@@ -22,7 +22,7 @@ public struct DiscoverAssetsService: Sendable {
         deviceId: String,
         wallet: Wallet,
         fromTimestamp: Int
-    ) async throws -> AssetUpdate {
+    ) async throws -> AsyncStream<AssetUpdate> {
         let tokenAddressIds: [(AssetId, String)] = try await assetsService
             .getAssetsByDeviceId(
                 deviceId: deviceId,
@@ -36,49 +36,56 @@ public struct DiscoverAssetsService: Sendable {
                 return nil
             }
 
-        return await updateBalances(tokenAddressIds, wallet)
+        return updateBalances(tokenAddressIds, wallet)
     }
 
-    public func updateCoins(wallet: Wallet) async -> AssetUpdate {
-        guard wallet.isMultiCoins else { return AssetUpdate(walletId: wallet.walletId, assetIds: []) }
+    public func updateCoins(wallet: Wallet) -> AsyncStream<AssetUpdate> {
+        guard wallet.isMultiCoins else { return AsyncStream.just(AssetUpdate(walletId: wallet.walletId, assetIds: [])) }
         
         let coinAddressIds: [(AssetId, String)] = wallet.accounts.map {
             ($0.chain.assetId, $0.address)
         }
 
-        return await updateBalances(coinAddressIds, wallet)
+        return updateBalances(coinAddressIds, wallet)
     }
     
     // MARK: - Private methods
     
-    private func updateBalances(_ assetAddressIds: [(AssetId, String)], _ wallet: Wallet) async -> AssetUpdate {
-        await withTaskGroup(of: AssetBalanceChange?.self) { group in
-            for (asset, address) in assetAddressIds {
-                group.addTask {
-                    do {
-                        return try await self.balanceService.updateBalance(
-                            walletId: wallet.id,
-                            asset: asset,
-                            address: address
-                        )
-                    } catch {
-                        NSLog("Error fetching token balance: \(error)")
-                        return nil
+    private func updateBalances(_ assetAddressIds: [(AssetId, String)], _ wallet: Wallet) -> AsyncStream<AssetUpdate> {
+        AsyncStream { continuation in
+            let task = Task {
+                await withTaskGroup(of: [AssetBalanceChange].self) { group in
+                    for (asset, address) in assetAddressIds {
+                        group.addTask {
+                            do {
+                                return try await self.balanceService.updateBalance(
+                                    walletId: wallet.id,
+                                    asset: asset,
+                                    address: address
+                                )
+                            } catch {
+                                NSLog("Error fetching token balance: \(error)")
+                                return []
+                            }
+                        }
                     }
+                    
+                    for await change in group {
+                        continuation.yield(
+                            AssetUpdate(
+                                walletId: wallet.walletId,
+                                assetIds: change.filter { $0.type.available.or(.zero) > 0}.map { $0.assetId }
+                            )
+                        )
+                    }
+                    
+                    continuation.finish()
                 }
             }
-
-            var updates: [AssetBalanceChange] = []
-            for await update in group {
-                if let update = update {
-                    updates.append(update)
-                }
+            
+            continuation.onTermination = { _ in
+                task.cancel()
             }
-
-            return AssetUpdate(
-                walletId: wallet.walletId,
-                assetIds: updates.filter { $0.type.available.or(.zero) > 0 }.map { $0.assetId }
-            )
         }
     }
 }

--- a/Services/DiscoverAssetsService/Tests/DiscoverAssetsServiceTests.swift
+++ b/Services/DiscoverAssetsService/Tests/DiscoverAssetsServiceTests.swift
@@ -1,6 +1,16 @@
 import Testing
+import Primitives
+import PrimitivesTestKit
+
 @testable import DiscoverAssetsService
 
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+struct DiscoverAssetsServiceTests {
+    @Test
+    func excludeDefaultAccounts() throws {
+        let filteredAccounts: [Account] = [.mock(chain: .bitcoin), .mock(chain: .solana), .mock(chain: .ton), .mock(chain: .aptos)].excludeDefaultAccounts()
+
+        #expect(filteredAccounts.count == 2)
+        #expect(filteredAccounts.contains(.mock(chain: .ton)))
+        #expect(filteredAccounts.contains(.mock(chain: .aptos)))
+    }
 }


### PR DESCRIPTION
Close: https://github.com/gemwalletcom/gem-ios/issues/856

This pull request improves the asset discovery process by refactoring DiscoverAssetsService for better performance and efficiency.

The service now returns an AsyncStream<AssetUpdate>, allowing asset updates to be processed as they are found rather than waiting for the entire scan to complete. This makes the feature more responsive.

Additionally, a filter has been added to excludeDefaultAccounts from the discovery process, preventing redundant checks on assets that are already enabled by default. Corresponding unit tests have been added to validate the new filtering logic.