### PR TITLE
Integrate AddressRecord display on confirmation screens

### DIFF
--- a/Features/Transfer/Package.swift
+++ b/Features/Transfer/Package.swift
@@ -45,7 +45,8 @@ let package = Package(
         .package(name: "BalanceService", path: "../../Services/BalanceService"),
         .package(name: "PriceService", path: "../../Services/PriceService"),
         .package(name: "ExplorerService", path: "../../Services/ExplorerService"),
-        .package(name: "SwapService", path: "../../Services/SwapService")
+        .package(name: "SwapService", path: "../../Services/SwapService"),
+        .package(name: "AddressNameService", path: "../../Services/AddressNameService")
     ],
     targets: [
         .target(
@@ -81,7 +82,8 @@ let package = Package(
                 "BalanceService",
                 "PriceService",
                 "ExplorerService",
-                "SwapService"
+                "SwapService",
+                "AddressNameService"
             ],
             path: "Sources"
         ),

--- a/Features/Transfer/Package.swift
+++ b/Features/Transfer/Package.swift
@@ -99,6 +99,7 @@ let package = Package(
                 .product(name: "ScanServiceTestKit", package: "ScanService"),
                 .product(name: "SwapServiceTestKit", package: "SwapService"),
                 .product(name: "KeystoreTestKit", package: "Keystore"),
+                .product(name: "AddressNameServiceTestKit", package: "AddressNameService"),
             ],
             path: "Tests"
         ),

--- a/Features/Transfer/Sources/Navigation/RecipientNavigationView.swift
+++ b/Features/Transfer/Sources/Navigation/RecipientNavigationView.swift
@@ -55,6 +55,7 @@ public struct RecipientNavigationView: View {
                         keystore: model.keystore,
                         swapService: model.swapService
                     ),
+                    addressNameService: model.addressNameService,
                     onComplete: onComplete
                 )
             )

--- a/Features/Transfer/Sources/ViewModels/ConfirmTransferViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmTransferViewModel.swift
@@ -19,6 +19,7 @@ import SwapService
 import Style
 import SwiftUI
 import Formatters
+import AddressNameService
 
 @Observable
 @MainActor
