### PR TITLE
Fix memo display logic in TransactionScene

### DIFF
--- a/Features/Transactions/Sources/ViewModels/TransactionDetailViewModel.swift
+++ b/Features/Transactions/Sources/ViewModels/TransactionDetailViewModel.swift
@@ -170,18 +170,7 @@ struct TransactionDetailViewModel {
     }
 
     var showMemoField: Bool {
-        switch model.transaction.transaction.type {
-        case .transfer, .transferNFT: model.transaction.asset.chain.isMemoSupported
-        case .swap,
-                .tokenApproval,
-                .assetActivation,
-                .smartContractCall,
-                .stakeRewards,
-                .stakeWithdraw,
-                .stakeDelegate,
-                .stakeUndelegate,
-                .stakeRedelegate: false
-        }
+        memo != nil
     }
 
     var memo: String? {

--- a/Features/Transactions/Tests/TransactionsTests/TransactionDetailViewModelTests.swift
+++ b/Features/Transactions/Tests/TransactionsTests/TransactionDetailViewModelTests.swift
@@ -55,14 +55,24 @@ struct TransactionDetailViewModelTests {
             #expect(TransactionDetailViewModel.mock(type: type).participant == nil)
         }
     }
+
+    @Test
+    func showMemoField() {
+        let allTypes: [TransactionType] = [.transfer, .transferNFT, .swap, .tokenApproval, .assetActivation, .smartContractCall, .stakeRewards, .stakeWithdraw, .stakeDelegate, .stakeUndelegate, .stakeRedelegate]
+        for type in allTypes {
+            #expect(TransactionDetailViewModel.mock(type: type, memo: nil).showMemoField == false)
+            #expect(TransactionDetailViewModel.mock(type: type, memo: "Test memo").showMemoField == true)
+        }
+    }
 }
 
 extension TransactionDetailViewModel {
     static func mock(
         type: TransactionType,
         direction: TransactionDirection = .outgoing,
-        participant: String = "participant_address"
+        participant: String = "participant_address",
+        memo: String? = nil
     ) -> TransactionDetailViewModel {
-        TransactionDetailViewModel(model: TransactionViewModel.mock(type: type, direction: direction, participant: participant))
+        TransactionDetailViewModel(model: TransactionViewModel.mock(type: type, direction: direction, participant: participant, memo: memo))
     }
 }

--- a/Features/Transactions/Tests/TransactionsTests/TransactionViewModelTests.swift
+++ b/Features/Transactions/Tests/TransactionsTests/TransactionViewModelTests.swift
@@ -38,7 +38,8 @@ extension TransactionViewModel {
         toValue: String = "",
         type: TransactionType = .swap,
         direction: TransactionDirection = .incoming,
-        participant: String = ""
+        participant: String = "",
+        memo: String? = nil
     ) -> TransactionViewModel {
         let fromAsset = Asset.mockEthereum()
         let toAsset = Asset.mockEthereumUSDT()
@@ -58,6 +59,7 @@ extension TransactionViewModel {
             direction: direction,
             to: participant,
             value: "1000000000000000000",
+            memo: memo,
             metadata: swapMetadata
         )
         let extended = TransactionExtended.mock(

--- a/Packages/Primitives/TestKit/Transaction+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/Transaction+PrimitivesTestKit.swift
@@ -10,6 +10,7 @@ public extension Transaction {
         direction: TransactionDirection = .incoming,
         to: String = "",
         value: String = "",
+        memo: String? = nil,
         metadata: TransactionMetadata? = nil
     ) -> Transaction {
         Transaction(
@@ -26,7 +27,7 @@ public extension Transaction {
             fee: "",
             feeAssetId: .mock(),
             value: value,
-            memo: .none,
+            memo: memo,
             direction: direction,
             utxoInputs: [],
             utxoOutputs: [],


### PR DESCRIPTION
## Summary
- Fixed memo display logic to show memo field whenever memo is not nil, regardless of transaction type
- Simplified `showMemoField` property to just check `memo \!= nil`
- Added comprehensive unit tests to verify memo display behavior

## Test plan
- [x] Added unit tests that verify memo shows for all transaction types when memo is present
- [x] Verified memo is hidden for all transaction types when memo is nil
- [x] All tests pass locally

Fixes #949

🤖 Generated with [Claude Code](https://claude.ai/code)