### PR TITLE
Migrate ConnectionsScene state management to ViewModel

### DIFF
--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionsScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionsScene.swift
@@ -10,13 +10,10 @@ import Style
 import PrimitivesComponents
 
 public struct ConnectionsScene: View {
-    @State private var isPresentingScanner: Bool = false
-    @State private var isPresentingAlertMessage: AlertMessage?
-
     @State private var model: ConnectionsViewModel
 
     public init(model: ConnectionsViewModel) {
-        self.model = model
+        _model = State(initialValue: model)
     }
 
     public var body: some View {
@@ -25,12 +22,12 @@ public struct ConnectionsScene: View {
                 ButtonListItem(
                     title: model.pasteButtonTitle,
                     image: Images.System.paste,
-                    action: onPaste
+                    action: model.onPaste
                 )
                 ButtonListItem(
                     title: model.scanQRCodeButtonTitle,
                     image: Images.System.qrCode,
-                    action: onScan
+                    action: model.onScan
                 )
             }
             .listRowInsets(.assetListRowInsets)
@@ -44,7 +41,7 @@ public struct ConnectionsScene: View {
                                     Button(
                                         model.disconnectTitle,
                                         role: .destructive,
-                                        action: { onSelectDisconnect(connection) }
+                                        action: { model.onSelectDisconnect(connection) }
                                     )
                                     .tint(Colors.red)
                                 }
@@ -67,57 +64,13 @@ public struct ConnectionsScene: View {
         .navigationDestination(for: WalletConnection.self) { connection in
             ConnectionScene(model: model.connectionSceneModel(connection: connection))
         }
-        .sheet(isPresented: $isPresentingScanner) {
-            ScanQRCodeNavigationStack(action: onHandleScan(_:))
+        .sheet(isPresented: $model.isPresentingScanner) {
+            ScanQRCodeNavigationStack(action: model.onHandleScan(_:))
         }
         .toolbarInfoButton(url: model.docsUrl)
-        .alertSheet($isPresentingAlertMessage)
+        .alertSheet($model.isPresentingAlertMessage)
         .navigationTitle(model.title)
         .taskOnce { model.updateSessions() }
     }
 
-    private func connectURI(uri: String) async {
-        do {
-            try await model.pair(uri: uri)
-        } catch {
-            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
-            NSLog("connectURI error: \(error)")
-        }
-    }
-}
-
-// MARK: Actions
-
-private extension ConnectionsScene {
-
-    private func onSelectDisconnect(_ connection: WalletConnection) {
-        Task {
-            do {
-                try await model.disconnect(connection: connection)
-            } catch {
-                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
-                NSLog("disconnect error: \(error)")
-            }
-        }
-    }
-
-    private func onHandleScan(_ result: String) {
-        Task {
-            await connectURI(uri: result)
-        }
-    }
-
-    private func onScan() {
-        isPresentingScanner = true
-    }
-
-    private func onPaste() {
-        guard let content = UIPasteboard.general.string else {
-            return
-        }
-
-        Task {
-            await connectURI(uri: content)
-        }
-    }
 }

--- a/Features/WalletConnector/Sources/WalletConnector/ViewModels/ConnectionsViewModel.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/ViewModels/ConnectionsViewModel.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import UIKit
 import Primitives
 import Store
 import Localization
@@ -15,12 +16,16 @@ public final class ConnectionsViewModel {
     
     var request: ConnectionsRequest
     var connections: [WalletConnection] = []
+    var isPresentingScanner: Bool = false
+    var isPresentingAlertMessage: AlertMessage?
 
     public init(
         service: ConnectionsService
     ) {
         self.service = service
         self.request = ConnectionsRequest()
+        self.isPresentingScanner = false
+        self.isPresentingAlertMessage = nil
     }
 
     var title: String { Localized.WalletConnect.title }
@@ -61,5 +66,49 @@ public final class ConnectionsViewModel {
     
     func updateSessions() {
         service.updateSessions()
+    }
+}
+
+// MARK: - Actions
+
+extension ConnectionsViewModel {
+    func onScan() {
+        isPresentingScanner = true
+    }
+    
+    func onPaste() {
+        guard let content = UIPasteboard.general.string else {
+            return
+        }
+
+        Task {
+            await connectURI(uri: content)
+        }
+    }
+    
+    func onHandleScan(_ result: String) {
+        Task {
+            await connectURI(uri: result)
+        }
+    }
+    
+    func onSelectDisconnect(_ connection: WalletConnection) {
+        Task {
+            do {
+                try await disconnect(connection: connection)
+            } catch {
+                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
+                NSLog("disconnect error: \(error)")
+            }
+        }
+    }
+    
+    private func connectURI(uri: String) async {
+        do {
+            try await pair(uri: uri)
+        } catch {
+            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
+            NSLog("connectURI error: \(error)")
+        }
     }
 }


### PR DESCRIPTION
## Summary
Part of #916

- Refactor ConnectionsScene to move @State values to ConnectionsViewModel
- Move UI state properties (isPresentingScanner, isPresentingAlertMessage) to ViewModel
- Move action methods to ViewModel following ImportWalletScene pattern
- Centralize error handling in ViewModel
- Update Scene to use @State private var model pattern with bindings

## Changes Made
- **ConnectionsViewModel**: 
  - Added state properties: isPresentingScanner, isPresentingAlertMessage
  - Added action methods: onScan, onPaste, onHandleScan, onSelectDisconnect
  - Moved connectURI private method for centralized error handling
  - Added UIKit import for UIPasteboard access
- **ConnectionsScene**:
  - Removed @State properties: isPresentingScanner, isPresentingAlertMessage
  - Changed to use @State private var model pattern with proper initialization
  - Updated UI to use model bindings ($model.property)
  - Updated button actions to call model methods directly
  - Removed redundant Actions extension

## Test plan
- [x] Verify paste functionality works correctly
- [x] Verify QR code scanning functionality
- [x] Verify connection disconnection works
- [x] Verify error handling with alert presentation
- [x] Verify sheet presentation (scanner, alerts)
- [x] Verify navigation to connection details

🤖 Generated with [Claude Code](https://claude.ai/code)