@@ -55,6 +56,7 @@ public final class ConfirmTransferViewModel {
     private let transerExecutor: any TransferExecutable
     private let keystore: any Keystore
     private let swapService: SwapService
+    private let addressNameService: AddressNameService
 
     private let wallet: Wallet
     private let onComplete: VoidAction
@@ -73,6 +75,7 @@ public final class ConfirmTransferViewModel {
         walletsService: WalletsService,
         swapDataProvider: any SwapQuoteDataProvidable,
         explorerService: any ExplorerLinkFetchable = ExplorerService.standard,
+        addressNameService: AddressNameService,
         confirmTransferDelegate: TransferDataCallback.ConfirmTransferDelegate? = .none,
         onComplete: VoidAction
     ) {
@@ -100,6 +103,7 @@ public final class ConfirmTransferViewModel {
             swapService: swapService
         )
         self.swapService = swapService
+        self.addressNameService = addressNameService
 
         self.transerExecutor = TransferExecutor(
             signer: TransactionSigner(keystore: keystore),
@@ -399,7 +403,7 @@ extension ConfirmTransferViewModel {
         )
     }
 
-    private var dataModel: TransferDataViewModel { TransferDataViewModel(data: data) }
+    private var dataModel: TransferDataViewModel { TransferDataViewModel(data: data, addressNameService: addressNameService) }
     private var availableValue: BigInt { dataModel.availableValue(metadata: metadata) }
     private var senderLink: BlockExplorerLink { explorerService.addressUrl(chain: dataModel.chain, address: senderAddress) }
     private var feeAssetAddress: AssetAddress { AssetAddress(asset: dataModel.asset.feeAsset, address: senderAddress)}

--- a/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
@@ -17,6 +17,7 @@ import SwiftUI
 import ScanService
 import Formatters
 import SwapService
+import AddressNameService
 
 public typealias RecipientDataAction = ((RecipientData) -> Void)?
 
@@ -29,6 +30,7 @@ public final class RecipientSceneViewModel {
     let stakeService: StakeService
     let scanService: ScanService
     let swapService: SwapService
+    let addressNameService: AddressNameService
 
     let wallet: Wallet
     let asset: Asset
@@ -57,6 +59,7 @@ public final class RecipientSceneViewModel {
         scanService: ScanService,
         swapService: SwapService,
         type: RecipientAssetType,
+        addressNameService: AddressNameService,
         onRecipientDataAction: RecipientDataAction,
         onTransferAction: TransferDataAction
     ) {
@@ -70,6 +73,7 @@ public final class RecipientSceneViewModel {
         self.stakeService = stakeService
         self.scanService = scanService
         self.swapService = swapService
+        self.addressNameService = addressNameService
 
         self.type = type
         self.onRecipientDataAction = onRecipientDataAction

--- a/Features/Transfer/Sources/ViewModels/TransferDataViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/TransferDataViewModel.swift
@@ -6,12 +6,15 @@ import Localization
 import PrimitivesComponents
 import Components
 import BigInt
+import AddressNameService
 
 struct TransferDataViewModel {
     let data: TransferData
+    let addressNameService: AddressNameService
 
-    init(data: TransferData) {
+    init(data: TransferData, addressNameService: AddressNameService) {
         self.data = data
+        self.addressNameService = addressNameService
     }
 
     var type: TransferDataType { data.type }
@@ -171,8 +174,7 @@ extension TransferDataViewModel {
                 .swap,
                 .tokenApprove,
                 .generic,
-                .account:
-            recipient.name ?? recipient.address
+                .account: getRecipientName()
         case .stake(_, let stakeType):
             switch stakeType {
             case .stake(let validator):
@@ -187,5 +189,11 @@ extension TransferDataViewModel {
                     .none
             }
         }
+    }
+    
+    private func getRecipientName() -> String {
+        recipient.name ??
+        (try? addressNameService.getAddressName(chain: chain, address: recipient.address)?.name) ??
+        recipient.address
     }
 }

--- a/Features/Transfer/Tests/ViewModels/ConfirmTransferViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmTransferViewModelTests.swift
@@ -16,6 +16,7 @@ import Localization
 import Preferences
 import PreferencesTestKit
 import GemAPI
+import AddressNameServiceTestKit
 
 @MainActor
 struct ConfirmTransferViewModelTests {
@@ -58,6 +59,7 @@ private extension ConfirmTransferViewModel {
             swapService: .mock(),
             walletsService: .mock(),
             swapDataProvider: .mock(),
+            addressNameService: .mock(),
             onComplete: {}
         )
     }

--- a/Features/Transfer/Tests/ViewModels/TransferDataViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/TransferDataViewModelTests.swift
@@ -3,6 +3,7 @@
 import Testing
 @testable import Transfer
 @testable import Primitives
+import AddressNameServiceTestKit
 
 struct TransferDataViewModelTests {
 
@@ -23,7 +24,8 @@ private extension TransferDataViewModel {
         type: TransferDataType = .transfer(.mock())
     ) -> TransferDataViewModel {
         return TransferDataViewModel(
-            data: TransferData.mock(type: type)
+            data: TransferData.mock(type: type),
+            addressNameService: .mock()
         )
     }
 }

--- a/Features/Transfer/Tests/ViewModels/TransferDataViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/TransferDataViewModelTests.swift
@@ -4,28 +4,52 @@ import Testing
 @testable import Transfer
 @testable import Primitives
 import AddressNameServiceTestKit
+import StoreTestKit
+import AddressNameService
+import Store
 
 struct TransferDataViewModelTests {
 
     @Test
     func testShouldShowMemo() {
-        #expect(TransferDataViewModel.mock(type: .transfer(.mock(id: .mockEthereum()))).shouldShowMemo == false)
-        #expect(TransferDataViewModel.mock(type: .transfer(.mock(id: .mockSolana()))).shouldShowMemo == true)
-        #expect(TransferDataViewModel.mock(type: .transfer(.mock(id: .mockSolana()))).shouldShowMemo == true)
+        #expect(TransferDataViewModel.mock(data: .mock(type: .transfer(.mock(id: .mockEthereum())))).shouldShowMemo == false)
+        #expect(TransferDataViewModel.mock(data: .mock(type: .transfer(.mock(id: .mockSolana())))).shouldShowMemo == true)
+        #expect(TransferDataViewModel.mock(data: .mock(type: .transfer(.mock(id: .mockSolana())))).shouldShowMemo == true)
         
-        #expect(TransferDataViewModel.mock(type: .transferNft(.mock())).shouldShowMemo == false)
-        #expect(TransferDataViewModel.mock(type: .transferNft(.mock())).shouldShowMemo == false)
-        #expect(TransferDataViewModel.mock(type: .transferNft(.mock())).shouldShowMemo == false)
+        #expect(TransferDataViewModel.mock(data: .mock(type: .transferNft(.mock()))).shouldShowMemo == false)
+        #expect(TransferDataViewModel.mock(data: .mock(type: .transferNft(.mock()))).shouldShowMemo == false)
+        #expect(TransferDataViewModel.mock(data: .mock(type: .transferNft(.mock()))).shouldShowMemo == false)
+    }
+    
+    @Test
+    func recipientNameUsesStoredAddressName() throws {
+        let addressName = AddressName.mock(chain: .ethereum)
+        let db = DB.mockAssets()
+        
+        let addressStore = AddressStore.mock(db: db)
+        try addressStore.addAddressNames([addressName])
+        let addressNameService = AddressNameService.mock(addressStore: addressStore)
+        
+        let viewModel = TransferDataViewModel.mock(
+            data: .mock(
+                type: .transfer(.mockEthereum()),
+                recipientData: .mock(recipient: .mock(address: addressName.address))
+            ),
+            addressNameService: addressNameService
+        )
+        
+        #expect(viewModel.recepientAccount.name == addressName.name)
     }
 }
 
 private extension TransferDataViewModel {
     static func mock(
-        type: TransferDataType = .transfer(.mock())
+        data: TransferData = .mock(),
+        addressNameService: AddressNameService = .mock()
     ) -> TransferDataViewModel {
-        return TransferDataViewModel(
-            data: TransferData.mock(type: type),
-            addressNameService: .mock()
+        TransferDataViewModel(
+            data: data,
+            addressNameService: addressNameService
         )
     }
 }

--- a/Gem.xcodeproj/project.pbxproj
+++ b/Gem.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		B62F6B9D2DE61ADF00AF56AB /* Onboarding in Frameworks */ = {isa = PBXBuildFile; productRef = B62F6B9C2DE61ADF00AF56AB /* Onboarding */; };
 		B62F6C4F2DE6F0FD00AF56AB /* AssetsServiceTestKit in Frameworks */ = {isa = PBXBuildFile; productRef = B62F6C4E2DE6F0FD00AF56AB /* AssetsServiceTestKit */; };
 		B66AFC6C2DDB260A0082C026 /* AppService in Frameworks */ = {isa = PBXBuildFile; productRef = B66AFC6B2DDB260A0082C026 /* AppService */; };
+		B66B5A622E2A51C000EC9B3A /* AddressNameService in Frameworks */ = {isa = PBXBuildFile; productRef = B66B5A612E2A51C000EC9B3A /* AddressNameService */; };
 		B66DEDB02D49F0EA00309D53 /* ImageGalleryService in Frameworks */ = {isa = PBXBuildFile; productRef = B66DEDAF2D49F0EA00309D53 /* ImageGalleryService */; };
 		B67ED5472DDB5DCC009F74E6 /* NotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67ED5462DDB5DCC009F74E6 /* NotificationHandler.swift */; };
 		B68BD2AA2DDF5FF900687F09 /* WalletServiceTestKit in Frameworks */ = {isa = PBXBuildFile; productRef = B68BD2A92DDF5FF900687F09 /* WalletServiceTestKit */; };
@@ -219,6 +220,7 @@
 		B617D6092D5B73B7001697A6 /* AvatarService */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AvatarService; sourceTree = "<group>"; };
 		B61C5C152D5FB899007699EC /* WalletAvatar */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = WalletAvatar; sourceTree = "<group>"; };
 		B66AFC6A2DDB14D50082C026 /* AppService */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AppService; sourceTree = "<group>"; };
+		B66B5A602E2A4F7A00EC9B3A /* AddressNameService */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AddressNameService; sourceTree = "<group>"; };
 		B66DEDAE2D49F0C600309D53 /* ImageGalleryService */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = ImageGalleryService; sourceTree = "<group>"; };
 		B67ED5462DDB5DCC009F74E6 /* NotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHandler.swift; sourceTree = "<group>"; };
 		B6B86A0F2D702E7C00D31D65 /* SwapNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapNavigationView.swift; sourceTree = "<group>"; };
@@ -365,6 +367,7 @@
 				836281B02DEF34DC00CA5C75 /* Assets in Frameworks */,
 				C35DA07C2A9C3B4B008CCEFA /* Settings in Frameworks */,
 				83EB5E302D2ECF00006A7CFB /* Onboarding in Frameworks */,
+				B66B5A622E2A51C000EC9B3A /* AddressNameService in Frameworks */,
 				839C794D2D1C42AE00E32072 /* ChainSettings in Frameworks */,
 				DF93C4EE2C969F4F00204ABD /* Gemstone in Frameworks */,
 				83EF67E52E005F48009C690F /* Formatters in Frameworks */,
@@ -674,6 +677,7 @@
 		D829BF4B2CBF022700DEB2E8 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				B66B5A602E2A4F7A00EC9B3A /* AddressNameService */,
 				B66AFC6A2DDB14D50082C026 /* AppService */,
 				8399EC4F2DB67EC50020C0A6 /* WalletService */,
 				8391FE572D7F4D9F0057A548 /* WalletSessionService */,
@@ -854,6 +858,7 @@
 				836281AF2DEF34DC00CA5C75 /* Assets */,
 				8327CBF02DF9E088000BF1E1 /* Validators */,
 				83EF67E42E005F48009C690F /* Formatters */,
+				B66B5A612E2A51C000EC9B3A /* AddressNameService */,
 			);
 			productName = wallet;
 			productReference = C30952B0299C39D70004C0F9 /* Gem.app */;
