### PR TITLE
Add unit tests for ConfirmTransferViewModel

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,9 @@
       "Bash(rm:*)",
       "Bash(mv:*)",
       "Bash(git pull:*)",
-      "Bash(git restore:*)"
+      "Bash(git restore:*)",
+      "Bash(just spm-resolve-all:*)",
+      "Bash(gh pr checks:*)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,19 @@ public extension Banner {
 - Prefer async/await over Combine for new code
 - Use protocol-based design for services
 - Avoid adding explanatory comments in tests - test code should be self-documenting
+- When extending types to conform to protocols, use explicit protocol conformance syntax:
+  ```swift
+  // Good - explicit protocol conformance
+  extension MyService: ServiceProtocol {
+      func performAction() { }
+  }
+  
+  // Bad - plain extension with comment
+  // MARK: - ServiceProtocol
+  extension MyService {
+      func performAction() { }
+  }
+  ```
 
 ### Code Organization
 - **One Type Per File**: Each service, type, view model, actor, or component must have its own separate file in the appropriate folder. Never inline multiple types in a single file

--- a/Features/ChainSettings/Package.resolved
+++ b/Features/ChainSettings/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "31344a3be76371c34b0a2244be96de92b84480459418cf7165c14ea45959274c",
+  "originHash" : "63f7601134aa1fa2a9ff1cab85fb9d6c1b8bdd35fc3008fb2313dd78f95fd9e2",
   "pins" : [
     {
       "identity" : "bigint",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "540dc48e86af2972b4f1815616aa1ed8ac97845a",
         "version" : "0.11.0"
-      }
-    },
-    {
-      "identity" : "keychainaccess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gemwalletcom/KeychainAccess",
-      "state" : {
-        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
-        "version" : "4.2.2"
       }
     }
   ],

--- a/Features/Currency/Package.resolved
+++ b/Features/Currency/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7d76be76ff78183627a627ccf26b7d5cc4bab208fcc7b785721da9f3db6872ac",
+  "originHash" : "fec69e19a89a1e6b272181c306c9a21e81dbca30689a48ec83baff95189b2f12",
   "pins" : [
     {
       "identity" : "bigint",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "540dc48e86af2972b4f1815616aa1ed8ac97845a",
         "version" : "0.11.0"
-      }
-    },
-    {
-      "identity" : "keychainaccess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gemwalletcom/KeychainAccess",
-      "state" : {
-        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
-        "version" : "4.2.2"
       }
     }
   ],

--- a/Features/ManageWallets/Package.resolved
+++ b/Features/ManageWallets/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d72955c49d1cc463fc43db9cb74a827fa06abfa9fe0ffd198c5ad1702d76b074",
+  "originHash" : "047043923aeb3f5e92e47ebaebdf27194c2d3cbbf7cd581f31c1f6830b6ff8f0",
   "pins" : [
     {
       "identity" : "bigint",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "540dc48e86af2972b4f1815616aa1ed8ac97845a",
         "version" : "0.11.0"
-      }
-    },
-    {
-      "identity" : "keychainaccess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gemwalletcom/KeychainAccess",
-      "state" : {
-        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
-        "version" : "4.2.2"
       }
     }
   ],

--- a/Features/MarketInsight/Package.resolved
+++ b/Features/MarketInsight/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "07ac7868c434e05547051ef71de00075c3f4add7d4dac4925a8fd43fb51f3258",
+  "originHash" : "2ec07cb9fb4dbaf7ad65ac1c5efff4235604faff9dd3aeb3f762df2767fd2e18",
   "pins" : [
     {
       "identity" : "bigint",
@@ -26,15 +26,6 @@
       "state" : {
         "revision" : "540dc48e86af2972b4f1815616aa1ed8ac97845a",
         "version" : "0.11.0"
-      }
-    },
-    {
-      "identity" : "keychainaccess",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gemwalletcom/KeychainAccess",
-      "state" : {
-        "revision" : "84e546727d66f1adc5439debad16270d0fdd04e7",
-        "version" : "4.2.2"
       }
     }
   ],

