### PR TITLE
feat: add info button to staking screen

### DIFF
--- a/Features/Staking/Sources/Scenes/StakeScene.swift
+++ b/Features/Staking/Sources/Scenes/StakeScene.swift
@@ -35,6 +35,7 @@ public struct StakeScene: View {
             await model.fetch()
         }
         .navigationTitle(model.title)
+        .toolbarInfoButton(url: model.stakeInfoUrl)
         .sheet(item: $model.isPresentingInfoSheet) {
             InfoSheetScene(model: InfoSheetViewModel(type: $0))
         }

--- a/Features/Staking/Sources/ViewModels/StakeViewModel.swift
+++ b/Features/Staking/Sources/ViewModels/StakeViewModel.swift
@@ -51,6 +51,7 @@ public final class StakeViewModel {
     var stakeTitle: String { Localized.Transfer.Stake.title }
     var claimRewardsTitle: String { Localized.Transfer.ClaimRewards.title }
     var assetTitle: String { assetModel.title }
+    var stakeInfoUrl: URL { Docs.url(.staking) }
 
     var stakeAprTitle: String { Localized.Stake.apr("") }
     var stakeAprValue: String {


### PR DESCRIPTION
## Summary
This PR adds an info button to the staking screen that provides users with quick access to staking documentation.

### Changes Made
- ✅ **Added toolbar info button** to StakeScene with documentation link
- ✅ **Added stakeInfoUrl property** to StakeViewModel pointing to staking docs  
- ✅ **Improved user experience** by providing quick access to staking information
- ✅ **Updated core submodule** to latest version

### Implementation Details
The info button is implemented using the existing `toolbarInfoButton` modifier and links directly to the staking documentation via `Docs.url(.staking)`.

### UI Enhancement
Users can now easily access staking documentation without leaving the app context, improving the overall user experience and reducing support inquiries.

### Test Plan
- [x] Info button appears in staking screen toolbar
- [x] Button opens staking documentation when tapped
- [x] Build successful with no issues
- [x] Core submodule updated correctly

### Screenshots
<img width="726" height="786" alt="collage_36610d93-d8ae-400c-bc9c-56b791e9fb30" src="https://github.com/user-attachments/assets/f1b82b75-33ba-43ca-89bb-bbc3151a5b7f" />


🤖 Generated with [Claude Code](https://claude.ai/code)