@@ -1825,6 +1830,10 @@
 		B66AFC6B2DDB260A0082C026 /* AppService */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AppService;
+		};
+		B66B5A612E2A51C000EC9B3A /* AddressNameService */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AddressNameService;
 		};
 		B66DEDAF2D49F0EA00309D53 /* ImageGalleryService */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
@@ -21,6 +21,7 @@ struct SelectAssetSceneNavigationStack: View {
     @Environment(\.stakeService) private var stakeService
     @Environment(\.scanService) private var scanService
     @Environment(\.swapService) private var swapService
+    @Environment(\.addressNameService) private var addressNameService
 
     @State private var isPresentingFilteringView: Bool = false
 
@@ -79,6 +80,7 @@ struct SelectAssetSceneNavigationStack: View {
                             scanService: scanService,
                             swapService: swapService,
                             type: .asset(input.asset),
+                            addressNameService: addressNameService,
                             onRecipientDataAction: {
                                 navigationPath.append($0)
                             },

--- a/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
@@ -20,6 +20,7 @@ struct SelectedAssetNavigationStack: View  {
     @Environment(\.stakeService) private var stakeService
     @Environment(\.scanService) private var scanService
     @Environment(\.swapService) private var swapService
+    @Environment(\.addressNameService) private var addressNameService
 
     @State private var navigationPath = NavigationPath()
 
@@ -54,6 +55,7 @@ struct SelectedAssetNavigationStack: View  {
                             scanService: scanService,
                             swapService: swapService,
                             type: type,
+                            addressNameService: addressNameService,
                             onRecipientDataAction: {
                                 navigationPath.append($0)
                             },

--- a/Gem/Navigation/Staking/StakeNavigationView.swift
+++ b/Gem/Navigation/Staking/StakeNavigationView.swift
@@ -16,6 +16,7 @@ struct StakeNavigationView: View {
     @Environment(\.walletsService) private var walletsService
     @Environment(\.scanService) private var scanService
     @Environment(\.swapService) private var swapService
+    @Environment(\.addressNameService) private var addressNameService
 
     private let wallet: Wallet
     private let assetId: AssetId
@@ -65,6 +66,7 @@ struct StakeNavigationView: View {
                         keystore: keystore,
                         swapService: swapService
                     ),
+                    addressNameService: addressNameService,
                     onComplete: onComplete
                 )
             )

--- a/Gem/Navigation/Swap/SwapNavigationView.swift
+++ b/Gem/Navigation/Swap/SwapNavigationView.swift
@@ -17,6 +17,7 @@ struct SwapNavigationView: View {
     @Environment(\.priceAlertService) private var priceAlertService
     @Environment(\.scanService) private var scanService
     @Environment(\.swapService) private var swapService
+    @Environment(\.addressNameService) private var addressNameService
 
     @State private var model: SwapSceneViewModel
 
@@ -47,6 +48,7 @@ struct SwapNavigationView: View {
                             keystore: keystore,
                             swapService: swapService
                         ),
+                        addressNameService: addressNameService,
                         onComplete: {
                             onSwapComplete(type: data.type)
                         }

--- a/Gem/Navigation/Transfer/ConfirmTransferNavigationStack.swift
+++ b/Gem/Navigation/Transfer/ConfirmTransferNavigationStack.swift
@@ -15,6 +15,7 @@ struct ConfirmTransferNavigationStack: View {
     @Environment(\.nodeService) private var nodeService
     @Environment(\.scanService) private var scanService
     @Environment(\.swapService) private var swapService
+    @Environment(\.addressNameService) private var addressNameService
 
     private let wallet: Wallet
     private let transferData: TransferData
@@ -46,6 +47,7 @@ struct ConfirmTransferNavigationStack: View {
                         keystore: keystore,
                         swapService: swapService
                     ),
+                    addressNameService: addressNameService,
                     onComplete: onComplete
                 )
             )

--- a/Gem/Navigation/WalletConnector/WalletConnectorNavigationStack.swift
+++ b/Gem/Navigation/WalletConnector/WalletConnectorNavigationStack.swift
@@ -15,6 +15,7 @@ struct WalletConnectorNavigationStack: View {
     @Environment(\.scanService) private var scanService
     @Environment(\.nodeService) private var nodeService
     @Environment(\.swapService) private var swapService
+    @Environment(\.addressNameService) private var addressNameService
 
     private let type: WalletConnectorSheetType
     private let presenter: WalletConnectorPresenter
@@ -46,6 +47,7 @@ struct WalletConnectorNavigationStack: View {
                                 keystore: keystore,
                                 swapService: swapService
                             ),
+                            addressNameService: addressNameService,
                             confirmTransferDelegate: data.delegate,
                             onComplete: { presenter.complete(type: type) }
                         )

--- a/Gem/Services/AppResolver+Services.swift
+++ b/Gem/Services/AppResolver+Services.swift
@@ -21,6 +21,7 @@ import ScanService
 import NFTService
 import AvatarService
 import SwapService
+import AddressNameService
 
 extension AppResolver {
     struct Services: Sendable {
@@ -52,6 +53,7 @@ extension AppResolver {
         let onstartService: OnstartService
         let onstartAsyncService: OnstartAsyncService
         let walletConnectorManager: WalletConnectorManager
+        let addressNameService: AddressNameService
 
         init(
             assetsService: AssetsService,
@@ -80,7 +82,8 @@ extension AppResolver {
             deviceObserverService: DeviceObserverService,
             onstartService: OnstartService,
             onstartAsyncService: OnstartAsyncService,
-            walletConnectorManager: WalletConnectorManager
+            walletConnectorManager: WalletConnectorManager,
+            addressNameService: AddressNameService
         ) {
             self.assetsService = assetsService
             self.balanceService = balanceService
@@ -109,6 +112,7 @@ extension AppResolver {
             self.onstartService = onstartService
             self.onstartAsyncService = onstartAsyncService
             self.walletConnectorManager = walletConnectorManager
+            self.addressNameService = addressNameService
         }
     }
 }

--- a/Gem/Services/ServicesFactory.swift
+++ b/Gem/Services/ServicesFactory.swift
@@ -28,6 +28,7 @@ import WalletSessionService
 import AppService
 import ScanService
 import SwapService
+import AddressNameService
 
 struct ServicesFactory {
     func makeServices(storages: AppResolver.Storages) -> AppResolver.Services {
@@ -165,6 +166,9 @@ struct ServicesFactory {
             configService: configService,
             releaseService: AppReleaseService(configService: configService)
         )
+        let addressNameService = AddressNameService(
+            addressStore: storeManager.addressStore
+        )
 
         return AppResolver.Services(
             assetsService: assetsService,
@@ -193,7 +197,8 @@ struct ServicesFactory {
             deviceObserverService: deviceObserverService,
             onstartService: onStartService,
             onstartAsyncService: onstartAsyncService,
-            walletConnectorManager: walletConnectorManager
+            walletConnectorManager: walletConnectorManager,
+            addressNameService: addressNameService
         )
     }
 }

--- a/Gem/Services/ServicesFactory.swift
+++ b/Gem/Services/ServicesFactory.swift
@@ -82,7 +82,8 @@ struct ServicesFactory {
             transactionStore: storeManager.transactionStore,
             assetsService: assetsService,
             walletStore: storeManager.walletStore,
-            deviceService: deviceService
+            deviceService: deviceService,
+            addressStore: storeManager.addressStore
         )
         let transactionService = Self.makeTransactionService(
             transactionStore: storeManager.transactionStore,
@@ -284,13 +285,15 @@ extension ServicesFactory {
         transactionStore: TransactionStore,
         assetsService: AssetsService,
         walletStore: WalletStore,
-        deviceService: any DeviceServiceable
+        deviceService: any DeviceServiceable,
+        addressStore: AddressStore
     ) -> TransactionsService {
         TransactionsService(
             transactionStore: transactionStore,
             assetsService: assetsService,
             walletStore: walletStore,
-            deviceService: deviceService
+            deviceService: deviceService,
+            addressStore: addressStore
         )
     }
 

--- a/Gem/Types/Environment.swift
+++ b/Gem/Types/Environment.swift
@@ -26,6 +26,7 @@ import AvatarService
 import AppService
 import ScanService
 import SwapService
+import AddressNameService
 
 extension EnvironmentValues {
     @Entry var navigationState: NavigationStateManager = AppResolver.main.navigation
@@ -51,4 +52,5 @@ extension EnvironmentValues {
     @Entry var releaseService: AppReleaseService = AppResolver.main.services.appReleaseService
     @Entry var scanService: ScanService = AppResolver.main.services.scanService
     @Entry var swapService: SwapService = AppResolver.main.services.swapService
+    @Entry var addressNameService: AddressNameService = AppResolver.main.services.addressNameService
 }

--- a/Packages/GemAPI/Sources/GemAPI.swift
+++ b/Packages/GemAPI/Sources/GemAPI.swift
@@ -108,7 +108,7 @@ public enum GemAPI: TargetType {
         case .updateDevice(let device):
             return "/v1/devices/\(device.id)"
         case .getTransactions(let deviceId, _):
-            return "/v1/transactions/device/\(deviceId)"
+            return "/v2/transactions/device/\(deviceId)"
         case .getAsset(let id):
             return "/v1/assets/\(id.identifier.replacingOccurrences(of: "/", with: "%2F"))"
         case .getAssets:

--- a/Packages/GemAPI/Sources/GemAPIService.swift
+++ b/Packages/GemAPI/Sources/GemAPIService.swift
@@ -51,8 +51,8 @@ public protocol GemAPISubscriptionService: Sendable {
 }
 
 public protocol GemAPITransactionService: Sendable {
-    func getTransactionsAll(deviceId: String, walletIndex: Int, fromTimestamp: Int) async throws -> [Primitives.Transaction]
-    func getTransactionsForAsset(deviceId: String, walletIndex: Int, asset: AssetId, fromTimestamp: Int) async throws -> [Primitives.Transaction]
+    func getTransactionsAll(deviceId: String, walletIndex: Int, fromTimestamp: Int) async throws -> TransactionsResponse
+    func getTransactionsForAsset(deviceId: String, walletIndex: Int, asset: AssetId, fromTimestamp: Int) async throws -> TransactionsResponse
 }
 
 public protocol GemAPIPriceAlertService: Sendable {
@@ -166,18 +166,18 @@ extension GemAPIService: GemAPISubscriptionService {
 }
 
 extension GemAPIService: GemAPITransactionService {
-    public func getTransactionsForAsset(deviceId: String, walletIndex: Int, asset: Primitives.AssetId, fromTimestamp: Int) async throws -> [Primitives.Transaction] {
+    public func getTransactionsForAsset(deviceId: String, walletIndex: Int, asset: Primitives.AssetId, fromTimestamp: Int) async throws -> TransactionsResponse {
         let options = TransactionsFetchOption(wallet_index: walletIndex.asInt32, asset_id: asset.identifier, from_timestamp: fromTimestamp.asUInt32)
         return try await provider
             .request(.getTransactions(deviceId: deviceId, options: options))
-            .map(as: [Primitives.Transaction].self)
+            .map(as: TransactionsResponse.self)
     }
     
-    public func getTransactionsAll(deviceId: String, walletIndex: Int, fromTimestamp: Int) async throws -> [Primitives.Transaction] {
+    public func getTransactionsAll(deviceId: String, walletIndex: Int, fromTimestamp: Int) async throws -> TransactionsResponse {
         let options = TransactionsFetchOption(wallet_index: walletIndex.asInt32, asset_id: .none, from_timestamp: fromTimestamp.asUInt32)
         return try await provider
             .request(.getTransactions(deviceId: deviceId, options: options))
-            .map(as: [Primitives.Transaction].self)
+            .map(as: TransactionsResponse.self)
     }
 }
 

--- a/Packages/Primitives/TestKit/TransferData+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/TransferData+PrimitivesTestKit.swift
@@ -7,11 +7,12 @@ import BigInt
 extension TransferData {
     public static func mock(
         type: TransferDataType = .transfer(.mock()),
-        value: BigInt = .zero
+        value: BigInt = .zero,
+        recipientData: RecipientData = .mock()
     ) -> Self {
         .init(
             type: type,
-            recipientData: .mock(),
+            recipientData: recipientData,
             value: value,
             canChangeValue: false,
             ignoreValueCheck: type.shouldIgnoreValueCheck

--- a/Packages/Store/Sources/Migrations.swift
+++ b/Packages/Store/Sources/Migrations.swift
@@ -272,7 +272,7 @@ public struct Migrations {
         }
         
         migrator.registerMigration("Add \(AddressRecord.databaseTableName) table33") { db in
-            try db.drop(table: AddressRecord.databaseTableName)
+            try? db.drop(table: AddressRecord.databaseTableName)
             try AddressRecord.create(db: db)
         }
         

--- a/Packages/Store/Sources/Stores/AddressStore.swift
+++ b/Packages/Store/Sources/Stores/AddressStore.swift
@@ -24,6 +24,16 @@ public struct AddressStore: Sendable {
         }
     }
     
+    public func getAddressName(chain: Chain, address: String) throws -> AddressName? {
+        try db.read { db in
+            try AddressRecord
+                .filter(AddressRecord.Columns.chain == chain.rawValue)
+                .filter(AddressRecord.Columns.address == address)
+                .fetchOne(db)
+                .map { $0.asPrimitive() }
+        }
+    }
+    
     public func deleteAddress(chain: Chain, address: String) throws -> Int {
         try db.write { db in
             try AddressRecord

--- a/Packages/Store/Sources/Stores/AddressStore.swift
+++ b/Packages/Store/Sources/Stores/AddressStore.swift
@@ -12,13 +12,15 @@ public struct AddressStore: Sendable {
         self.db = db.dbQueue
     }
     
-    public func addAddress(chain: Chain, address: String, name: String) throws {
+    public func addAddressNames(_ addressNames: [AddressName]) throws {
         try db.write { db in
-            try AddressRecord(
-                chain: chain,
-                address: address,
-                name: name
-            ).save(db, onConflict: .replace)
+            for addressName in addressNames {
+                try AddressRecord(
+                    chain: addressName.chain,
+                    address: addressName.address,
+                    name: addressName.name
+                ).save(db, onConflict: .replace)
+            }
         }
     }
     

--- a/Packages/Store/TestKit/AddressStore+TestKit.swift
+++ b/Packages/Store/TestKit/AddressStore+TestKit.swift
@@ -1,0 +1,10 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Store
+
+extension AddressStore {
+    public static func mock(db: DB = .mock()) -> Self {
+        AddressStore(db: db)
+    }
+}

--- a/Services/AddressNameService/.gitignore
+++ b/Services/AddressNameService/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Services/AddressNameService/Package.swift
+++ b/Services/AddressNameService/Package.swift
@@ -1,0 +1,48 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "AddressNameService",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v12)
+    ],
+    products: [
+        .library(
+            name: "AddressNameService",
+            targets: ["AddressNameService"]),
+        .library(
+            name: "AddressNameServiceTestKit",
+            targets: ["AddressNameServiceTestKit"]
+        ),
+    ],
+    dependencies: [
+        .package(name: "Primitives", path: "../../Packages/Primitives"),
+        .package(name: "Store", path: "../../Packages/Store"),
+    ],
+    targets: [
+        .target(
+            name: "AddressNameService",
+            dependencies: [
+                "Primitives",
+                "Store",
+            ],
+            path: "Sources"
+        ),
+        .target(
+            name: "AddressNameServiceTestKit",
+            dependencies: [
+                .product(name: "StoreTestKit", package: "Store"),
+                "Primitives",
+            ],
+            path: "TestKit"
+        ),
+        .testTarget(
+            name: "AddressNameServiceTests",
+            dependencies: [
+                "AddressNameServiceTestKit"
+            ]
+        ),
+    ]
+)

--- a/Services/AddressNameService/Sources/AddressNameService.swift
+++ b/Services/AddressNameService/Sources/AddressNameService.swift
@@ -1,0 +1,17 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Store
+import Primitives
+
+public struct AddressNameService: Sendable {
+    private let addressStore: AddressStore
+    
+    public init(addressStore: AddressStore) {
+        self.addressStore = addressStore
+    }
+    
+    public func getAddressName(chain: Chain, address: String) throws -> AddressName? {
+        try addressStore.getAddressName(chain: chain, address: address)
+    }
+}

--- a/Services/AddressNameService/TestKit/AddressNameService+TestKit.swift
+++ b/Services/AddressNameService/TestKit/AddressNameService+TestKit.swift
@@ -1,0 +1,12 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import AddressNameService
+import Store
+import StoreTestKit
+
+public extension AddressNameService {
+    static func mock(addressStore: AddressStore = .mock()) -> AddressNameService {
+        AddressNameService(addressStore: addressStore)
+    }
+}

--- a/Services/AddressNameService/Tests/AddressNameServiceTests/AddressNameServiceTests.swift
+++ b/Services/AddressNameService/Tests/AddressNameServiceTests/AddressNameServiceTests.swift
@@ -1,0 +1,6 @@
+import Testing
+@testable import AddressNameService
+
+@Test func example() async throws {
+    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+}

--- a/Services/TransactionsService/TestKit/TransactionsService+TestKit.swift
+++ b/Services/TransactionsService/TestKit/TransactionsService+TestKit.swift
@@ -12,7 +12,8 @@ public extension TransactionsService {
             transactionStore: .mock(),
             assetsService: .mock(),
             walletStore: .mock(),
-            deviceService: DeviceServiceMock()
+            deviceService: DeviceServiceMock(),
+            addressStore: .mock()
         )
     }
 }


### PR DESCRIPTION
## Summary
- Integrate AddressRecord display functionality on confirmation screens
- Create AddressNameService for address name lookup functionality
- Update transfer confirmation screens to display human-readable address names

⚠️ **Note**: This PR depends on resolving issue #989 first, as the current implementation may not work correctly with Wallet Connect ERC-20 transactions that show contract addresses instead of recipient addresses.

## Changes Made
### New Service Layer
- **AddressNameService**: Created new service package for address name lookups
- **AddressStore Enhancement**: Added `getAddressName` method to retrieve stored address names
- **TestKit Support**: Added comprehensive mock support for the new service

### Transfer UI Integration
- **ConfirmTransferViewModel**: Updated to use AddressNameService for displaying names
- **TransferDataViewModel**: Enhanced to show address names instead of raw addresses
- **Navigation Updates**: Modified navigation stacks to pass AddressNameService dependency

### Dependency Injection
- **AppResolver**: Added AddressNameService to the services container
- **ServicesFactory**: Updated to create and inject AddressNameService
- **Environment**: Added service to SwiftUI environment

## Technical Details
The implementation follows a clean architecture pattern:
1. **AddressNameService** acts as a facade over AddressStore
2. **Service Integration** through proper dependency injection
3. **UI Enhancement** showing human-readable names when available
4. **Fallback Behavior** displays raw address when no name is stored

## User Experience
- Transfer confirmation screens now show meaningful address names
- Improved readability for users when confirming transactions
- Seamless fallback to addresses when names aren't available

## Dependencies
- **Blocked by**: #989 - Wallet Connect shows contract address instead of recipient address
- **Reason**: The AddressNameService will look up names for the displayed address, but if the wrong address is being displayed (contract vs recipient), the name lookup will fail

## Test Plan
- [ ] Build and run the app successfully
- [ ] Verify transfer screens display address names when available
- [ ] Test fallback to raw addresses works properly
- [ ] Confirm dependency injection works across navigation stacks
- [ ] Validate TestKit mocks follow established patterns
- [ ] Test address name lookup functionality
- [ ] Verify UI displays correctly on confirmation screens
- [ ] **Critical**: Test with Wallet Connect ERC-20 transactions after #989 is resolved

## Files Changed
- **New Package**: `Services/AddressNameService/`
- **Enhanced Store**: `Packages/Store/Sources/Stores/AddressStore.swift`
- **Transfer UI**: `Features/Transfer/Sources/ViewModels/`
- **Navigation**: `Gem/Navigation/` (multiple files)
- **Service Layer**: `Gem/Services/` (AppResolver, ServicesFactory)

## Related Issues
- Addresses #984
- Depends on #989

Close: https://github.com/gemwalletcom/gem-ios/issues/984

🤖 Generated with [Claude Code](https://claude.ai/code)