### PR TITLE
Migrate remaining .alert() usages to AlertMessage pattern

### DIFF
--- a/Features/ChainSettings/Sources/Scenes/AddNodeScene.swift
+++ b/Features/ChainSettings/Sources/Scenes/AddNodeScene.swift
@@ -55,13 +55,7 @@ public struct AddNodeScene: View {
         .sheet(isPresented: $model.isPresentingScanner) {
             ScanQRCodeNavigationStack(action: onHandleScan(_:))
         }
-        .alert("",
-            isPresented: $model.isPresentingErrorAlert.mappedToBool(),
-            actions: {},
-            message: {
-                Text(model.isPresentingErrorAlert ?? "")
-            }
-        )
+        .alertSheet($model.isPresentingAlertMessage)
     }
 }
 
@@ -134,7 +128,7 @@ extension AddNodeScene {
             try model.importFoundNode()
             onDismiss?()
         } catch {
-            model.isPresentingErrorAlert = error.localizedDescription
+            model.isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
         }
     }
 

--- a/Features/ChainSettings/Sources/ViewModels/AddNodeSceneViewModel.swift
+++ b/Features/ChainSettings/Sources/ViewModels/AddNodeSceneViewModel.swift
@@ -20,7 +20,7 @@ public final class AddNodeSceneViewModel {
     public var urlInput: String = ""
     public var state: StateViewType<AddNodeResultViewModel> = .noData
     public var isPresentingScanner: Bool = false
-    public var isPresentingErrorAlert: String?
+    public var isPresentingAlertMessage: AlertMessage?
 
     public init(chain: Chain, nodeService: NodeService) {
         self.chain = chain

--- a/Features/ManageWallets/Sources/Scenes/WalletDetailScene.swift
+++ b/Features/ManageWallets/Sources/Scenes/WalletDetailScene.swift
@@ -23,7 +23,7 @@ public struct WalletDetailScene: View {
 
     @State private var name: String
 
-    @State private var isPresentingErrorMessage: String?
+    @State private var isPresentingAlertMessage: AlertMessage?
     @State private var isPresentingDeleteConfirmation: Bool?
     @State private var isPresentingExportWallet: ExportWalletType?
     @FocusState private var focusedField: Field?
@@ -125,14 +125,7 @@ public struct WalletDetailScene: View {
                 )
             }
         )
-        .alert(
-            Localized.Errors.transfer(""),
-            isPresented: $isPresentingErrorMessage.mappedToBool(),
-            actions: {},
-            message: {
-                Text(isPresentingErrorMessage ?? "")
-            }
-        )
+        .alertSheet($isPresentingAlertMessage)
         .sheet(item: $isPresentingExportWallet) {
             ExportWalletNavigationStack(flow: $0)
         }
@@ -146,7 +139,7 @@ extension WalletDetailScene {
         do {
             try model.rename(name: name)
         } catch {
-            isPresentingErrorMessage = error.localizedDescription
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
         }
     }
 
@@ -155,7 +148,7 @@ extension WalletDetailScene {
             do {
                 isPresentingExportWallet = .words(try model.getMnemonicWords())
             } catch {
-                isPresentingErrorMessage = error.localizedDescription
+                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
             }
         }
     }
@@ -166,7 +159,7 @@ extension WalletDetailScene {
                 //In the future it should allow to export PK for multichain wallet and specify the chain
                 isPresentingExportWallet = .privateKey(try model.getPrivateKey())
             } catch {
-                isPresentingErrorMessage = error.localizedDescription
+                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
             }
         }
     }
@@ -180,7 +173,7 @@ extension WalletDetailScene {
             try model.delete()
             dismiss()
         } catch {
-            isPresentingErrorMessage = error.localizedDescription
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
         }
     }
 