--- a/Features/Transfer/Package.swift
+++ b/Features/Transfer/Package.swift
@@ -93,6 +93,10 @@ let package = Package(
                 .product(name: "StakeServiceTestKit", package: "StakeService"),
                 .product(name: "WalletsServiceTestKit", package: "WalletsService"),
                 .product(name: "StoreTestKit", package: "Store"),
+                .product(name: "BlockchainTestKit", package: "Blockchain"),
+                .product(name: "ScanServiceTestKit", package: "ScanService"),
+                .product(name: "SwapServiceTestKit", package: "SwapService"),
+                .product(name: "KeystoreTestKit", package: "Keystore"),
             ],
             path: "Tests"
         ),

--- a/Features/Transfer/Tests/ViewModels/ConfirmTransferViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmTransferViewModelTests.swift
@@ -8,6 +8,7 @@ import WalletsService
 import WalletsServiceTestKit
 import BlockchainTestKit
 import ScanService
+import ScanServiceTestKit
 import SwapService
 import SwapServiceTestKit
 import KeystoreTestKit
@@ -55,24 +56,11 @@ private extension ConfirmTransferViewModel {
             data: data,
             keystore: KeystoreMock(),
             chainService: ChainServiceMock(),
-            scanService: ScanService(apiService: GemAPIScanServiceMock(), securePreferences: SecurePreferences.mock()),
+            scanService: .mock(),
             swapService: .mock(),
             walletsService: .mock(),
-            swapDataProvider: SwapQuoteDataProviderMock(),
+            swapDataProvider: .mock(),
             onComplete: {}
         )
     }
 }
-
-private struct SwapQuoteDataProviderMock: SwapQuoteDataProvidable {
-    func fetchQuoteData(wallet: Wallet, quote: SwapQuote) async throws -> SwapQuoteData {
-        .mock()
-    }
-}
-
-private struct GemAPIScanServiceMock: GemAPIScanService {
-    func getScanTransaction(payload: ScanTransactionPayload) async throws -> ScanTransaction {
-        ScanTransaction(isMalicious: false, isMemoRequired: false)
-    }
-}
-

--- a/Features/Transfer/Tests/ViewModels/ConfirmTransferViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmTransferViewModelTests.swift
@@ -1,0 +1,78 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+@testable import Transfer
+import Primitives
+import PrimitivesTestKit
+import WalletsService
+import WalletsServiceTestKit
+import BlockchainTestKit
+import ScanService
+import SwapService
+import SwapServiceTestKit
+import KeystoreTestKit
+import Localization
+import Gemstone
+import Preferences
+import PreferencesTestKit
+import GemAPI
+
+@MainActor
+struct ConfirmTransferViewModelTests {
+    
+    @Test
+    func appText() async {
+        let model = ConfirmTransferViewModel.mock()
+        #expect(model.appText == Localized.Errors.unknown)
+        
+        let modelWithWebsite = ConfirmTransferViewModel.mock(
+            data: .mock(type: .generic(asset: .mock(), metadata: .mock(name: "Gem Wallet", url: "https://example.com"), extra: .mock()))
+        )
+        #expect(modelWithWebsite.appText == "Gem Wallet (example.com)")
+    }
+    
+    @Test
+    func title() async {
+        #expect(ConfirmTransferViewModel.mock(data: .mock(type: .transfer(.mock()))).title == Localized.Transfer.Send.title)
+        #expect(ConfirmTransferViewModel.mock(data: .mock(type: .transferNft(.mock()))).title == Localized.Transfer.Send.title)
+        #expect(ConfirmTransferViewModel.mock(data: .mock(type: .swap(.mock(), .mock(), .mock(), nil))).title == Localized.Wallet.swap)
+        #expect(ConfirmTransferViewModel.mock(data: .mock(type: .tokenApprove(.mock(), .mock()))).title == Localized.Wallet.swap)
+    }
+    
+    @Test
+    func senderTitle() async {
+        #expect(ConfirmTransferViewModel.mock().senderTitle == Localized.Wallet.title)
+    }
+}
+
+private extension ConfirmTransferViewModel {
+    static func mock(
+        wallet: Wallet = .mock(),
+        data: TransferData = .mock()
+    ) -> ConfirmTransferViewModel {
+        ConfirmTransferViewModel(
+            wallet: wallet,
+            data: data,
+            keystore: KeystoreMock(),
+            chainService: ChainServiceMock(),
+            scanService: ScanService(apiService: GemAPIScanServiceMock(), securePreferences: SecurePreferences.mock()),
+            swapService: .mock(),
+            walletsService: .mock(),
+            swapDataProvider: SwapQuoteDataProviderMock(),
+            onComplete: {}
+        )
+    }
+}
+
+private struct SwapQuoteDataProviderMock: SwapQuoteDataProvidable {
+    func fetchQuoteData(wallet: Wallet, quote: SwapQuote) async throws -> SwapQuoteData {
+        .mock()
+    }
+}
+
+private struct GemAPIScanServiceMock: GemAPIScanService {
+    func getScanTransaction(payload: ScanTransactionPayload) async throws -> ScanTransaction {
+        ScanTransaction(isMalicious: false, isMemoRequired: false)
+    }
+}
+

