### PR TITLE
Fix wallet_switchEthereumChain and wallet_addEthereumChain null response

### DIFF
--- a/Services/WalletConnectorService/Sources/Extentions/AnyCodable+Null.swift
+++ b/Services/WalletConnectorService/Sources/Extentions/AnyCodable+Null.swift
@@ -1,0 +1,15 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import ReownWalletKit
+
+extension AnyCodable {
+    static func null() -> AnyCodable {
+        AnyCodable(any: Null())
+    }
+    private struct Null: Codable {
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encodeNil()
+        }
+    }
+}

--- a/Services/WalletConnectorService/Sources/Services/EthereumWalletConnectService.swift
+++ b/Services/WalletConnectorService/Sources/Services/EthereumWalletConnectService.swift
@@ -103,11 +103,11 @@ extension EthereumWalletConnectService {
     }
 
     private func walletAddEthereumChain(chain: Chain, request: WalletConnectSign.Request) -> RPCResult {
-        .response(AnyCodable(any: NSNull()))
+        .response(AnyCodable.null())
     }
 
     private func walletSwitchEthereumChain(chain: Chain, request: WalletConnectSign.Request) -> RPCResult {
-        .response(AnyCodable(any: NSNull()))
+        .response(AnyCodable.null())
     }
         
     // TODO: - Implement methods


### PR DESCRIPTION
Fixes: https://github.com/gemwalletcom/gem-ios/issues/939

## Summary
• Fix WalletConnect Ethereum chain switching and adding methods to return proper JSON null responses
• Replace problematic NSNull() usage with custom null encoding implementation
• Add convenient AnyCodable.null() extension for better code readability

## Changes
- **Add AnyCodable.null() extension** with custom Null struct that properly encodes to JSON null
- **Update walletSwitchEthereumChain method** to use AnyCodable.null() instead of NSNull()  
- **Update walletAddEthereumChain method** to use AnyCodable.null() instead of NSNull()
- **Implement proper null encoding** via singleValueContainer.encodeNil() for correct JSON serialization
- **Improve code readability** with clean AnyCodable.null() syntax

## Technical Details
The issue was caused by NSNull() not properly serializing through AnyCodable's JSONSerialization path. The new implementation uses a custom Codable struct with explicit null encoding via singleValueContainer.encodeNil(), ensuring proper JSON null output.

🤖 Generated with [Claude Code](https://claude.ai/code)