### PR TITLE
Add support for WalletConnect session topic deep links

### DIFF
--- a/Gem/ViewModels/RootSceneViewModel.swift
+++ b/Gem/ViewModels/RootSceneViewModel.swift
@@ -1,17 +1,17 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import Foundation
+import AppService
 import DeviceService
+import Foundation
+import LockManager
+import Onboarding
 import Primitives
 import SwiftUI
-import LockManager
-import WalletConnector
-import TransactionsService
 import TransactionService
+import TransactionsService
+import WalletConnector
 import WalletService
 import WalletsService
-import Onboarding
-import AppService
 
 @Observable
 @MainActor
@@ -30,11 +30,12 @@ final class RootSceneViewModel {
 
     var availableRelease: Release?
     var canSkipUpdate: Bool { availableRelease?.upgradeRequired == false }
-    
+
     var isPresentingConnectorError: String? {
         get { walletConnectorPresenter.isPresentingError }
         set { walletConnectorPresenter.isPresentingError = newValue }
     }
+
     var isPresentingConnnectorSheet: WalletConnectorSheetType? {
         get { walletConnectorPresenter.isPresentingSheet }
         set { walletConnectorPresenter.isPresentingSheet = newValue }
@@ -105,6 +106,9 @@ extension RootSceneViewModel {
                 try await connectionsService.pair(uri: uri)
             case .walletConnectRequest:
                 isPresentingConnectorBar = true
+            case .walletConnectSession:
+                isPresentingConnectorBar = true
+                connectionsService.updateSessions()
             case .asset(let assetId):
                 notificationHandler.notify(notification: PushNotification.asset(assetId))
             }
@@ -113,7 +117,7 @@ extension RootSceneViewModel {
             isPresentingConnectorError = error.localizedDescription
         }
     }
-    
+
     func skipRelease() {
         guard let version = availableRelease?.version else { return }
         onstartAsyncService.skipRelease(version)
@@ -123,7 +127,6 @@ extension RootSceneViewModel {
 // MARK: - Private
 
 extension RootSceneViewModel {
-
     private func setup(wallet: Wallet) {
         onstartAsyncService.setup(wallet: wallet)
         do {

--- a/Packages/Primitives/Sources/URLAction.swift
+++ b/Packages/Primitives/Sources/URLAction.swift
@@ -5,5 +5,6 @@ import Foundation
 public enum URLAction: Equatable {
     case walletConnect(uri: String)
     case walletConnectRequest
+    case walletConnectSession(String)
     case asset(AssetId)
 }

--- a/Packages/Primitives/Sources/URLParser.swift
+++ b/Packages/Primitives/Sources/URLParser.swift
@@ -2,14 +2,13 @@
 
 import Foundation
 
-public struct URLParser {
-    
+public enum URLParser {
     public static func from(url: URL) throws -> URLAction {
-        let urlComponents = Array(url.pathComponents.dropFirst());
+        let urlComponents = Array(url.pathComponents.dropFirst())
         // universal links
         if url.host() == DeepLink.host || url.scheme == "gem" {
             if urlComponents.count >= 2 && urlComponents.first == "tokens" {
-                let chain = try Chain(id: try urlComponents.getElement(safe: 1))
+                let chain = try Chain(id: urlComponents.getElement(safe: 1))
                 return .asset(AssetId(chain: chain, tokenId: urlComponents.element(at: 2)))
             }
         }
@@ -21,6 +20,12 @@ public struct URLParser {
             return .walletConnect(uri: uri)
         } else if url.absoluteString.contains("wc?requestId") {
             return .walletConnectRequest
+        } else if url.absoluteString.contains("wc?sessionTopic") {
+            guard let components = URLComponents(string: url.absoluteString),
+                  let sessionTopic = components.queryItems?.first(where: { $0.name == "sessionTopic" })?.value else {
+                throw AnyError("invalid sessionTopic url")
+            }
+            return .walletConnectSession(sessionTopic)
         }
         throw AnyError("url parser: unknown url")
     }

--- a/Packages/Primitives/Tests/PrimitivesTests/URLParserTests.swift
+++ b/Packages/Primitives/Tests/PrimitivesTests/URLParserTests.swift
@@ -1,22 +1,21 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import Testing
 import Foundation
 @testable import Primitives
+import Testing
 
 struct URLParserTests {
-
-    @Test func testAssetUrl() async throws {
+    @Test func assetUrl() async throws {
         let chainAction = try URLParser.from(url: URL(string: "https://gemwallet.com/tokens/bitcoin")!)
-        
+
         #expect(chainAction == URLAction.asset(AssetId(chain: .bitcoin, tokenId: .none)))
-        
+
         let tokenAction = try URLParser.from(url: URL(string: "https://gemwallet.com/tokens/ethereum/0xdAC17F958D2ee523a2206206994597C13D831ec7")!)
-        
-        #expect(tokenAction == URLAction.asset(AssetId(chain: .ethereum, tokenId: "0xdAC17F958D2ee523a2206206994597C13D831ec7")) )
+
+        #expect(tokenAction == URLAction.asset(AssetId(chain: .ethereum, tokenId: "0xdAC17F958D2ee523a2206206994597C13D831ec7")))
     }
 
-    @Test func testWCUrl() async throws {
+    @Test func walletConnectSessionTopicUrl() async throws {
         let url = "gem://wc?sessionTopic=64a4f0817e3dd003cbe23202fb6ffaa16d38074de84762a5797e6092b2250a27"
 
         let action = try URLParser.from(url: URL(string: url)!)

--- a/Packages/Primitives/Tests/PrimitivesTests/URLParserTests.swift
+++ b/Packages/Primitives/Tests/PrimitivesTests/URLParserTests.swift
@@ -15,4 +15,12 @@ struct URLParserTests {
         
         #expect(tokenAction == URLAction.asset(AssetId(chain: .ethereum, tokenId: "0xdAC17F958D2ee523a2206206994597C13D831ec7")) )
     }
+
+    @Test func testWCUrl() async throws {
+        let url = "gem://wc?sessionTopic=64a4f0817e3dd003cbe23202fb6ffaa16d38074de84762a5797e6092b2250a27"
+
+        let action = try URLParser.from(url: URL(string: url)!)
+
+        #expect(action == .walletConnectSession("64a4f0817e3dd003cbe23202fb6ffaa16d38074de84762a5797e6092b2250a27"))
+    }
 }


### PR DESCRIPTION
## Summary
- Add support for parsing `gem://wc?sessionTopic=` URIs in URLParser
- Add new `walletConnectSession` case to URLAction enum  
- Update RootSceneViewModel to handle session topic deep links
- Add comprehensive test coverage

## Changes Made
- **URLAction.swift**: Added `.walletConnectSession(String)` case
- **URLParser.swift**: Added proper query parameter parsing using URLComponents to extract sessionTopic
- **RootSceneViewModel.swift**: Added handling for session topic links that calls `connectionsService.updateSessions()`
- **URLParserTests.swift**: Added test case for session topic parsing
- Format code

## Test Plan
- [x] Added unit test for session topic URL parsing
- [x] Verified URLParser correctly extracts sessionTopic parameter
- [x] Confirmed RootSceneViewModel handles new case appropriately
- [x] Manual testing of magiceden.io

🤖 Generated with [Claude Code](https://claude.ai/code)