### PR TITLE
Migrate VerifyPhraseWalletScene state management to ViewModel

### DIFF
--- a/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
@@ -8,12 +8,10 @@ import PrimitivesComponents
 
 struct VerifyPhraseWalletScene: View {
     
-    @StateObject var model: VerifyPhraseViewModel
-
-    @State private var isPresentingAlertMessage: AlertMessage?
+    @State private var model: VerifyPhraseViewModel
 
     init(model: VerifyPhraseViewModel) {
-        _model = StateObject(wrappedValue: model)
+        _model = State(initialValue: model)
     }
 
     var body: some View {
@@ -64,39 +62,15 @@ struct VerifyPhraseWalletScene: View {
             StateButton(
                 text: Localized.Common.continue,
                 type: .primary(model.buttonState),
-                action: onImportWallet
+                action: model.onImportWallet
             )
             .frame(maxWidth: .scene.button.maxWidth)
         }
         .padding(.bottom, .scene.bottom)
         .background(Colors.grayBackground)
         .navigationTitle(model.title)
-        .alertSheet($isPresentingAlertMessage)
+        .alertSheet($model.isPresentingAlertMessage)
     }
 
 }
 
-// MARK: - Actions
-
-extension VerifyPhraseWalletScene {
-    func onImportWallet() {
-        model.buttonState = .loading(showProgress: true)
-
-        Task {
-            try await Task.sleep(for: .milliseconds(50))
-            do {
-                try await MainActor.run {
-                    try model.importWallet()
-                }
-            } catch {
-                await MainActor.run {
-                    isPresentingAlertMessage = AlertMessage(
-                        title: Localized.Errors.createWallet(""),
-                        message: error.localizedDescription
-                    )
-                    model.buttonState = .normal
-                }
-            }
-        }
-    }
-}


### PR DESCRIPTION
## Summary
Part of #916

- Refactor VerifyPhraseWalletScene to move @State values to VerifyPhraseViewModel
- Migrate from ObservableObject to @Observable and @MainActor annotations
- Move UI state properties (isPresentingAlertMessage) to ViewModel
- Move action methods to ViewModel following ImportWalletScene pattern
- Update Scene to use @State private var model pattern instead of @StateObject

## Changes Made
- **VerifyPhraseViewModel**: 
  - Migrated from `ObservableObject` to `@Observable` and `@MainActor` annotations
  - Removed `@Published` wrappers from properties
  - Added `isPresentingAlertMessage: AlertMessage?` property
  - Added `onImportWallet()` action method with error handling
- **VerifyPhraseWalletScene**:
  - Changed from `@StateObject var model` to `@State private var model` pattern
  - Removed `@State private var isPresentingAlertMessage: AlertMessage?`
  - Updated UI to use model bindings ($model.isPresentingAlertMessage)
  - Updated button action to call model.onImportWallet directly
  - Removed redundant Actions extension

## Test plan
- [x] Verify phrase verification flow works correctly
- [x] Verify word selection and highlighting
- [x] Verify continue button state changes
- [x] Verify wallet import functionality
- [x] Verify error handling with alert presentation
- [x] Verify button loading states

🤖 Generated with [Claude Code](https://claude.ai/code)