--- a/Packages/Blockchain/Package.swift
+++ b/Packages/Blockchain/Package.swift
@@ -9,6 +9,9 @@ let package = Package(
         .library(
             name: "Blockchain",
             targets: ["Blockchain"]),
+        .library(
+            name: "BlockchainTestKit",
+            targets: ["BlockchainTestKit"]),
     ],
     dependencies: [
         .package(name: "Primitives", path: "../Primitives"),
@@ -34,10 +37,20 @@ let package = Package(
             ],
             path: "Sources"
         ),
+        .target(
+            name: "BlockchainTestKit",
+            dependencies: [
+                "Blockchain",
+                "Primitives",
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
+            ],
+            path: "TestKit"
+        ),
         .testTarget(
             name: "BlockchainTests",
             dependencies: [
                 "Blockchain",
+                "BlockchainTestKit",
                 .product(name: "PrimitivesTestKit", package: "Primitives"),
             ],
             resources: [.process("Resources")]

--- a/Packages/Blockchain/TestKit/ChainServiceMock.swift
+++ b/Packages/Blockchain/TestKit/ChainServiceMock.swift
@@ -1,0 +1,104 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Blockchain
+import Primitives
+import BigInt
+
+public struct ChainServiceMock: ChainServiceable {
+    
+    // Injected data
+    public var addressStatuses: [AddressStatus] = []
+    public var coinBalances: [String: AssetBalance] = [:]
+    public var tokenBalances: [String: [AssetBalance]] = [:]
+    public var stakeBalance: AssetBalance?
+    public var broadcastResponse: String = ""
+    public var fee: Fee = Fee(fee: .zero, gasPriceType: .regular(gasPrice: .zero), gasLimit: .zero)
+    public var feeRates: [FeeRate] = []
+    public var chainID: String?
+    public var latestBlock: BigInt = .zero
+    public var validators: [DelegationValidator] = []
+    public var delegations: [DelegationBase] = []
+    public var inSync: Bool = true
+    public var tokenData: [String: Asset] = [:]
+    public var transactionData: TransactionData = TransactionData(fee: Fee(fee: .zero, gasPriceType: .regular(gasPrice: .zero), gasLimit: .zero))
+    public var transactionPreload: TransactionPreload = TransactionPreload()
+    
+    public init() {}
+}
+
+extension ChainServiceMock {
+    public func getAddressStatus(address: String) async throws -> [AddressStatus] {
+        addressStatuses
+    }
+    
+    public func coinBalance(for address: String) async throws -> AssetBalance {
+        coinBalances[address] ?? .init(assetId: AssetId(chain: .ethereum, tokenId: nil), balance: .zero)
+    }
+    
+    public func tokenBalance(for address: String, tokenIds: [AssetId]) async throws -> [AssetBalance] {
+        tokenBalances[address] ?? tokenIds.map { AssetBalance(assetId: $0, balance: .zero) }
+    }
+    
+    public func getStakeBalance(for address: String) async throws -> AssetBalance? {
+        stakeBalance
+    }
+    
+    public func broadcast(data: String, options: BroadcastOptions) async throws -> String {
+        broadcastResponse
+    }
+    
+    public func getFee(asset: Asset, input: FeeInput) async throws -> Fee {
+        fee
+    }
+    
+    public func feeRates(type: TransferDataType) async throws -> [FeeRate] {
+        feeRates
+    }
+    
+    public func getChainID() async throws -> String {
+        chainID ?? ""
+    }
+    
+    public func getLatestBlock() async throws -> BigInt {
+        latestBlock
+    }
+    
+    public func getValidators(apr: Double) async throws -> [DelegationValidator] {
+        validators
+    }
+    
+    public func getStakeDelegations(address: String) async throws -> [DelegationBase] {
+        delegations
+    }
+    
+    public func getInSync() async throws -> Bool {
+        inSync
+    }
+    
+    public func getTokenData(tokenId: String) async throws -> Asset {
+        tokenData[tokenId] ?? Asset(
+            id: AssetId(chain: .ethereum, tokenId: nil),
+            name: "Ethereum",
+            symbol: "ETH",
+            decimals: 18,
+            type: .native
+        )
+    }
+    
+    public func getIsTokenAddress(tokenId: String) -> Bool {
+        tokenData[tokenId] != nil
+    }
+    
+    public func load(input: Blockchain.TransactionInput) async throws -> TransactionData {
+        transactionData
+    }
+    
+    public func preload(input: TransactionPreloadInput) async throws -> TransactionPreload {
+        transactionPreload
+    }
+    
+    public func transactionState(for request: TransactionStateRequest) async throws -> TransactionChanges {
+        TransactionChanges(state: .pending, changes: [])
+    }
+}

--- a/Packages/Blockchain/TestKit/ChainServiceMock.swift
+++ b/Packages/Blockchain/TestKit/ChainServiceMock.swift
@@ -23,6 +23,7 @@ public struct ChainServiceMock: ChainServiceable {
     public var tokenData: [String: Asset] = [:]
     public var transactionData: TransactionData = TransactionData(fee: Fee(fee: .zero, gasPriceType: .regular(gasPrice: .zero), gasLimit: .zero))
     public var transactionPreload: TransactionPreload = TransactionPreload()
+    public var transactionState: TransactionChanges = TransactionChanges(state: .pending, changes: [])
     
     public init() {}
 }
@@ -99,6 +100,6 @@ extension ChainServiceMock {
     }
     
     public func transactionState(for request: TransactionStateRequest) async throws -> TransactionChanges {
-        TransactionChanges(state: .pending, changes: [])
+        transactionState
     }
 }