--- a/Features/ManageWallets/Sources/Scenes/WalletsScene.swift
+++ b/Features/ManageWallets/Sources/Scenes/WalletsScene.swift
@@ -9,7 +9,7 @@ import Localization
 public struct WalletsScene: View {
     @Environment(\.dismiss) private var dismiss
 
-    @State private var isPresentingErrorMessage: String?
+    @State private var isPresentingAlertMessage: AlertMessage?
     @State private var showingDeleteAlert = false
 
     @Binding private var isPresentingCreateWalletSheet: Bool
@@ -101,13 +101,7 @@ public struct WalletsScene: View {
             .listRowInsets(.assetListRowInsets)
         }
         .contentMargins(.top, .scene.top, for: .scrollContent)
-        .alert("",
-            isPresented: $isPresentingErrorMessage.mappedToBool(),
-            actions: {},
-            message: {
-                Text(isPresentingErrorMessage ?? "")
-            }
-        )
+        .alertSheet($isPresentingAlertMessage)
         .confirmationDialog(
             Localized.Common.deleteConfirmation(walletDelete?.name ?? ""),
             presenting: $walletDelete,
@@ -213,7 +207,7 @@ extension WalletsScene {
             do {
                 try model.delete(wallet)
             } catch {
-                isPresentingErrorMessage = error.localizedDescription
+                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
             }
         }
     }

--- a/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
@@ -10,7 +10,7 @@ struct VerifyPhraseWalletScene: View {
     
     @StateObject var model: VerifyPhraseViewModel
 
-    @State private var isPresentingErrorMessage: String?
+    @State private var isPresentingAlertMessage: AlertMessage?
 
     init(model: VerifyPhraseViewModel) {
         _model = StateObject(wrappedValue: model)
@@ -71,9 +71,7 @@ struct VerifyPhraseWalletScene: View {
         .padding(.bottom, .scene.bottom)
         .background(Colors.grayBackground)
         .navigationTitle(model.title)
-        .alert(item: $isPresentingErrorMessage) {
-            Alert(title: Text(Localized.Errors.createWallet("")), message: Text($0))
-        }
+        .alertSheet($isPresentingAlertMessage)
     }
 
 }
@@ -92,7 +90,10 @@ extension VerifyPhraseWalletScene {
                 }
             } catch {
                 await MainActor.run {
-                    isPresentingErrorMessage = error.localizedDescription
+                    isPresentingAlertMessage = AlertMessage(
+                        title: Localized.Errors.createWallet(""),
+                        message: error.localizedDescription
+                    )
                     model.buttonState = .normal
                 }
             }

--- a/Features/Settings/Sources/Scenes/SecurityScene.swift
+++ b/Features/Settings/Sources/Scenes/SecurityScene.swift
@@ -38,11 +38,7 @@ public struct SecurityScene: View {
         .contentMargins(.top, .scene.top, for: .scrollContent)
         .onChange(of: model.isEnabled, onToggleBiometrics)
         .onChange(of: model.isPrivacyLockEnabled, onToggleSecurityLock)
-        .alert("",
-            isPresented: $model.isPresentingError.mappedToBool(),
-            actions: {},
-            message: { Text(model.errorTitle) }
-        )
+        .alertSheet($model.isPresentingAlertMessage)
         .navigationTitle(model.title)
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Features/Settings/Sources/ViewModels/SecurityViewModel.swift
+++ b/Features/Settings/Sources/ViewModels/SecurityViewModel.swift
@@ -15,7 +15,7 @@ public final class SecurityViewModel {
 
     static let reason: String = Localized.Settings.Security.authentication
 
-    var isPresentingError: String?
+    var isPresentingAlertMessage: AlertMessage?
     var isEnabled: Bool
     var isPrivacyLockEnabled: Bool
     var isHideBalanceEnabled: Bool {
@@ -72,7 +72,7 @@ extension SecurityViewModel {
             lockPeriod = service.lockPeriod 
         } catch let error as BiometryAuthenticationError {
             if !error.isAuthenticationCancelled {
-                isPresentingError = error.localizedDescription
+                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
             }
             isEnabled.toggle()
         } catch {

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionsScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionsScene.swift
@@ -11,7 +11,7 @@ import PrimitivesComponents
 
 public struct ConnectionsScene: View {
     @State private var isPresentingScanner: Bool = false
-    @State private var isPresentingErrorMessage: String?
+    @State private var isPresentingAlertMessage: AlertMessage?
 
     @State private var model: ConnectionsViewModel
 
@@ -71,13 +71,7 @@ public struct ConnectionsScene: View {
             ScanQRCodeNavigationStack(action: onHandleScan(_:))
         }
         .toolbarInfoButton(url: model.docsUrl)
-        .alert("",
-               isPresented: $isPresentingErrorMessage.mappedToBool(),
-               actions: {},
-               message: {
-            Text(isPresentingErrorMessage ?? "")
-        }
-        )
+        .alertSheet($isPresentingAlertMessage)
         .navigationTitle(model.title)
         .taskOnce { model.updateSessions() }
     }
@@ -86,7 +80,7 @@ public struct ConnectionsScene: View {
         do {
             try await model.pair(uri: uri)
         } catch {
-            isPresentingErrorMessage = error.localizedDescription
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
             NSLog("connectURI error: \(error)")
         }
     }
@@ -101,7 +95,7 @@ private extension ConnectionsScene {
             do {
                 try await model.disconnect(connection: connection)
             } catch {
-                isPresentingErrorMessage = error.localizedDescription
+                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
                 NSLog("disconnect error: \(error)")
             }
         }


### PR DESCRIPTION
- Update 8 files to use AlertMessage struct instead of String? for error states
- Replace complex .alert() calls with simple .alertSheet() calls
- Maintain consistent error handling across the app
- Preserve existing functionality while improving code consistency

Files updated:
- AddNodeScene & AddNodeSceneViewModel
- WalletDetailScene & WalletsScene
- SecurityScene & SecurityViewModel
- VerifyPhraseWalletScene
- ConnectionsScene

🤖 Generated with [Claude Code](https://claude.ai/code)