### PR TITLE
Refactor swap details price impact display

### DIFF
--- a/Features/Swap/Sources/ViewModels/SwapDetailsViewModel.swift
+++ b/Features/Swap/Sources/ViewModels/SwapDetailsViewModel.swift
@@ -113,8 +113,7 @@ public final class SwapDetailsViewModel {
         }
     }
     var priceImpactValue: String? {
-        guard let value = priceImpactModel.value?.value else { return nil }
-        return " (\(value))"
+        priceImpactModel.value?.value
     }
     
     // MARK: - Slippage

--- a/Features/Swap/Sources/Views/SwapDetailsListView.swift
+++ b/Features/Swap/Sources/Views/SwapDetailsListView.swift
@@ -18,18 +18,18 @@ public struct SwapDetailsListView: View {
             
             Spacer()
             
-            VStack(alignment: .trailing, spacing: .tiny) {
-                if let rate = model.rateText {
-                    HStack(spacing: .zero) {
-                        Text(rate)
-                            .textStyle(.calloutSecondary)
-                        if model.shouldShowPriceImpactInDetails, let value = model.priceImpactValue {
-                            Text(value)
-                                .textStyle(model.priceImpactModel.priceImpactStyle)
+            if let rate = model.rateText {
+                HStack(spacing: .tiny) {
+                    Text(rate)
+                        .textStyle(.calloutSecondary)
+                    if model.shouldShowPriceImpactInDetails, let value = model.priceImpactValue {
+                        HStack(spacing: .zero) {
+                            Text("(").textStyle(.calloutSecondary)
+                            Text(value).textStyle(model.priceImpactModel.priceImpactStyle)
+                            Text(")").textStyle(.calloutSecondary)
                         }
                     }
                 }
-                ListItemView(subtitle: model.providerText)
             }
         }
     }

--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -131,16 +131,17 @@ extension ConfirmTransferScene {
                 if model.shouldShowMemo {
                     MemoListItemView(memo: model.memo)
                 }
-            }
-            
-
-            Section {
+                
                 if let swapDetailsViewModel = model.swapDetailsViewModel {
                     NavigationCustomLink(
                         with: SwapDetailsListView(model: swapDetailsViewModel),
                         action: model.onSelectSwapDetails
                     )
                 }
+            }
+            
+
+            Section {
                 if model.shouldShowFeeRatesSelector {
                     NavigationCustomLink(
                         with: networkFeeView,


### PR DESCRIPTION
Updated SwapDetailsViewModel to return raw price impact value instead of a formatted string. Adjusted SwapDetailsListView to handle parentheses and styling for price impact in the view layer, improving separation of concerns and display consistency. Minor layout changes in ConfirmTransferScene for better clarity.