### PR TITLE
Fix missing ignoreValueCheck parameter in withdraw stake (#1021)

### DIFF
--- a/Features/Staking/Sources/ViewModels/StakeDetailViewModel.swift
+++ b/Features/Staking/Sources/ViewModels/StakeDetailViewModel.swift
@@ -141,7 +141,8 @@ public struct StakeDetailViewModel {
                 amount: .none
             ),
             value: model.delegation.base.balanceValue,
-            canChangeValue: false
+            canChangeValue: false,
+            ignoreValueCheck: true
         )
     }
 }

--- a/Features/Staking/Tests/ViewModels/StakeDetailViewModelTests.swift
+++ b/Features/Staking/Tests/ViewModels/StakeDetailViewModelTests.swift
@@ -1,0 +1,40 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Testing
+import PrimitivesTestKit
+import Primitives
+import StakeService
+import StakeServiceTestKit
+
+@testable import Staking
+
+struct StakeDetailViewModelTests {
+
+    @Test
+    func testWithdrawStakeTransferData() throws {
+        let delegation = Delegation.mock(state: .awaitingWithdrawal)
+        let model = StakeDetailViewModel.mock(delegation: delegation)
+
+        let transferData = try model.withdrawStakeTransferData()
+
+        #expect(transferData.canChangeValue == false)
+        #expect(transferData.ignoreValueCheck == true)
+        #expect(transferData.type.shouldIgnoreValueCheck == true)
+        #expect(transferData.value == delegation.base.balanceValue)
+        #expect(transferData.recipientData.recipient.address == delegation.validator.id)
+        #expect(transferData.recipientData.recipient.name == delegation.validator.name)
+    }
+}
+
+extension StakeDetailViewModel {
+    static func mock(delegation: Delegation) -> StakeDetailViewModel {
+        StakeDetailViewModel(
+            wallet: .mock(),
+            model: StakeDelegationViewModel(delegation: delegation),
+            service: .mock(),
+            onAmountInputAction: .none,
+            onTransferAction: .none
+        )
+    }
+}

--- a/Packages/Primitives/TestKit/DelegationBase+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/DelegationBase+PrimitivesTestKit.swift
@@ -10,7 +10,7 @@ public extension DelegationBase {
         DelegationBase(
             assetId: .mock(),
             state: state,
-            balance: .empty,
+            balance: "1",
             shares: .empty,
             rewards: .empty,
             completionDate: nil,


### PR DESCRIPTION
## Summary
- Fixed missing `ignoreValueCheck: true` parameter in `StakeDetailViewModel.withdrawStakeTransferData()`
- Added comprehensive tests for withdraw stake functionality
- Updated test mocks to support proper testing

## Problem
The `withdrawStakeTransferData()` method was missing the `ignoreValueCheck: true` parameter, which caused TransferAmountCalculator to incorrectly validate balance requirements for stake withdrawal operations.

## Solution
- Added `ignoreValueCheck: true` parameter to the TransferData creation in `withdrawStakeTransferData()`
- Created proper unit tests for StakeDetailViewModel to verify the withdraw behavior
- Enhanced DelegationBase mock with non-empty balance for better test coverage

## Test plan
- [x] Added StakeDetailViewModelTests to verify withdrawStakeTransferData() parameters
- [x] Verified that withdrawal operations now correctly bypass balance validation
- [x] All existing tests continue to pass

Fixes https://github.com/gemwalletcom/gem-ios/issues/1021

🤖 Generated with [Claude Code](https://claude.ai/code)