### PR TITLE
Fix: Reserve minimum account balance for Solana accounts

### DIFF
--- a/Packages/Blockchain/Sources/Solana/SolanaService.swift
+++ b/Packages/Blockchain/Sources/Solana/SolanaService.swift
@@ -138,7 +138,7 @@ extension SolanaService: ChainBalanceable {
         return AssetBalance(
             assetId: chain.assetId,
             balance: Balance(
-                available: balance
+                available: max(balance - chain.minimumAccountBalance, .zero) // Keeping rent to avoid account closure
             )
         )
     }


### PR DESCRIPTION
## Summary
- Subtract minimum account balance (2039280 lamports) from Solana available balance
- Prevents users from accidentally closing their accounts by spending below rent-exempt threshold
- Fixes issue where users could send max amount and leave insufficient balance for account maintenance

## Changes
- Modified `SolanaService.coinBalance` to return `max(balance - chain.minimumAccountBalance, .zero)` as available balance

## Test plan
- [x] Verify Solana accounts show correct available balance (raw balance - 2039280 lamports)
- [x] Confirm max send operations leave minimum balance intact
- [x] Test edge cases where account balance is below or equal to minimum threshold

Fixes #1014

🤖 Generated with [Claude Code](https://claude.ai/code)