### PR TITLE
Refactor SelectAssetScene state management to ViewModel

### DIFF
--- a/Features/Assets/Sources/Scenes/SelectAssetScene.swift
+++ b/Features/Assets/Sources/Scenes/SelectAssetScene.swift
@@ -7,16 +7,12 @@ import PrimitivesComponents
 
 public struct SelectAssetScene: View {
 
-    @Binding private var isPresentingAddToken: Bool
-
     @State private var model: SelectAssetViewModel
 
     public init(
-        model: SelectAssetViewModel,
-        isPresentingAddToken: Binding<Bool>
+        model: SelectAssetViewModel
     ) {
         _model = State(wrappedValue: model)
-        _isPresentingAddToken = isPresentingAddToken
     }
 
     public var body: some View {
@@ -45,7 +41,7 @@ public struct SelectAssetScene: View {
                     model: EmptyContentTypeViewModel(
                         type: .search(
                             type: .assets,
-                            action: model.showAddToken ? { onSelectAddCustomToken() } : nil
+                            action: model.showAddToken ? { model.onSelectAddCustomToken() } : nil
                         )
                     )
                 )
@@ -144,10 +140,3 @@ public struct SelectAssetScene: View {
     }
 }
 
-// MARK: - Actions
-
-extension SelectAssetScene {
-    private func onSelectAddCustomToken() {
-        isPresentingAddToken.toggle()
-    }
-}

--- a/Features/Assets/Sources/Scenes/SelectAssetScene.swift
+++ b/Features/Assets/Sources/Scenes/SelectAssetScene.swift
@@ -7,9 +7,6 @@ import PrimitivesComponents
 
 public struct SelectAssetScene: View {
 
-    @State private var isPresentingCopyToast: Bool = false
-    @State private var copyTypeViewModel: CopyTypeViewModel?
-
     @Binding private var isPresentingAddToken: Bool
 
     @State private var model: SelectAssetViewModel
@@ -58,10 +55,10 @@ public struct SelectAssetScene: View {
         .onChange(of: model.filterModel, model.onChangeFilterModel)
         .onChange(of: model.searchModel.searchableQuery, model.updateRequest)
         .onChange(of: model.isSearching, model.onChangeFocus)
-        .ifLet(copyTypeViewModel) {
+        .ifLet(model.copyTypeViewModel) {
             $0.copyToast(
                 model: $1,
-                isPresenting: $isPresentingCopyToast
+                isPresenting: $model.isPresentingCopyToast
             )
         }
         .listSectionSpacing(.compact)
@@ -121,7 +118,7 @@ public struct SelectAssetScene: View {
                         assetData: assetData,
                         currencyCode: model.currencyCode,
                         type: model.selectType.listType,
-                        action: onAsset
+                        action: model.onAssetAction
                     )
                 }
             case .manage:
@@ -129,7 +126,7 @@ public struct SelectAssetScene: View {
                     assetData: assetData,
                     currencyCode: model.currencyCode,
                     type: model.selectType.listType,
-                    action: onAsset
+                    action: model.onAssetAction
                 )
             case .swap, .priceAlert:
                 NavigationCustomLink(
@@ -137,7 +134,7 @@ public struct SelectAssetScene: View {
                         assetData: assetData,
                         currencyCode: model.currencyCode,
                         type: model.selectType.listType,
-                        action: onAsset
+                        action: model.onAssetAction
                     )
                 ) {
                     model.selectAsset(asset: assetData.asset)
@@ -152,25 +149,5 @@ public struct SelectAssetScene: View {
 extension SelectAssetScene {
     private func onSelectAddCustomToken() {
         isPresentingAddToken.toggle()
-    }
-
-    private func onAsset(action: ListAssetItemAction, assetData: AssetData) {
-        let asset = assetData.asset
-        switch action {
-        case .switcher(let enabled):
-            Task {
-                await model.handleAction(assetId: asset.id, enabled: enabled)
-            }
-        case .copy:
-            let address = assetData.account.address
-            copyTypeViewModel = CopyTypeViewModel(
-                type: .address(asset, address: address),
-                copyValue: address
-            )
-            isPresentingCopyToast = true
-            Task {
-                await model.handleAction(assetId: asset.id, enabled: true)
-            }
-        }
     }
 }

--- a/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
@@ -32,6 +32,7 @@ public final class SelectAssetViewModel {
 
     var isPresentingCopyToast: Bool = false
     var copyTypeViewModel: CopyTypeViewModel?
+    public var isPresentingAddToken: Bool = false
 
     public var filterModel: AssetsFilterViewModel
     public var onSelectAssetAction: AssetAction
@@ -220,6 +221,10 @@ extension SelectAssetViewModel {
                 await handleAction(assetId: asset.id, enabled: true)
             }
         }
+    }
+    
+    func onSelectAddCustomToken() {
+        isPresentingAddToken.toggle()
     }
 }
 

--- a/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
@@ -30,6 +30,9 @@ public final class SelectAssetViewModel {
     var isSearching: Bool = false
     var isDismissSearch: Bool = false
 
+    var isPresentingCopyToast: Bool = false
+    var copyTypeViewModel: CopyTypeViewModel?
+
     public var filterModel: AssetsFilterViewModel
     public var onSelectAssetAction: AssetAction
 
@@ -193,6 +196,30 @@ extension SelectAssetViewModel {
 
     func onChangeFilterModel(_: AssetsFilterViewModel, model: AssetsFilterViewModel) {
         request.filters = model.filters
+    }
+}
+
+// MARK: - Actions
+
+extension SelectAssetViewModel {
+    func onAssetAction(action: ListAssetItemAction, assetData: AssetData) {
+        let asset = assetData.asset
+        switch action {
+        case .switcher(let enabled):
+            Task {
+                await handleAction(assetId: asset.id, enabled: enabled)
+            }
+        case .copy:
+            let address = assetData.account.address
+            copyTypeViewModel = CopyTypeViewModel(
+                type: .address(asset, address: address),
+                copyValue: address
+            )
+            isPresentingCopyToast = true
+            Task {
+                await handleAction(assetId: asset.id, enabled: true)
+            }
+        }
     }
 }
 

--- a/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
@@ -21,7 +21,6 @@ struct SelectAssetSceneNavigationStack: View {
     @Environment(\.stakeService) private var stakeService
     @Environment(\.scanService) private var scanService
 
-    @State private var isPresentingAddToken: Bool = false
     @State private var isPresentingFilteringView: Bool = false
 
     @State private var model: SelectAssetViewModel
@@ -39,8 +38,7 @@ struct SelectAssetSceneNavigationStack: View {
     var body: some View {
         NavigationStack(path: $navigationPath) {
             SelectAssetScene(
-                model: model,
-                isPresentingAddToken: $isPresentingAddToken
+                model: model
             )
             .toolbar {
                 ToolbarDismissItem(
@@ -58,7 +56,7 @@ struct SelectAssetSceneNavigationStack: View {
                 if model.showAddToken {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button {
-                            isPresentingAddToken = true
+                            model.isPresentingAddToken = true
                         } label: {
                             Images.System.plus
                         }
@@ -113,10 +111,10 @@ struct SelectAssetSceneNavigationStack: View {
             }
             .navigationBarTitleDisplayMode(.inline)
         }
-        .sheet(isPresented: $isPresentingAddToken) {
+        .sheet(isPresented: $model.isPresentingAddToken) {
             AddTokenNavigationStack(
                 wallet: model.wallet,
-                isPresenting: $isPresentingAddToken
+                isPresenting: $model.isPresentingAddToken
             )
         }
         .sheet(isPresented: $isPresentingFilteringView) {

--- a/Gem/Navigation/Price Alerts/AddAssetPriceAlertNavigationStack.swift
+++ b/Gem/Navigation/Price Alerts/AddAssetPriceAlertNavigationStack.swift
@@ -19,8 +19,7 @@ struct AddAssetPriceAlertsNavigationStack: View {
     var body: some View {
         NavigationStack {
             SelectAssetScene(
-                model: selectAssetModel,
-                isPresentingAddToken: .constant(false)
+                model: selectAssetModel
             )
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {


### PR DESCRIPTION
## Summary
- Moved @State isPresentingCopyToast and copyTypeViewModel properties to SelectAssetViewModel
- Added onAssetAction method to ViewModel to handle asset list item actions
- Updated SelectAssetScene to use ViewModel properties instead of @State
- Followed @Observable @MainActor pattern for state management
- Maintained existing functionality while centralizing state in ViewModel

## Test plan
- [x] Tests pass successfully
- [x] SelectAssetScene compiles and functions correctly
- [x] Copy functionality works as expected
- [x] All asset selection types (buy, receive, send, manage, swap, priceAlert) work correctly

Linked to #916

🤖 Generated with [Claude Code](https://claude.ai/code)