### PR TITLE
Fix navigation update warnings in TransactionsFilterScene

### DIFF
--- a/Features/Transactions/Sources/Scenes/TransactionsFilterScene.swift
+++ b/Features/Transactions/Sources/Scenes/TransactionsFilterScene.swift
@@ -76,16 +76,10 @@ extension TransactionsFilterScene {
 
     private func onFinishSelection(value: SelectionResult<Chain>) {
         model.onFinishChainSelection(value: value)
-        if value.isConfirmed {
-            dismiss()
-        }
     }
 
     private func onFinishSelection(value: SelectionResult<TransactionFilterType>) {
         model.onFinishTypeSelection(value: value)
-        if value.isConfirmed {
-            dismiss()
-        }
     }
 
 }

--- a/Features/Transactions/Sources/ViewModels/TransactionsFilterViewModel.swift
+++ b/Features/Transactions/Sources/ViewModels/TransactionsFilterViewModel.swift
@@ -22,9 +22,7 @@ public final class TransactionsFilterViewModel: Equatable {
 
     public static func == (lhs: TransactionsFilterViewModel, rhs: TransactionsFilterViewModel) -> Bool {
         lhs.chainsFilter == rhs.chainsFilter &&
-        lhs.transactionTypesFilter == rhs.transactionTypesFilter &&
-        lhs.isPresentingChains == rhs.isPresentingChains &&
-        lhs.isPresentingTypes == rhs.isPresentingTypes
+        lhs.transactionTypesFilter == rhs.transactionTypesFilter
     }
 
     public var isAnyFilterSpecified: Bool {


### PR DESCRIPTION
## Summary
- Fixes NavigationRequestObserver & NavigationAuthority warnings when using Activity filters
- Removes automatic dismissal behavior when filter selections are confirmed
- Prevents multiple navigation updates per frame

## Problem
When users selected a filter type (e.g., Swap) and tapped Done, the sheet would dismiss twice:
1. From the selection handler when `value.isConfirmed` was true
2. From the Done button action

This caused performance warnings about multiple navigation updates per frame.

## Solution
Removed the automatic dismissal from selection handlers. Users now explicitly tap Done to confirm their filter selections and dismiss the sheet.

## Test plan
- [x] Open the app and navigate to Activity screen
- [x] Tap filter button and select Type filter
- [x] Choose Swap and tap Done
- [x] Verify no navigation warnings appear in console
- [x] Verify filter sheet dismisses correctly
- [x] Verify selected filters are applied

Fixes #593

🤖 Generated with [Claude Code](https://claude.ai/code)