### PR TITLE
Fix invalid background color under action buttons on macOS (#840)

### DIFF
--- a/Features/Assets/Sources/Scenes/AddTokenScene.swift
+++ b/Features/Assets/Sources/Scenes/AddTokenScene.swift
@@ -27,43 +27,6 @@ public struct AddTokenScene: View {
     }
 
     public var body: some View {
-        VStack {
-            addTokenList
-            Spacer()
-            StateButton(
-                text: model.actionButtonTitle,
-                type: .primary(model.state),
-                action: onSelectImportToken
-            )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .toolbarInfoButton(url: model.customTokenUrl)
-        .onAppear {
-            focusedField = .address
-        }
-        .onChange(of: model.input.address, onAddressClean)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
-        .listSectionSpacing(.compact)
-        .navigationTitle(model.title)
-        .navigationDestination(for: Scenes.NetworksSelector.self) { _ in
-            NetworkSelectorScene(
-                model: $networksModel,
-                onFinishSelection: onFinishChainSelection(chains:)
-            )
-        }
-        .sheet(isPresented: $model.isPresentingScanner) {
-            ScanQRCodeNavigationStack(action: onHandleScan(_:))
-        }
-        .safariSheet(url: $isPresentingUrl)
-    }
-}
-
-// MARK: - UI Components
-
-extension AddTokenScene {
-    @ViewBuilder
-    private var addTokenList: some View {
         List {
             if let chain = model.input.chain {
                 Section(model.networkTitle) {
@@ -129,6 +92,30 @@ extension AddTokenScene {
                 )
             }
         }
+        .toolbarActionButton(
+            StateButton(
+                text: model.actionButtonTitle,
+                type: .primary(model.state),
+                action: onSelectImportToken
+            )
+        )
+        .toolbarInfoButton(url: model.customTokenUrl)
+        .onAppear {
+            focusedField = .address
+        }
+        .onChange(of: model.input.address, onAddressClean)
+        .listSectionSpacing(.compact)
+        .navigationTitle(model.title)
+        .navigationDestination(for: Scenes.NetworksSelector.self) { _ in
+            NetworkSelectorScene(
+                model: $networksModel,
+                onFinishSelection: onFinishChainSelection(chains:)
+            )
+        }
+        .sheet(isPresented: $model.isPresentingScanner) {
+            ScanQRCodeNavigationStack(action: onHandleScan(_:))
+        }
+        .safariSheet(url: $isPresentingUrl)
     }
 }
 

--- a/Features/FiatConnect/Sources/Scenes/FiatScene.swift
+++ b/Features/FiatConnect/Sources/Scenes/FiatScene.swift
@@ -21,30 +21,25 @@ public struct FiatScene: View {
 
     public var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                CurrencyInputView(
-                    text: $model.amountText,
-                    config: model.currencyInputConfig
-                )
-                .focused($focusedField, equals: model.input.type == .buy ? .amountBuy : .amountSell)
-                .padding(.top, .medium)
-                .listGroupRowStyle()
-                amountSelectorSection
-                providerSection
-            }
-            .contentMargins([.top], .zero, for: .scrollContent)
-            Spacer()
+        List {
+            CurrencyInputView(
+                text: $model.amountText,
+                config: model.currencyInputConfig
+            )
+            .focused($focusedField, equals: model.input.type == .buy ? .amountBuy : .amountSell)
+            .padding(.top, .medium)
+            .listGroupRowStyle()
+            amountSelectorSection
+            providerSection
+        }
+        .toolbarActionButton(
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.state, showProgress: false),
                 action: model.onSelectContinue
             )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
-        .frame(maxWidth: .infinity)
+        )
+        .contentMargins([.top], .zero, for: .scrollContent)
         .onChange(of: model.focusField, onChangeFocus)
         .onChange(of: model.input.type, model.onChangeType)
         .onChange(of: model.amountText, model.onChangeAmountText)

