### PR TITLE
Migrate WalletsScene state management to ViewModel

### DIFF
--- a/Features/ManageWallets/Sources/ViewModels/WalletIDetailViewModel.swift
+++ b/Features/ManageWallets/Sources/ViewModels/WalletIDetailViewModel.swift
@@ -14,7 +14,7 @@ import Onboarding
 @MainActor
 public final class WalletDetailViewModel {
 
-    @Binding var navigationPath: NavigationPath
+    private let navigationPath: Binding<NavigationPath>
     let wallet: Wallet
     let walletService: WalletService
     let explorerService: any ExplorerLinkFetchable
@@ -30,7 +30,7 @@ public final class WalletDetailViewModel {
         walletService: WalletService,
         explorerService: any ExplorerLinkFetchable = ExplorerService.standard
     ) {
-        _navigationPath = navigationPath
+        self.navigationPath = navigationPath
         self.wallet = wallet
         self.walletService = walletService
         self.explorerService = explorerService
@@ -105,7 +105,7 @@ extension WalletDetailViewModel {
     }
 
     func onSelectImage() {
-        navigationPath.append(Scenes.WalletSelectImage(wallet: wallet))
+        navigationPath.wrappedValue.append(Scenes.WalletSelectImage(wallet: wallet))
     }
 }
 

--- a/Features/ManageWallets/Sources/ViewModels/WalletsSceneViewModel.swift
+++ b/Features/ManageWallets/Sources/ViewModels/WalletsSceneViewModel.swift
@@ -9,7 +9,7 @@ import Components
 @Observable
 @MainActor
 public final class WalletsSceneViewModel {
-    @Binding var navigationPath: NavigationPath
+    private let navigationPath: Binding<NavigationPath>
     let service: WalletService
     let currentWalletId: WalletId?
     
@@ -20,7 +20,7 @@ public final class WalletsSceneViewModel {
         navigationPath: Binding<NavigationPath>,
         walletService: WalletService
     ) {
-        _navigationPath = navigationPath
+        self.navigationPath = navigationPath
         self.service = walletService
         self.currentWalletId = service.currentWalletId
         self.isPresentingAlertMessage = nil
@@ -40,7 +40,7 @@ extension WalletsSceneViewModel {
     }
 
     func onEdit(wallet: Wallet) {
-        navigationPath.append(Scenes.WalletDetail(wallet: wallet))
+        navigationPath.wrappedValue.append(Scenes.WalletDetail(wallet: wallet))
     }
 
     func delete(_ wallet: Wallet) throws {

--- a/Features/ManageWallets/Sources/ViewModels/WalletsSceneViewModel.swift
+++ b/Features/ManageWallets/Sources/ViewModels/WalletsSceneViewModel.swift
@@ -4,11 +4,17 @@ import SwiftUI
 import Localization
 import Preferences
 import WalletService
+import Components
 
-public class WalletsSceneViewModel {
+@Observable
+@MainActor
+public final class WalletsSceneViewModel {
     @Binding var navigationPath: NavigationPath
     let service: WalletService
     let currentWalletId: WalletId?
+    
+    var isPresentingAlertMessage: AlertMessage?
+    var walletDelete: Wallet?
     
     public init(
         navigationPath: Binding<NavigationPath>,
@@ -17,6 +23,8 @@ public class WalletsSceneViewModel {
         _navigationPath = navigationPath
         self.service = walletService
         self.currentWalletId = service.currentWalletId
+        self.isPresentingAlertMessage = nil
+        self.walletDelete = nil
     }
     
     var title: String {
@@ -49,5 +57,29 @@ extension WalletsSceneViewModel {
 
     func swapOrder(from: WalletId, to: WalletId) throws {
         try service.swapOrder(from: from, to: to)
+    }
+}
+
+// MARK: - Actions
+
+extension WalletsSceneViewModel {
+    func onDelete(wallet: Wallet) {
+        walletDelete = wallet
+    }
+    
+    func onPin(wallet: Wallet) {
+        do {
+            try pin(wallet)
+        } catch {
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
+        }
+    }
+    
+    func onDeleteConfirmed(wallet: Wallet) {
+        do {
+            try delete(wallet)
+        } catch {
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
+        }
     }
 }

--- a/Features/Settings/Sources/ViewModels/SecurityViewModel.swift
+++ b/Features/Settings/Sources/ViewModels/SecurityViewModel.swift
@@ -76,7 +76,7 @@ extension SecurityViewModel {
             }
             isEnabled.toggle()
         } catch {
-            isPresentingError = error.localizedDescription
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
             isEnabled.toggle()
         }
     }
@@ -86,7 +86,7 @@ extension SecurityViewModel {
         do {
             try service.togglePrivacyLock(enbaled: isPrivacyLockEnabled)
         } catch {
-            isPresentingError = error.localizedDescription
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
             isPrivacyLockEnabled.toggle()
         }
     }
@@ -95,7 +95,7 @@ extension SecurityViewModel {
         do {
             try service.update(period: lockPeriod)
         } catch {
-            isPresentingError = error.localizedDescription
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
             lockPeriod = service.lockPeriod
         }
     }


### PR DESCRIPTION
## Summary
Part of #916

- Refactor WalletsScene to move @State values to WalletsSceneViewModel
- Add @Observable and @MainActor annotations to make ViewModel observable
- Move UI state properties (isPresentingAlertMessage, walletDelete) to ViewModel
- Remove unused showingDeleteAlert @State variable
- Move action methods to ViewModel following ImportWalletScene pattern
- Update Scene to use @State private var model pattern with bindings

## Changes Made
- **WalletsSceneViewModel**: 
  - Added @Observable and @MainActor annotations
  - Added state properties: isPresentingAlertMessage, walletDelete
  - Added action methods: onDelete, onPin, onDeleteConfirmed
- **WalletsScene**:
  - Changed from `var model` to `@State private var model` pattern
  - Removed @State variables: isPresentingAlertMessage, walletDelete, showingDeleteAlert
  - Updated UI to use model bindings ($model.property)
  - Updated error handling to use ViewModel's alert system
  - Maintained @Query and @Binding usage for appropriate concerns

## Test plan
- [x] Verify wallet selection and dismiss functionality
- [x] Verify wallet editing navigation
- [x] Verify wallet pinning/unpinning
- [x] Verify wallet deletion with confirmation dialog
- [x] Verify wallet reordering (move operations)
- [x] Verify error handling with alert presentation
- [x] Verify create/import wallet sheet presentation

🤖 Generated with [Claude Code](https://claude.ai/code)