### PR TITLE
Fix address table migration error

### DIFF
--- a/Packages/Store/Sources/Migrations.swift
+++ b/Packages/Store/Sources/Migrations.swift
@@ -272,7 +272,7 @@ public struct Migrations {
         }
         
         migrator.registerMigration("Add \(AddressRecord.databaseTableName) table33") { db in
-            try db.drop(table: AddressRecord.databaseTableName)
+            try? db.drop(table: AddressRecord.databaseTableName)
             try AddressRecord.create(db: db)
         }
         

--- a/Packages/Store/TestKit/AddressStore+TestKit.swift
+++ b/Packages/Store/TestKit/AddressStore+TestKit.swift
@@ -1,0 +1,10 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Store
+
+extension AddressStore {
+    public static func mock(db: DB = .mock()) -> Self {
+        AddressStore(db: db)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix SQLite error when dropping non-existent addresses table during migration
- Use `try?` instead of `try` to gracefully handle case where table doesn't exist

## Changes
- Modified migration in `Migrations.swift` to use optional try for dropping addresses table
- This prevents crash when the table doesn't exist and allows migration to proceed

## Test plan
- [ ] Verify migration runs without errors on clean database
- [ ] Verify existing databases continue to work
- [ ] Test AddressStore functionality after migration

🤖 Generated with [Claude Code](https://claude.ai/code)