--- a/Packages/Formatters/Package.resolved
+++ b/Packages/Formatters/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2c0629e73149f0e62703de6fb9bf6a14636644c532d105706a1dea6fe59647e8",
+  "originHash" : "9c334c53ea2cc942fb114e7a93522d7570349eaa88b4d726b350ef8d22f0f77c",
   "pins" : [
     {
       "identity" : "bigint",

--- a/Packages/Primitives/TestKit/Fee+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/Fee+PrimitivesTestKit.swift
@@ -1,0 +1,21 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import BigInt
+
+public extension Fee {
+    static func mock(
+        fee: BigInt = BigInt(21000),
+        gasPriceType: GasPriceType = .regular(gasPrice: BigInt(1000000000)),
+        gasLimit: BigInt = BigInt(21000),
+        options: FeeOptionMap = [:]
+    ) -> Fee {
+        Fee(
+            fee: fee,
+            gasPriceType: gasPriceType,
+            gasLimit: gasLimit,
+            options: options
+        )
+    }
+}

--- a/Packages/Primitives/TestKit/TransactionPreload+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/TransactionPreload+PrimitivesTestKit.swift
@@ -1,0 +1,25 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import BigInt
+
+public extension TransactionPreload {
+    static func mock(
+        blockHash: String = "",
+        blockNumber: Int = 0,
+        utxos: [UTXO] = [],
+        sequence: Int = 0,
+        chainId: String = "",
+        isDestinationAddressExist: Bool = true
+    ) -> TransactionPreload {
+        TransactionPreload(
+            blockHash: blockHash,
+            blockNumber: blockNumber,
+            utxos: utxos,
+            sequence: sequence,
+            chainId: chainId,
+            isDestinationAddressExist: isDestinationAddressExist
+        )
+    }
+}

--- a/Packages/Primitives/TestKit/TransferDataExtra+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/TransferDataExtra+PrimitivesTestKit.swift
@@ -1,0 +1,21 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import BigInt
+
+public extension TransferDataExtra {
+    static func mock(
+        gasLimit: BigInt? = nil,
+        gasPrice: GasPriceType? = nil,
+        data: Data? = nil,
+        outputType: OutputType = .encodedTransaction
+    ) -> TransferDataExtra {
+        TransferDataExtra(
+            gasLimit: gasLimit,
+            gasPrice: gasPrice,
+            data: data,
+            outputType: outputType
+        )
+    }
+}

--- a/Packages/Validators/Package.resolved
+++ b/Packages/Validators/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2c0629e73149f0e62703de6fb9bf6a14636644c532d105706a1dea6fe59647e8",
+  "originHash" : "97685fd3141bd06e1f833d4429412628b196a94cf31c04280952d58a34589509",
   "pins" : [
     {
       "identity" : "bigint",

--- a/Services/ScanService/Package.swift
+++ b/Services/ScanService/Package.swift
@@ -12,6 +12,9 @@ let package = Package(
         .library(
             name: "ScanService",
             targets: ["ScanService"]),
+        .library(
+            name: "ScanServiceTestKit",
+            targets: ["ScanServiceTestKit"]),
     ],
     dependencies: [
         .package(name: "Primitives", path: "../../Packages/Primitives"),
@@ -27,6 +30,16 @@ let package = Package(
                 "Preferences",
             ],
             path: "Sources"
+        ),
+        .target(
+            name: "ScanServiceTestKit",
+            dependencies: [
+                "ScanService",
+                "Primitives",
+                "GemAPI",
+                .product(name: "PreferencesTestKit", package: "Preferences"),
+            ],
+            path: "TestKit"
         ),
     ]
 )

--- a/Services/ScanService/TestKit/ScanService+TestKit.swift
+++ b/Services/ScanService/TestKit/ScanService+TestKit.swift
@@ -1,0 +1,23 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import ScanService
+import Primitives
+import Preferences
+import PreferencesTestKit
+import GemAPI
+
+public extension ScanService {
+    static func mock() -> ScanService {
+        ScanService(
+            apiService: GemAPIScanServiceMock(),
+            securePreferences: SecurePreferences.mock()
+        )
+    }
+}
+
+private struct GemAPIScanServiceMock: GemAPIScanService {
+    func getScanTransaction(payload: ScanTransactionPayload) async throws -> ScanTransaction {
+        ScanTransaction(isMalicious: false, isMemoRequired: false)
+    }
+}

--- a/Services/SwapService/TestKit/SwapQuoteDataProvider+TestKit.swift
+++ b/Services/SwapService/TestKit/SwapQuoteDataProvider+TestKit.swift
@@ -1,0 +1,24 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import SwapService
+import Primitives
+import Gemstone
+
+public extension SwapQuoteDataProvider {
+    static func mock() -> SwapQuoteDataProviderMock {
+        SwapQuoteDataProviderMock()
+    }
+}
+
+public struct SwapQuoteDataProviderMock: SwapQuoteDataProvidable {
+    public let quoteData: SwapQuoteData
+    
+    public init(quoteData: SwapQuoteData = .mock()) {
+        self.quoteData = quoteData
+    }
+    
+    public func fetchQuoteData(wallet: Wallet, quote: SwapQuote) async throws -> SwapQuoteData {
+        quoteData
+    }
+}

--- a/Services/SwapService/TestKit/Types+Mock/ApprovalData+TestKit.swift
+++ b/Services/SwapService/TestKit/Types+Mock/ApprovalData+TestKit.swift
@@ -2,11 +2,12 @@
 
 import struct Gemstone.ApprovalData
 
-extension ApprovalData {
+public extension ApprovalData {
     static func mock() -> ApprovalData {
         ApprovalData(
             token: "0x",
             spender: "0x",
             value: "1000000000000000000"
         )
-    }}
+    }
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for ConfirmTransferViewModel properties
- Create reusable test infrastructure for Transfer module testing
- Fix #944

## Test plan
- [x] Run tests locally with `just test-specific TransferTests`
- [x] All tests pass successfully
- [x] New test mocks follow existing patterns

🤖 Generated with [Claude Code](https://claude.ai/code)