--- a/Features/Onboarding/Sources/Scenes/AcceptTermsScene.swift
+++ b/Features/Onboarding/Sources/Scenes/AcceptTermsScene.swift
@@ -15,37 +15,31 @@ struct AcceptTermsScene: View {
     }
 
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: model.message))
-                    .cleanListRow()
+        List {
+            CalloutView(style: .header(title: model.message))
+                .cleanListRow()
 
-                ForEach($model.items) { $item in
-                    Section {
-                        Toggle(isOn: $item.isConfirmed) {
-                            Text(item.message)
-                                .textStyle(item.style)
-                        }
-                        .accessibilityIdentifier(item.id)
-                        .toggleStyle(CheckboxStyle(position: .left))
+            ForEach($model.items) { $item in
+                Section {
+                    Toggle(isOn: $item.isConfirmed) {
+                        Text(item.message)
+                            .textStyle(item.style)
                     }
-                    .listRowInsets(.assetListRowInsets)
+                    .accessibilityIdentifier(item.id)
+                    .toggleStyle(CheckboxStyle(position: .left))
                 }
+                .listRowInsets(.assetListRowInsets)
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-            
-            Spacer()
-            
+        }
+        .toolbarActionButton(
             StateButton(
                 text: Localized.Onboarding.AcceptTerms.continue,
                 type: .primary(model.state),
                 action: { model.onNext?() }
             )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        )
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .navigationTitle(model.title)
         .toolbarTitleDisplayMode(.inline)
         .toolbarInfoButton(url: model.termsAndServicesURL)

--- a/Features/Onboarding/Sources/Scenes/SecurityReminderScene.swift
+++ b/Features/Onboarding/Sources/Scenes/SecurityReminderScene.swift
@@ -15,35 +15,29 @@ struct SecurityReminderScene: View {
     }
     
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: model.message))
-                    .cleanListRow()
-                
-                ForEach(model.items) { item in
-                    Section {
-                        ListItemView(
-                            title: TextValue(text: item.title, style: .headline),
-                            titleExtra: TextValue(text: item.subtitle, style: .bodySecondary),
-                            imageStyle: item.image
-                        )
-                    }
-                    .listRowInsets(.assetListRowInsets)
+        List {
+            CalloutView(style: .header(title: model.message))
+                .cleanListRow()
+            
+            ForEach(model.items) { item in
+                Section {
+                    ListItemView(
+                        title: TextValue(text: item.title, style: .headline),
+                        titleExtra: TextValue(text: item.subtitle, style: .bodySecondary),
+                        imageStyle: item.image
+                    )
                 }
+                .listRowInsets(.assetListRowInsets)
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-            
-            Spacer()
-            
+        }
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
+        .toolbarActionButton(
             StateButton(
                 text: Localized.Common.continue,
                 action: model.onNext
             )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        )
         .navigationTitle(model.title)
         .toolbarTitleDisplayMode(.inline)
         .toolbarInfoButton(url: model.docsUrl)

--- a/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
@@ -13,42 +13,38 @@ struct ShowSecretDataScene: View {
     @State private var isPresentingCopyToast = false
 
     var body: some View {
-        VStack {
-            List {
-                if let calloutViewStyle = model.calloutViewStyle {
-                    CalloutView(style: calloutViewStyle)
-                        .cleanListRow()
-                }
-
-                Section {
-                    SecretDataTypeView(
-                        type: model.type
-                    )
-                }
-                .cleanListRow()
-
-                ListButton(
-                    title: Localized.Common.copy,
-                    image: Images.System.copy,
-                    action: copy
-                )
-                .frame(maxWidth: .infinity, alignment: .center)
-                .cleanListRow()
+        List {
+            if let calloutViewStyle = model.calloutViewStyle {
+                CalloutView(style: calloutViewStyle)
+                    .cleanListRow()
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
             
-            if model.continueAction != nil {
+            Section {
+                SecretDataTypeView(
+                    type: model.type
+                )
+            }
+            .cleanListRow()
+            
+            ListButton(
+                title: Localized.Common.copy,
+                image: Images.System.copy,
+                action: copy
+            )
+            .frame(maxWidth: .infinity, alignment: .center)
+            .cleanListRow()
+        }
+        .ifLet(model.continueAction) { view, _ in
+            view.toolbarActionButton(
                 StateButton(
                     text: Localized.Common.continue,
                     action: continueAction
                 )
-                .frame(maxWidth: .scene.button.maxWidth)
-            }
+            )
         }
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .toolbarInfoButton(url: model.docsUrl)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationTitle(model.title)
         .copyToast(
             model: model.copyModel,

--- a/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
@@ -15,59 +15,55 @@ struct VerifyPhraseWalletScene: View {
     }
 
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: Localized.SecretPhrase.Confirm.QuickTest.title))
-                    .cleanListRow()
-                
-                Section {
-                    SecretPhraseGridView(
-                        rows: model.rows,
-                        highlightIndex: model.wordsIndex
-                    )
-                }
+        List {
+            CalloutView(style: .header(title: Localized.SecretPhrase.Confirm.QuickTest.title))
                 .cleanListRow()
-                
-                Section {
-                    Grid(alignment: .center) {
-                        ForEach(model.rowsSections, id: \.self) { section in
-                            GridRow(alignment: .center) {
-                                ForEach(section) { row in
-                                    if model.isVerified(index: row) {
-                                        Button { } label: {
-                                            Text(row.word)
-                                        }
-                                        .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny))
-                                        .disabled(true)
-                                        .fixedSize()
-                                    } else {
-                                        Button {
-                                            model.pickWord(index: row)
-                                        } label: {
-                                            Text(row.word)
-                                        }
-                                        .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny))
-                                        .fixedSize()
+            
+            Section {
+                SecretPhraseGridView(
+                    rows: model.rows,
+                    highlightIndex: model.wordsIndex
+                )
+            }
+            .cleanListRow()
+            
+            Section {
+                Grid(alignment: .center) {
+                    ForEach(model.rowsSections, id: \.self) { section in
+                        GridRow(alignment: .center) {
+                            ForEach(section) { row in
+                                if model.isVerified(index: row) {
+                                    Button { } label: {
+                                        Text(row.word)
                                     }
+                                    .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny))
+                                    .disabled(true)
+                                    .fixedSize()
+                                } else {
+                                    Button {
+                                        model.pickWord(index: row)
+                                    } label: {
+                                        Text(row.word)
+                                    }
+                                    .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny))
+                                    .fixedSize()
                                 }
                             }
                         }
                     }
                 }
-                .cleanListRow()
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-
+            .cleanListRow()
+        }
+        .toolbarActionButton(
             StateButton(
                 text: Localized.Common.continue,
                 type: .primary(model.buttonState),
                 action: model.onImportWallet
             )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        )
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .navigationTitle(model.title)
         .alertSheet($model.isPresentingAlertMessage)
     }

--- a/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
+++ b/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
@@ -24,39 +24,33 @@ public struct SetPriceAlertScene: View {
     }
     
     public var body: some View {
-        VStack(spacing: .zero) {
-            List {
-                Section {
-                    VStack(spacing: .small) {
-                        Text(model.alertDirectionTitle)
-                            .textStyle(.subheadline)
-                        
-                        CurrencyInputView(
-                            text: $model.state.amount,
-                            config: model.currencyInputConfig(for: assetData)
-                        )
-                        .focused($focusedField)
-                    }
+        List {
+            Section {
+                VStack(spacing: .small) {
+                    Text(model.alertDirectionTitle)
+                        .textStyle(.subheadline)
                     
-                    if model.showPercentagePreselectedPicker {
-                        preselectedPercentagePickerView
-                            .padding(.top, Spacing.medium)
-                    }
+                    CurrencyInputView(
+                        text: $model.state.amount,
+                        config: model.currencyInputConfig(for: assetData)
+                    )
+                    .focused($focusedField)
                 }
-                .cleanListRow()
+                
+                if model.showPercentagePreselectedPicker {
+                    preselectedPercentagePickerView
+                        .padding(.top, Spacing.medium)
+                }
             }
-            
-            Spacer()
-            
+            .cleanListRow()
+        }
+        .toolbarActionButton(
             StateButton(
                 text: Localized.Transfer.confirm,
                 type: .primary(model.confirmButtonState),
                 action: confirm
             )
-            .frame(maxWidth: Spacing.scene.button.maxWidth)
-        }
-        .padding(.bottom, Spacing.scene.bottom)
-        .background(Colors.grayBackground)
+        )
         .toolbar {
             ToolbarItem(placement: .principal) {
                 alertTypePickerView

--- a/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
+++ b/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
@@ -24,25 +24,21 @@ public struct AddNodeScene: View {
     }
 
     public var body: some View {
-        VStack {
-            List {
-                networkSection
-                inputView
-                nodeInfoView
-            }
-            Spacer()
+        List {
+            networkSection
+            inputView
+            nodeInfoView
+        }
+        .toolbarActionButton(
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.state),
                 action: onSelectImport
             )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
+        )
         .onAppear {
             focusedField = .address
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .frame(maxWidth: .infinity)
         .navigationTitle(model.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/Features/Transfer/Sources/Scenes/AmountScene.swift
+++ b/Features/Transfer/Sources/Scenes/AmountScene.swift
@@ -20,70 +20,65 @@ struct AmountScene: View {
 
     var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                CurrencyInputValidationView(
-                    model: $model.amountInputModel,
-                    config: model.inputConfig,
-                    infoAction: model.infoAction(for:)
-                )
-                .padding(.top, .medium)
-                .listGroupRowStyle()
-                .disabled(model.isInputDisabled)
-                .focused($focusedField)
+        List {
+            CurrencyInputValidationView(
+                model: $model.amountInputModel,
+                config: model.inputConfig,
+                infoAction: model.infoAction(for:)
+            )
+            .padding(.top, .medium)
+            .listGroupRowStyle()
+            .disabled(model.isInputDisabled)
+            .focused($focusedField)
 
-                if model.isBalanceViewEnabled {
-                    Section {
-                        AssetBalanceView(
-                            image: model.assetImage,
-                            title: model.assetName,
-                            balance: model.balanceText,
-                            secondary: {
-                                Button(
-                                    model.maxTitle,
-                                    action: model.onSelectMaxButton
-                                )
-                                .buttonStyle(.lightGray(paddingHorizontal: .medium, paddingVertical: .small))
-                                .fixedSize()
-                            }
-                        )
-                    }
-                }
-
-                switch model.type {
-                case .transfer, .deposit:
-                    EmptyView()
-                case .stake, .unstake, .redelegate, .withdraw:
-                    if let viewModel = model.stakeValidatorViewModel  {
-                        Section(model.validatorTitle) {
-                            if model.isSelectValidatorEnabled {
-                                NavigationCustomLink(
-                                    with: ValidatorView(model: viewModel),
-                                    action: model.onSelectCurrentValidator
-                                )
-                            } else {
-                                ValidatorView(model: viewModel)
-                            }
+            if model.isBalanceViewEnabled {
+                Section {
+                    AssetBalanceView(
+                        image: model.assetImage,
+                        title: model.assetName,
+                        balance: model.balanceText,
+                        secondary: {
+                            Button(
+                                model.maxTitle,
+                                action: model.onSelectMaxButton
+                            )
+                            .buttonStyle(.lightGray(paddingHorizontal: .medium, paddingVertical: .small))
+                            .fixedSize()
                         }
-                        .listRowInsets(.assetListRowInsets)
-                    }
-                case .perpetual:
-                    // PositionView()
-                    EmptyView()
+                    )
                 }
             }
-            .contentMargins([.top], .zero, for: .scrollContent)
 
-            Spacer()
+            switch model.type {
+            case .transfer, .deposit:
+                EmptyView()
+            case .stake, .unstake, .redelegate, .withdraw:
+                if let viewModel = model.stakeValidatorViewModel  {
+                    Section(model.validatorTitle) {
+                        if model.isSelectValidatorEnabled {
+                            NavigationCustomLink(
+                                with: ValidatorView(model: viewModel),
+                                action: model.onSelectCurrentValidator
+                            )
+                        } else {
+                            ValidatorView(model: viewModel)
+                        }
+                    }
+                    .listRowInsets(.assetListRowInsets)
+                }
+            case .perpetual:
+                // PositionView()
+                EmptyView()
+            }
+        }
+        .contentMargins([.top], .zero, for: .scrollContent)
+        .toolbarActionButton(
             StateButton(
                 text: model.continueTitle,
                 type: .primary(model.actionButtonState),
                 action: model.onSelectNextButton
             )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        )
         .frame(maxWidth: .infinity)
         .navigationTitle(model.title)
         .onAppear(perform: model.onAppear)

--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -18,15 +18,9 @@ public struct ConfirmTransferScene: View {
     }
 
     public var body: some View {
-        VStack {
-            transactionsList
-            Spacer()
-            StateButton(model.confirmButtonModel)
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
-        .frame(maxWidth: .infinity)
+        transactionsList
+            .toolbarActionButton(StateButton(model.confirmButtonModel))
+            .frame(maxWidth: .infinity)
         .debounce(
             value: model.feeModel.priority,
             interval: nil,

--- a/Features/Transfer/Sources/Scenes/RecipientScene.swift
+++ b/Features/Transfer/Sources/Scenes/RecipientScene.swift
@@ -22,87 +22,83 @@ struct RecipientScene: View {
 
     var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                Section {
-                    InputValidationField(
-                        model: $model.addressInputModel,
-                        placeholder: model.recipientField,
-                        allowClean: true,
-                        trailingView: {
-                            HStack(spacing: .large/2) {
-                                NameRecordView(
-                                    model: model.nameRecordViewModel,
-                                    state: $model.nameResolveState,
-                                    address: $model.addressInputModel.text
+        List {
+            Section {
+                InputValidationField(
+                    model: $model.addressInputModel,
+                    placeholder: model.recipientField,
+                    allowClean: true,
+                    trailingView: {
+                        HStack(spacing: .large/2) {
+                            NameRecordView(
+                                model: model.nameRecordViewModel,
+                                state: $model.nameResolveState,
+                                address: $model.addressInputModel.text
+                            )
+                            if model.shouldShowInputActions {
+                                ListButton(
+                                    image: model.pasteImage,
+                                    action: { model.onSelectPaste(field: .address) }
                                 )
-                                if model.shouldShowInputActions {
-                                    ListButton(
-                                        image: model.pasteImage,
-                                        action: { model.onSelectPaste(field: .address) }
-                                    )
-                                    ListButton(
-                                        image: model.qrImage,
-                                        action: { model.onSelectScan(field: .address) }
-                                    )
-                                }
+                                ListButton(
+                                    image: model.qrImage,
+                                    action: { model.onSelectScan(field: .address) }
+                                )
                             }
                         }
+                    }
+                )
+                .focused($focusedField, equals: .address)
+                .keyboardType(.alphabet)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            }
+
+            if model.showMemo {
+                Section {
+                    FloatTextField(
+                        model.memoField,
+                        text: $model.memo,
+                        allowClean: focusedField == .memo,
+                        trailingView: {
+                            ListButton(
+                                image: model.qrImage,
+                                action: { model.onSelectScan(field: .memo) }
+                            )
+                        }
                     )
-                    .focused($focusedField, equals: .address)
+                    .focused($focusedField, equals: .memo)
                     .keyboardType(.alphabet)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                 }
+            }
 
-                if model.showMemo {
-                    Section {
-                        FloatTextField(
-                            model.memoField,
-                            text: $model.memo,
-                            allowClean: focusedField == .memo,
-                            trailingView: {
-                                ListButton(
-                                    image: model.qrImage,
-                                    action: { model.onSelectScan(field: .memo) }
-                                )
-                            }
+            ForEach(model.recipientSections) { section in
+                Section {
+                    ForEach(section.values) { item in
+                        NavigationCustomLink(
+                            with: ListItemView(title: item.value.name),
+                            action: { model.onSelectRecipient(item.value) }
                         )
-                        .focused($focusedField, equals: .memo)
-                        .keyboardType(.alphabet)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
                     }
-                }
-
-                ForEach(model.recipientSections) { section in
-                    Section {
-                        ForEach(section.values) { item in
-                            NavigationCustomLink(
-                                with: ListItemView(title: item.value.name),
-                                action: { model.onSelectRecipient(item.value) }
-                            )
-                        }
-                    } header: {
-                        Label {
-                            Text(section.section)
-                        } icon: {
-                            section.image
-                        }
+                } header: {
+                    Label {
+                        Text(section.section)
+                    } icon: {
+                        section.image
                     }
                 }
             }
-            Spacer()
+        }
+        .contentMargins(.top, .scene.top, for: .scrollContent)
+        .toolbarActionButton(
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.actionButtonState),
                 action: model.onContinue
             )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .contentMargins(.top, .scene.top, for: .scrollContent)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        )
         .navigationTitle(model.tittle)
         .onChange(of: model.addressInputModel.text, model.onChangeAddressText)
         .onChange(of: model.nameResolveState, model.onChangeNameResolverState)

--- a/Packages/Components/Sources/SelectableSheet.swift
+++ b/Packages/Components/Sources/SelectableSheet.swift
@@ -35,40 +35,28 @@ public struct SelectableSheet<ViewModel: SelectableSheetViewable, Content: View>
 
     public var body: some View {
         NavigationStack {
-            ZStack(alignment: .bottom) {
-                Group {
-                    if model.isSearchable {
-                        SearchableSelectableListView(
-                            model: $model,
-                            onFinishSelection: { onFinish(items: $0, isConfirmed: false) },
-                            listContent: listContent
-                        )
-                    } else {
-                        SelectableListView(
-                            model: $model,
-                            onFinishSelection: { onFinish(items: $0, isConfirmed: false) },
-                            listContent: listContent
-                        )
-                    }
-                }
-                .padding(.bottom, .scene.button.height)
-                
-                VStack(spacing: .small) {
-                    Divider()
-                        .frame(height: 1 / UIScreen.main.scale)
-                        .background(Colors.grayVeryLight)
-                    
-                    StateButton(
-                        text: model.confirmButtonTitle,
-                        action: onConfirm
+            Group {
+                if model.isSearchable {
+                    SearchableSelectableListView(
+                        model: $model,
+                        onFinishSelection: { onFinish(items: $0, isConfirmed: false) },
+                        listContent: listContent
                     )
-                    .frame(maxWidth: .scene.button.maxWidth)
+                } else {
+                    SelectableListView(
+                        model: $model,
+                        onFinishSelection: { onFinish(items: $0, isConfirmed: false) },
+                        listContent: listContent
+                    )
                 }
-                .background(Colors.grayBackground)
             }
-            .padding(.bottom, .scene.bottom)
+            .toolbarActionButton(
+                StateButton(
+                    text: model.confirmButtonTitle,
+                    action: onConfirm
+                )
+            )
             .contentMargins(.top, .scene.top, for: .scrollContent)
-            .background(Colors.grayBackground)
             .navigationTitle(model.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/Packages/Components/Sources/ToolbarActionButtonModifier.swift
+++ b/Packages/Components/Sources/ToolbarActionButtonModifier.swift
@@ -1,0 +1,29 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Style
+
+private struct ToolbarActionButtonModifier: ViewModifier {
+    private let button: StateButton
+    
+    init(button: StateButton) {
+        self.button = button
+    }
+    
+    func body(content: Content) -> some View {
+        content
+            .toolbar {
+                ToolbarItem(placement: .bottomBar) {
+                    button
+                        .frame(maxWidth: .scene.button.maxWidth)
+                        .frame(minHeight: .scene.button.accessoryHeight)
+                }
+            }
+    }
+}
+
+public extension View {
+    func toolbarActionButton(_ button: StateButton) -> some View {
+        modifier(ToolbarActionButtonModifier(button: button))
+    }
+}


### PR DESCRIPTION
Closes #840

## Summary

Fixes invalid background color under action buttons on macOS by implementing a unified `toolbarActionButton` modifier.

### Problem
- VStack + List + Spacer + StateButton pattern caused inconsistent background colors on macOS
- Action buttons had incorrect background colors that didn't match the main UI
- UI looked broken with color mismatches on macOS platform

### Solution
- Created `ToolbarActionButtonModifier` that uses SwiftUI's toolbar system
- Replaced problematic pattern across 9 scenes with `.toolbarActionButton()` modifier
- Ensures consistent background colors on all platforms (iOS, macOS)
- Unified approach for all action buttons in the app

### Changes
- **New Component**: `ToolbarActionButtonModifier.swift`
- **Modified Scenes**: 9 scenes updated to use new modifier
  - AcceptTermsScene
  - SecurityReminderScene  
  - ShowSecretDataScene
  - VerifyPhraseWalletScene
  - ConfirmTransferScene
  - AmountScene
  - RecipientScene
  - AddNodeScene
  - SetPriceAlertScene

### Technical Details
```swift
// Before (problematic)
VStack {
    List { ... }
    Spacer()
    StateButton(...)
}

// After (fixed)
List { ... }
.toolbarActionButton(StateButton(...))
```

## Screenshots
<img width="726" height="786" alt="collage_013e2896-ca38-45b5-9611-cd4131ff8e2b" src="https://github.com/user-attachments/assets/934c849f-0895-46c9-8b52-05f31bbbaf9b" />
<img width="1136" height="908" alt="Screenshot 2025-08-04 at 16 13 22" src="https://github.com/user-attachments/assets/859ba3c3-fd94-4671-aa37-5d6be584a7db" />
<img width="1136" height="908" alt="Screenshot 2025-08-04 at 16 13 37" src="https://github.com/user-attachments/assets/fc9f8271-58c6-4d4d-8602-f72d19290cd9" />



https://github.com/user-attachments/assets/50b24d63-cd90-4014-a3b1-aeda56e99c90


## Test Plan
- [x] Test on iOS - action buttons display correctly
- [x] Test on macOS - background colors now match properly
- [x] Verify all 9 affected scenes work correctly
- [x] Ensure no regression in button functionality

🤖 Generated with [Claude Code](https://claude.ai/code)