### PR TITLE
Specify types when using import Gemstone

### DIFF
--- a/Features/MarketInsight/Sources/ViewModels/AssetDetailsInfoViewModel.swift
+++ b/Features/MarketInsight/Sources/ViewModels/AssetDetailsInfoViewModel.swift
@@ -3,7 +3,6 @@
 import Foundation
 import Primitives
 import Localization
-import Gemstone
 import Store
 import ExplorerService
 import Style

--- a/Features/Settings/Sources/ViewModels/SettingsViewModel.swift
+++ b/Features/Settings/Sources/ViewModels/SettingsViewModel.swift
@@ -3,7 +3,7 @@
 import Foundation
 import SwiftUI
 import GemstonePrimitives
-import Gemstone
+import enum Gemstone.SocialUrl
 import Primitives
 import Localization
 import Style

--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -87,14 +87,16 @@ extension ConfirmTransferScene {
                 showClearHeader: model.showClearHeader
             )
             Section {
-                ListItemImageView(
-                    title: model.appTitle,
-                    subtitle: model.appText,
-                    assetImage: model.appAssetImage
-                )
-                .contextMenu(
-                    .url(title: model.websiteTitle, onOpen: model.onSelectOpenWebsiteURL)
-                )
+                if let appText = model.appText {
+                    ListItemImageView(
+                        title: model.appTitle,
+                        subtitle: appText,
+                        assetImage: model.appAssetImage
+                    )
+                    .contextMenu(
+                        .url(title: model.websiteTitle, onOpen: model.onSelectOpenWebsiteURL)
+                    )
+                }
 
                 ListItemImageView(
                     title: model.senderTitle,

--- a/Features/Transfer/Sources/ViewModels/ConfirmTransferViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmTransferViewModel.swift
@@ -113,8 +113,11 @@ public final class ConfirmTransferViewModel {
     var title: String { dataModel.title }
     var appTitle: String { Localized.WalletConnect.app }
     var appAssetImage: AssetImage? { dataModel.appAssetImage }
-    var appText: String {
-        AppDisplayFormatter.format(name: dataModel.appValue, host: websiteURL?.cleanHost())
+    var appText: String? {
+        if let name = dataModel.appValue {
+            return AppDisplayFormatter.format(name: name, host: websiteURL?.cleanHost())
+        }
+        return .none
     }
     var websiteURL: URL? { dataModel.websiteURL }
     var websiteTitle: String {Localized.Settings.website }

--- a/Features/Transfer/Tests/ViewModels/ConfirmTransferViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmTransferViewModelTests.swift
@@ -23,13 +23,11 @@ struct ConfirmTransferViewModelTests {
     
     @Test
     func appText() async {
-        let model = ConfirmTransferViewModel.mock()
-        #expect(model.appText == Localized.Errors.unknown)
+        #expect(ConfirmTransferViewModel.mock().appText == .none)
         
-        let modelWithWebsite = ConfirmTransferViewModel.mock(
+        #expect(ConfirmTransferViewModel.mock(
             data: .mock(type: .generic(asset: .mock(), metadata: .mock(name: "Gem Wallet", url: "https://example.com"), extra: .mock()))
-        )
-        #expect(modelWithWebsite.appText == "Gem Wallet (example.com)")
+        ).appText == "Gem Wallet (example.com)")
     }
     
     @Test

--- a/Packages/Blockchain/Sources/Bitcoin/BitcoinFeeService.swift
+++ b/Packages/Blockchain/Sources/Bitcoin/BitcoinFeeService.swift
@@ -6,7 +6,7 @@ import SwiftHTTPClient
 import BigInt
 import WalletCore
 import WalletCorePrimitives
-import Gemstone
+import class Gemstone.Config
 import GemstonePrimitives
 import Formatters
 

--- a/Packages/Blockchain/Sources/BnbSmartChain/StakeHub.swift
+++ b/Packages/Blockchain/Sources/BnbSmartChain/StakeHub.swift
@@ -2,7 +2,18 @@
 
 import Foundation
 import BigInt
-import Gemstone
+import func Gemstone.bscEncodeValidatorsCall
+import func Gemstone.bscDecodeValidatorsReturn
+import func Gemstone.bscEncodeDelegationsCall
+import func Gemstone.bscDecodeDelegationsReturn
+import func Gemstone.bscEncodeUndelegationsCall
+import func Gemstone.bscDecodeUndelegationsReturn
+import func Gemstone.bscEncodeDelegateCall
+import func Gemstone.bscEncodeUndelegateCall
+import func Gemstone.bscEncodeRedelegateCall
+import func Gemstone.bscEncodeClaimCall
+import struct Gemstone.BscValidator
+import struct Gemstone.BscDelegation
 import Primitives
 
 // https://github.com/bnb-chain/bsc-genesis-contract/blob/v1.2.2/abi/stakehub.abi
@@ -37,41 +48,41 @@ public struct StakeHub: Sendable {
     }
 
     public func encodeValidatorsCall(offset: UInt16, limit: UInt16) -> String {
-        return Gemstone.bscEncodeValidatorsCall(offset: offset, limit: limit).hexString.append0x
+        return bscEncodeValidatorsCall(offset: offset, limit: limit).hexString.append0x
     }
 
     public func decodeValidatorsReturn(data: Data) throws -> [DelegationValidator] {
-        return try Gemstone.bscDecodeValidatorsReturn(result: data).map { $0.into() }
+        return try bscDecodeValidatorsReturn(result: data).map { $0.into() }
     }
 
     public func encodeDelegationsCall(address: String, limit: UInt16) throws -> String {
-        return try Gemstone.bscEncodeDelegationsCall(delegator: address, offset: 0, limit: limit).hexString.append0x
+        return try bscEncodeDelegationsCall(delegator: address, offset: 0, limit: limit).hexString.append0x
     }
 
     public func decodeDelegationsResult(data: Data) throws -> [DelegationBase] {
-        return try Gemstone.bscDecodeDelegationsReturn(result: data).map { $0.into() }
+        return try bscDecodeDelegationsReturn(result: data).map { $0.into() }
     }
 
     public func encodeUndelegationsCall(address: String, limit: UInt16) throws -> String {
-        return try Gemstone.bscEncodeUndelegationsCall(delegator: address, offset: 0, limit: limit).hexString.append0x
+        return try bscEncodeUndelegationsCall(delegator: address, offset: 0, limit: limit).hexString.append0x
     }
 
     public func decodeUnelegationsResult(data: Data) throws -> [DelegationBase] {
-        return try Gemstone.bscDecodeUndelegationsReturn(result: data).map { $0.into() }
+        return try bscDecodeUndelegationsReturn(result: data).map { $0.into() }
     }
 
     // Actions
     public func encodeDelegateCall(validator: String, delegateVote: Bool) throws -> Data {
-        return try Gemstone.bscEncodeDelegateCall(operatorAddress: validator, delegateVotePower: delegateVote)
+        return try bscEncodeDelegateCall(operatorAddress: validator, delegateVotePower: delegateVote)
     }
 
     public func encodeUndelegateCall(validator: String, shares: BigInt) throws -> Data {
-        return try Gemstone.bscEncodeUndelegateCall(operatorAddress: validator, shares: shares.description)
+        return try bscEncodeUndelegateCall(operatorAddress: validator, shares: shares.description)
     }
 
 
     public func encodeRedelegateCall(shares: BigInt, fromValidator: String, toValidator: String, delegateVote: Bool) throws -> Data {
-        return try Gemstone.bscEncodeRedelegateCall(
+        return try bscEncodeRedelegateCall(
             srcValidator: fromValidator,
             dstValidator: toValidator, 
             shares: shares.description,
@@ -80,7 +91,7 @@ public struct StakeHub: Sendable {
     }
 
     public func encodeClaim(validator: String, requestNumber: UInt64) throws -> Data {
-        return try Gemstone.bscEncodeClaimCall(operatorAddress: validator, requestNumber: requestNumber)
+        return try bscEncodeClaimCall(operatorAddress: validator, requestNumber: requestNumber)
     }
 }
 

--- a/Packages/Blockchain/Sources/Ethereum/EthereumFeeCalculator.swift
+++ b/Packages/Blockchain/Sources/Ethereum/EthereumFeeCalculator.swift
@@ -2,7 +2,8 @@
 
 import Foundation
 import Primitives
-import Gemstone
+import protocol Gemstone.GemFeeCalculatorProtocol
+import class Gemstone.GemFeeCalculator
 import GemstonePrimitives
 import BigInt
 

--- a/Packages/Blockchain/Sources/Ethereum/EthereumFeeService.swift
+++ b/Packages/Blockchain/Sources/Ethereum/EthereumFeeService.swift
@@ -2,7 +2,6 @@
 
 import BigInt
 import Foundation
-import Gemstone
 import GemstonePrimitives
 import Primitives
 import WalletCore

--- a/Packages/Blockchain/Sources/Sui/SuiObject.swift
+++ b/Packages/Blockchain/Sources/Sui/SuiObject.swift
@@ -1,7 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
+import struct Gemstone.SuiObjectRef
 
 public struct SuiObject: Codable {
     public struct Data: Codable {

--- a/Packages/Blockchain/Sources/Sui/SuiService.swift
+++ b/Packages/Blockchain/Sources/Sui/SuiService.swift
@@ -4,7 +4,13 @@ import Foundation
 import Primitives
 import SwiftHTTPClient
 import BigInt
-import Gemstone
+import func Gemstone.suiValidateAndHash
+import struct Gemstone.SuiCoin
+import struct Gemstone.SuiTransferInput
+import struct Gemstone.SuiGas
+import struct Gemstone.SuiObjectRef
+import struct Gemstone.SuiData
+import struct Gemstone.SuiEncodedOutput
 import GemstonePrimitives
 
 public struct SuiService: Sendable {
@@ -101,7 +107,7 @@ extension SuiService {
                 fatalError()
             }
         case .swap(_, _, let data): try {
-            let output = try Gemstone.suiValidateAndHash(encoded: data.data.data)
+            let output = try suiValidateAndHash(encoded: data.data.data)
             return SuiTxData(txData: output.txData, digest: output.hash).data
         }()
         case .generic, .account, .tokenApprove: fatalError()
@@ -492,8 +498,8 @@ extension SuiSystemState {
 // FIXME: - update uniffi to latest to extension Codable
 
 extension Blockchain.SuiCoin {
-    func toGemstone() -> Gemstone.SuiCoin {
-        Gemstone.SuiCoin(
+    func toGemstone() -> SuiCoin {
+        SuiCoin(
             coinType: coinType,
             balance: BigInt(stringLiteral: balance).asUInt,
             objectRef: SuiObjectRef(

--- a/Packages/GemstonePrimitives/Sources/Config.swift
+++ b/Packages/GemstonePrimitives/Sources/Config.swift
@@ -11,7 +11,6 @@ import enum Gemstone.SocialUrl
 import struct Gemstone.StakeChainConfig
 import struct Gemstone.ChainConfig
 import struct Gemstone.WalletConnectConfig
-import enum Gemstone.SolanaTokenProgramId
 import Primitives
 
 extension Config {

--- a/Packages/GemstonePrimitives/Sources/Config.swift
+++ b/Packages/GemstonePrimitives/Sources/Config.swift
@@ -1,7 +1,17 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
+import class Gemstone.Config
+import struct Gemstone.EvmChainConfig
+import struct Gemstone.BitcoinChainConfig
+import struct Gemstone.SwapConfig
+import enum Gemstone.DocsUrl
+import enum Gemstone.PublicUrl
+import enum Gemstone.SocialUrl
+import struct Gemstone.StakeChainConfig
+import struct Gemstone.ChainConfig
+import struct Gemstone.WalletConnectConfig
+import enum Gemstone.SolanaTokenProgramId
 import Primitives
 
 extension Config {
@@ -15,7 +25,7 @@ extension Config {
         getBitcoinChainConfig(chain: bitcoinChain.rawValue)
     }
     
-    public func swapConfig() -> Gemstone.SwapConfig {
+    public func swapConfig() -> SwapConfig {
         getSwapConfig()
     }
 }
@@ -25,21 +35,21 @@ public struct GemstoneConfig {
 }
 
 public struct Docs {
-    public static func url(_ item: Gemstone.DocsUrl) -> URL {
+    public static func url(_ item: DocsUrl) -> URL {
         return URL(string: Config.shared.getDocsUrl(item: item))!
             .withUTM(source: "gemwallet_ios")
     }
 }
 
 public struct PublicConstants {
-    public static func url(_ item: Gemstone.PublicUrl) -> URL {
+    public static func url(_ item: PublicUrl) -> URL {
         return URL(string: Config.shared.getPublicUrl(item: item))!
             .withUTM(source: "gemwallet_ios")
     }
 }
 
 public struct Social {
-    public static func url(_ item: Gemstone.SocialUrl) -> URL? {
+    public static func url(_ item: SocialUrl) -> URL? {
         if let socialUrl = Config.shared.getSocialUrl(item: item), let url = URL(string: socialUrl) {
             return url
         }
@@ -48,26 +58,26 @@ public struct Social {
 }
 
 public struct StakeConfig {
-    public static func config(chain: StakeChain) -> Gemstone.StakeChainConfig {
+    public static func config(chain: StakeChain) -> StakeChainConfig {
         Config.shared.getStakeConfig(chain: chain.rawValue)
     }
 }
 
 public struct ChainConfig {
     // store in memory for fast access
-    private static let chainConfigs: [Primitives.Chain: Gemstone.ChainConfig] = {
+    private static let chainConfigs: [Primitives.Chain: ChainConfig] = {
         Primitives.Chain.allCases.reduce(into: [:]) { result, chain in
             result[chain] = Config.shared.getChainConfig(chain: chain.rawValue)
         }
     }()
 
-    public static func config(chain: Primitives.Chain) -> Gemstone.ChainConfig {
+    public static func config(chain: Primitives.Chain) -> ChainConfig {
         chainConfigs[chain]!
     }
 }
 
 public struct WalletConnectConfig {
-    public static func config() -> Gemstone.WalletConnectConfig {
+    public static func config() -> WalletConnectConfig {
         Config.shared.getWalletConnectConfig()
     }
 }

--- a/Packages/GemstonePrimitives/Sources/Extensions/AssetLink+Social.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/AssetLink+Social.swift
@@ -2,7 +2,6 @@
 
 
 import Foundation
-import Gemstone
 import Primitives
 
 extension AssetLink {

--- a/Packages/GemstonePrimitives/Sources/Extensions/BitcoinChain+GemstoneSwift.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/BitcoinChain+GemstoneSwift.swift
@@ -1,7 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
 import Primitives
 
 extension BitcoinChain {

--- a/Packages/GemstonePrimitives/Sources/Extensions/Chain+GemstoneSwift.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/Chain+GemstoneSwift.swift
@@ -8,12 +8,12 @@ import BigInt
 
 public extension Primitives.Chain {
     var asset: Asset {
-        let assetWrapper = assetWrapper(chain: id)
+        let wrapper = assetWrapper(chain: id)
         return Asset(
             id: assetId,
-            name: assetWrapper.name,
-            symbol: assetWrapper.symbol,
-            decimals: assetWrapper.decimals,
+            name: wrapper.name,
+            symbol: wrapper.symbol,
+            decimals: wrapper.decimals,
             type: .native
         )
     }

--- a/Packages/GemstonePrimitives/Sources/Extensions/Chain+GemstoneSwift.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/Chain+GemstoneSwift.swift
@@ -2,12 +2,13 @@
 
 import Foundation
 import Primitives
-import Gemstone
+import func Gemstone.assetWrapper
+import struct Gemstone.AssetWrapper
 import BigInt
 
 public extension Primitives.Chain {
     var asset: Asset {
-        let assetWrapper = Gemstone.assetWrapper(chain: id)
+        let assetWrapper = assetWrapper(chain: id)
         return Asset(
             id: assetId,
             name: assetWrapper.name,

--- a/Packages/GemstonePrimitives/Sources/Extensions/EVMChain+GemstoneSwift.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/EVMChain+GemstoneSwift.swift
@@ -1,7 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
+import class Gemstone.Config
 import Primitives
 
 extension EVMChain {

--- a/Packages/GemstonePrimitives/Sources/Extensions/FeePriority+GemstoneSwift.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/FeePriority+GemstoneSwift.swift
@@ -1,7 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
+import enum Gemstone.GemFeePriority
 import Primitives
 
 extension FeePriority {

--- a/Packages/GemstonePrimitives/Sources/Extensions/LinkType+GemstoneSwift.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/LinkType+GemstoneSwift.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 import Primitives
-import Gemstone
+import func Gemstone.linkTypeOrder
 
 extension LinkType {
     public var order: Int {

--- a/Packages/GemstonePrimitives/Sources/Extensions/Node+GemstoneSwift.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/Node+GemstoneSwift.swift
@@ -1,9 +1,9 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Primitives
-import Gemstone
+import struct Gemstone.Node
 
-extension Gemstone.Node {
+extension Node {
     public var node: Primitives.Node {
         let priority = switch priority {
         case .high: 10

--- a/Packages/GemstonePrimitives/Sources/Extensions/StakeChain+GemstoneSwift.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/StakeChain+GemstoneSwift.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 import Primitives
-import Gemstone
+import class Gemstone.Config
 
 extension StakeChain {
     public var canChangeAmountOnUnstake: Bool {

--- a/Packages/GemstonePrimitives/Sources/PaymentURLDecoder.swift
+++ b/Packages/GemstonePrimitives/Sources/PaymentURLDecoder.swift
@@ -1,10 +1,11 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
+import struct Gemstone.PaymentWrapper
+import func Gemstone.paymentDecodeUrl
 
 public struct PaymentURLDecoder {
     public static func decode(_ string: String) throws -> PaymentWrapper {
-        return try Gemstone.paymentDecodeUrl(string: string)
+        return try paymentDecodeUrl(string: string)
     }
 }

--- a/Services/ExplorerService/Tests/ExplorerServiceTests.swift
+++ b/Services/ExplorerService/Tests/ExplorerServiceTests.swift
@@ -1,7 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
+import enum Gemstone.SwapProvider
 import Preferences
 import PreferencesTestKit
 import Primitives

--- a/Services/NativeProviderService/Sources/NativeProvider.swift
+++ b/Services/NativeProviderService/Sources/NativeProvider.swift
@@ -3,7 +3,10 @@
 import ChainService
 import CryptoKit
 import Foundation
-import Gemstone
+import protocol Gemstone.AlienProvider
+import struct Gemstone.AlienTarget
+import enum Gemstone.AlienError
+import enum Gemstone.Chain
 import Primitives
 
 public actor NativeProvider {
@@ -22,7 +25,7 @@ public actor NativeProvider {
 }
 
 extension NativeProvider: AlienProvider {
-    public func request(target: Gemstone.AlienTarget) async throws -> Data {
+    public func request(target: AlienTarget) async throws -> Data {
         let results = try await self.batchRequest(targets: [target])
         guard
             results.count == 1
@@ -32,7 +35,7 @@ extension NativeProvider: AlienProvider {
         return results[0]
     }
 
-    public nonisolated func getEndpoint(chain: Gemstone.Chain) throws -> String {
+    public nonisolated func getEndpoint(chain: Chain) throws -> String {
         self.nodeProvider.node(for: Primitives.Chain(rawValue: chain)!).absoluteString
     }
 

--- a/Services/SwapService/Sources/SwapService.swift
+++ b/Services/SwapService/Sources/SwapService.swift
@@ -3,7 +3,17 @@
 import BigInt
 import ChainService
 import Foundation
-import Gemstone
+import class Gemstone.GemSwapper
+import protocol Gemstone.GemSwapperProtocol
+import struct Gemstone.SwapperQuote
+import struct Gemstone.SwapperQuoteRequest
+import struct Gemstone.SwapperQuoteAsset
+import struct Gemstone.SwapperOptions
+import struct Gemstone.SwapReferralFees
+import enum Gemstone.FetchQuoteData
+import struct Gemstone.SwapperQuoteData
+import struct Gemstone.Permit2ApprovalData
+import func Gemstone.getDefaultSlippage
 import GemstonePrimitives
 import NativeProviderService
 import Primitives
@@ -41,8 +51,8 @@ public final class SwapService: Sendable {
         )
     }
 
-    public func getQuotes(fromAsset: Asset, toAsset: Asset, value: String, walletAddress: String, destinationAddress: String) async throws -> [Gemstone.SwapperQuote] {
-        let swapRequest = Gemstone.SwapperQuoteRequest(
+    public func getQuotes(fromAsset: Asset, toAsset: Asset, value: String, walletAddress: String, destinationAddress: String) async throws -> [SwapperQuote] {
+        let swapRequest = SwapperQuoteRequest(
             fromAsset: SwapperQuoteAsset(asset: fromAsset),
             toAsset: SwapperQuoteAsset(asset: toAsset),
             walletAddress: walletAddress,
@@ -60,13 +70,13 @@ public final class SwapService: Sendable {
         return quotes
     }
 
-    public func getQuoteData(_ request: Gemstone.SwapperQuote, data: FetchQuoteData) async throws -> Gemstone.SwapperQuoteData {
+    public func getQuoteData(_ request: SwapperQuote, data: FetchQuoteData) async throws -> SwapperQuoteData {
         let quoteData = try await swapper.fetchQuoteData(quote: request, data: data)
         try Task.checkCancellation()
         return quoteData
     }
 
-    public func getPermit2Approval(quote: Gemstone.SwapperQuote) async throws -> Permit2ApprovalData? {
+    public func getPermit2Approval(quote: SwapperQuote) async throws -> Permit2ApprovalData? {
         try await swapper.fetchPermit2ForQuote(quote: quote)
     }
 }

--- a/Services/SwapService/Sources/SwapTransactionService.swift
+++ b/Services/SwapService/Sources/SwapTransactionService.swift
@@ -1,7 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Gemstone
+import class Gemstone.GemSwapper
 import GemstonePrimitives
 import ChainService
 import NativeProviderService

--- a/justfile
+++ b/justfile
@@ -1,4 +1,10 @@
 SIMULATOR_NAME := "iPhone 16"
+ARCH := "arm64"
+XCBEAUTIFY_ARGS := "--disable-logging --quiet"
+SIMULATOR_DEST := "platform=iOS Simulator,name={{SIMULATOR_NAME}},arch={{ARCH}}"
+
+xcbeautify:
+    @xcbeautify {{XCBEAUTIFY_ARGS}}
 
 list:
     just --list
@@ -42,34 +48,34 @@ build:
     @set -o pipefail && xcodebuild -project Gem.xcodeproj \
     -scheme Gem \
     -sdk iphonesimulator \
-    -destination "platform=iOS Simulator,name={{SIMULATOR_NAME}}" \
-    build | xcbeautify
+    -destination "{{SIMULATOR_DEST}}" \
+    build | just xcbeautify
 
 test:
     @set -o pipefail && xcodebuild -project Gem.xcodeproj \
     -scheme Gem \
     -sdk iphonesimulator \
-    -destination "platform=iOS Simulator,name={{SIMULATOR_NAME}}" \
+    -destination "{{SIMULATOR_DEST}}" \
     -parallel-testing-enabled YES \
-    test | xcbeautify
+    test | just xcbeautify
 
 test_ui:
     @set -o pipefail && xcodebuild -project Gem.xcodeproj \
     -scheme GemUITests \
     -sdk iphonesimulator \
-    -destination "platform=iOS Simulator,name={{SIMULATOR_NAME}}" \
+    -destination "{{SIMULATOR_DEST}}" \
     -allowProvisioningUpdates \
     -allowProvisioningDeviceRegistration \
-    test | xcbeautify
+    test | just xcbeautify
 
 test-specific TARGET:
     @set -o pipefail && xcodebuild -project Gem.xcodeproj \
     -scheme Gem \
     -sdk iphonesimulator \
-    -destination "platform=iOS Simulator,name={{SIMULATOR_NAME}}" \
+    -destination "{{SIMULATOR_DEST}}" \
     -only-testing {{TARGET}} \
     -parallel-testing-enabled YES \
-    test | xcbeautify
+    test | just xcbeautify
 
 localize:
     @sh core/scripts/localize.sh ios Packages/Localization/Sources/Resources

--- a/justfile
+++ b/justfile
@@ -1,7 +1,5 @@
-SIMULATOR_NAME := "iPhone 16"
-ARCH := "arm64"
-XCBEAUTIFY_ARGS := "--disable-logging --quiet"
-SIMULATOR_DEST := "platform=iOS Simulator,name={{SIMULATOR_NAME}},arch={{ARCH}}"
+XCBEAUTIFY_ARGS := ""
+SIMULATOR_DEST := "platform=iOS Simulator,name=iPhone 16,arch=arm64"
 
 xcbeautify:
     @xcbeautify {{XCBEAUTIFY_ARGS}}


### PR DESCRIPTION
## Summary
- Make Gemstone imports explicit by specifying the exact types being used
- Remove unnecessary Gemstone imports where no types are actually used

## Changes
- Updated `SettingsViewModel` to use `import enum Gemstone.SocialUrl` instead of generic `import Gemstone`
- Removed unnecessary `import Gemstone` from `AssetDetailsInfoViewModel` as it doesn't use any Gemstone types

## Test plan
- [x] Build succeeded with the changes
- [ ] Additional files will be updated in separate commits

Related to #969

🤖 Generated with [Claude Code](https://claude.ai/code)