### PR TITLE
Add underlayingError extension to SwapperError

### DIFF
--- a/Features/Swap/Sources/Errors/ErrorWrapper+Swap.swift
+++ b/Features/Swap/Sources/Errors/ErrorWrapper+Swap.swift
@@ -1,8 +1,8 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Localization
 import enum Gemstone.SwapperError
+import Localization
 
 public struct ErrorWrapper: Error, LocalizedError {
     public let error: Error
@@ -27,9 +27,32 @@ public struct ErrorWrapper: Error, LocalizedError {
                  .NotImplemented,
                  .ComputeQuoteError,
                  .InvalidRoute,
-                 .TransactionError: error.localizedDescription
+                 .TransactionError: swapperError.underlayingError
             }
         default: error.localizedDescription
+        }
+    }
+}
+
+public extension Gemstone.SwapperError {
+    var underlayingError: String {
+        switch self {
+        case .NotSupportedChain,
+             .NotSupportedAsset,
+             .NotSupportedPair,
+             .NoAvailableProvider,
+             .InputAmountTooSmall,
+             .InvalidRoute,
+             .NoQuoteAvailable,
+             .NotImplemented:
+            return localizedDescription
+        case .InvalidAddress(let error),
+             .InvalidAmount(let error),
+             .NetworkError(let error),
+             .AbiError(let error),
+             .ComputeQuoteError(let error),
+             .TransactionError(let error):
+            return error
         }
     }
 }

--- a/Features/Swap/Sources/Errors/ErrorWrapper+Swap.swift
+++ b/Features/Swap/Sources/Errors/ErrorWrapper+Swap.swift
@@ -27,7 +27,7 @@ public struct ErrorWrapper: Error, LocalizedError {
                  .NotImplemented,
                  .ComputeQuoteError,
                  .InvalidRoute,
-                 .TransactionError: swapperError.underlayingError
+                 .TransactionError: swapperError.underlyingError
             }
         default: error.localizedDescription
         }
@@ -35,7 +35,7 @@ public struct ErrorWrapper: Error, LocalizedError {
 }
 
 public extension Gemstone.SwapperError {
-    var underlayingError: String {
+    var underlyingError: String {
         switch self {
         case .NotSupportedChain,
              .NotSupportedAsset,

--- a/Features/Swap/Tests/SwapTests/SwapperErrorTests.swift
+++ b/Features/Swap/Tests/SwapTests/SwapperErrorTests.swift
@@ -15,4 +15,12 @@ struct SwapperErrorTests {
         #expect(SwapperError.NotSupportedChain.isRetryAvailable == false)
         #expect(SwapperError.InvalidAmount("").isRetryAvailable == false)
     }
+    
+    @Test
+    func underlayingError() {
+        let swapperError = SwapperError.TransactionError("Attempt to debit an account but found no record of a prior credit")
+        let errorWrapper = ErrorWrapper(swapperError)
+        
+        #expect(errorWrapper.errorDescription == "Attempt to debit an account but found no record of a prior credit")
+    }
 }

--- a/Features/Swap/Tests/SwapTests/SwapperErrorTests.swift
+++ b/Features/Swap/Tests/SwapTests/SwapperErrorTests.swift
@@ -17,7 +17,7 @@ struct SwapperErrorTests {
     }
     
     @Test
-    func underlayingError() {
+    func underlyingError() {
         let swapperError = SwapperError.TransactionError("Attempt to debit an account but found no record of a prior credit")
         let errorWrapper = ErrorWrapper(swapperError)
         


### PR DESCRIPTION
## Summary
- Add `underlayingError` computed property to `SwapperError` extension for better error message extraction
- Group error cases by return type for cleaner code organization  
- Update `ErrorWrapper` to use `underlayingError` for enhanced error reporting
- Add comprehensive unit test for `TransactionError` case with `ErrorWrapper`

## Test plan
- [x] Unit test added for `TransactionError` case
- [x] Verify error messages are properly extracted from associated values
- [x] Confirm grouped error cases work correctly
- [ ] Run existing swap feature tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)