### PR TITLE
Integrate v2 transactions endpoints with address names storage

### DIFF
--- a/Gem/Services/ServicesFactory.swift
+++ b/Gem/Services/ServicesFactory.swift
@@ -82,7 +82,8 @@ struct ServicesFactory {
             transactionStore: storeManager.transactionStore,
             assetsService: assetsService,
             walletStore: storeManager.walletStore,
-            deviceService: deviceService
+            deviceService: deviceService,
+            addressStore: storeManager.addressStore
         )
         let transactionService = Self.makeTransactionService(
             transactionStore: storeManager.transactionStore,
@@ -284,13 +285,15 @@ extension ServicesFactory {
         transactionStore: TransactionStore,
         assetsService: AssetsService,
         walletStore: WalletStore,
-        deviceService: any DeviceServiceable
+        deviceService: any DeviceServiceable,
+        addressStore: AddressStore
     ) -> TransactionsService {
         TransactionsService(
             transactionStore: transactionStore,
             assetsService: assetsService,
             walletStore: walletStore,
-            deviceService: deviceService
+            deviceService: deviceService,
+            addressStore: addressStore
         )
     }
 

--- a/Packages/GemAPI/Sources/GemAPI.swift
+++ b/Packages/GemAPI/Sources/GemAPI.swift
@@ -108,7 +108,7 @@ public enum GemAPI: TargetType {
         case .updateDevice(let device):
             return "/v1/devices/\(device.id)"
         case .getTransactions(let deviceId, _):
-            return "/v1/transactions/device/\(deviceId)"
+            return "/v2/transactions/device/\(deviceId)"
         case .getAsset(let id):
             return "/v1/assets/\(id.identifier.replacingOccurrences(of: "/", with: "%2F"))"
         case .getAssets:

--- a/Packages/GemAPI/Sources/GemAPIService.swift
+++ b/Packages/GemAPI/Sources/GemAPIService.swift
@@ -51,8 +51,8 @@ public protocol GemAPISubscriptionService: Sendable {
 }
 
 public protocol GemAPITransactionService: Sendable {
-    func getTransactionsAll(deviceId: String, walletIndex: Int, fromTimestamp: Int) async throws -> [Primitives.Transaction]
-    func getTransactionsForAsset(deviceId: String, walletIndex: Int, asset: AssetId, fromTimestamp: Int) async throws -> [Primitives.Transaction]
+    func getTransactionsAll(deviceId: String, walletIndex: Int, fromTimestamp: Int) async throws -> TransactionsResponse
+    func getTransactionsForAsset(deviceId: String, walletIndex: Int, asset: AssetId, fromTimestamp: Int) async throws -> TransactionsResponse
 }
 
 public protocol GemAPIPriceAlertService: Sendable {
@@ -166,18 +166,18 @@ extension GemAPIService: GemAPISubscriptionService {
 }
 
 extension GemAPIService: GemAPITransactionService {
-    public func getTransactionsForAsset(deviceId: String, walletIndex: Int, asset: Primitives.AssetId, fromTimestamp: Int) async throws -> [Primitives.Transaction] {
+    public func getTransactionsForAsset(deviceId: String, walletIndex: Int, asset: Primitives.AssetId, fromTimestamp: Int) async throws -> TransactionsResponse {
         let options = TransactionsFetchOption(wallet_index: walletIndex.asInt32, asset_id: asset.identifier, from_timestamp: fromTimestamp.asUInt32)
         return try await provider
             .request(.getTransactions(deviceId: deviceId, options: options))
-            .map(as: [Primitives.Transaction].self)
+            .map(as: TransactionsResponse.self)
     }
     
-    public func getTransactionsAll(deviceId: String, walletIndex: Int, fromTimestamp: Int) async throws -> [Primitives.Transaction] {
+    public func getTransactionsAll(deviceId: String, walletIndex: Int, fromTimestamp: Int) async throws -> TransactionsResponse {
         let options = TransactionsFetchOption(wallet_index: walletIndex.asInt32, asset_id: .none, from_timestamp: fromTimestamp.asUInt32)
         return try await provider
             .request(.getTransactions(deviceId: deviceId, options: options))
-            .map(as: [Primitives.Transaction].self)
+            .map(as: TransactionsResponse.self)
     }
 }
 

--- a/Packages/Store/Sources/Migrations.swift
+++ b/Packages/Store/Sources/Migrations.swift
@@ -272,7 +272,7 @@ public struct Migrations {
         }
         
         migrator.registerMigration("Add \(AddressRecord.databaseTableName) table33") { db in
-            try db.drop(table: AddressRecord.databaseTableName)
+            try? db.drop(table: AddressRecord.databaseTableName)
             try AddressRecord.create(db: db)
         }
         

--- a/Packages/Store/Sources/Stores/AddressStore.swift
+++ b/Packages/Store/Sources/Stores/AddressStore.swift
@@ -12,13 +12,15 @@ public struct AddressStore: Sendable {
         self.db = db.dbQueue
     }
     
-    public func addAddress(chain: Chain, address: String, name: String) throws {
+    public func addAddressNames(_ addressNames: [AddressName]) throws {
         try db.write { db in
-            try AddressRecord(
-                chain: chain,
-                address: address,
-                name: name
-            ).save(db, onConflict: .replace)
+            for addressName in addressNames {
+                try AddressRecord(
+                    chain: addressName.chain,
+                    address: addressName.address,
+                    name: addressName.name
+                ).save(db, onConflict: .replace)
+            }
         }
     }
     

--- a/Packages/Store/TestKit/AddressStore+TestKit.swift
+++ b/Packages/Store/TestKit/AddressStore+TestKit.swift
@@ -1,0 +1,10 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Store
+
+extension AddressStore {
+    public static func mock(db: DB = .mock()) -> Self {
+        AddressStore(db: db)
+    }
+}

--- a/Services/TransactionsService/TestKit/TransactionsService+TestKit.swift
+++ b/Services/TransactionsService/TestKit/TransactionsService+TestKit.swift
@@ -12,7 +12,8 @@ public extension TransactionsService {
             transactionStore: .mock(),
             assetsService: .mock(),
             walletStore: .mock(),
-            deviceService: DeviceServiceMock()
+            deviceService: DeviceServiceMock(),
+            addressStore: .mock()
         )
     }
 }


### PR DESCRIPTION
## Summary
- Integrate v2 transactions endpoints with address names storage functionality
- Update API endpoint from `/v1/transactions` to `/v2/transactions`
- Change response structure from `[Transaction]` to `TransactionsResponse`
- Add address names storage functionality to `AddressStore`
- Update `TransactionsService` to handle and store address names

## Changes Made
### API Layer
- **GemAPI.swift**: Updated endpoint from `/v1/transactions` to `/v2/transactions`
- **GemAPIService.swift**: Updated `GemAPITransactionService` protocol to return `TransactionsResponse`
- **GemAPIService.swift**: Updated service implementation to map to `TransactionsResponse.self`

### Storage Layer
- **AddressStore.swift**: Added `addAddressNames` method to store multiple address names
- **AddressStore+TestKit.swift**: Created mock following established patterns

### Service Layer
- **TransactionsService.swift**: Added `AddressStore` dependency and address storage logic
- **ServicesFactory.swift**: Updated dependency injection to provide `AddressStore`
- **TransactionsService+TestKit.swift**: Updated mock to include `AddressStore`

## Technical Details
The v2 transactions endpoint returns a `TransactionsResponse` struct containing:
- `transactions: [Transaction]` - The transaction data
- `addressNames: [AddressName]` - Associated address names for improved UX

This enables the app to display human-readable names for addresses instead of raw addresses.

## Test Plan
- [x] Build succeeds without compilation errors
- [x] All existing tests continue to pass
- [x] New mock implementations follow established patterns
- [x] Dependency injection works correctly
- [x] Address names are properly stored when transactions are fetched

## Related Issue
Closes #983

🤖 Generated with [Claude Code](https://claude.ai/code)