### PR TITLE
Create PerpetualConfig in core

### DIFF
--- a/Packages/Blockchain/Sources/Hypercore/HyperCoreService.swift
+++ b/Packages/Blockchain/Sources/Hypercore/HyperCoreService.swift
@@ -3,6 +3,7 @@
 import BigInt
 import Foundation
 import Formatters
+import GemstonePrimitives
 import Primitives
 import SwiftHTTPClient
 
@@ -11,9 +12,19 @@ public struct HyperCoreService: Sendable {
     let provider: Provider<HypercoreProvider>
     let cacheService: HyperCoreCacheService
     
-    public static let builderAddress = "0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc"
-    public static let referralCode = "GEMWALLET"
-    public static let maxBuilderFeeBps = 45 // 0.045%
+    private static let perpetualConfig = GemstoneConfig.shared.perpetualConfig()
+    
+    public static var builderAddress: String {
+        perpetualConfig.builderAddress
+    }
+    
+    public static var referralCode: String {
+        perpetualConfig.referralCode
+    }
+    
+    public static var maxBuilderFeeBps: Int {
+        Int(perpetualConfig.maxBuilderFeeBps)
+    }
     
     public init(
         chain: Primitives.Chain = .hyperCore,

--- a/Packages/Blockchain/Sources/Hypercore/HyperCoreService.swift
+++ b/Packages/Blockchain/Sources/Hypercore/HyperCoreService.swift
@@ -14,17 +14,9 @@ public struct HyperCoreService: Sendable {
     
     private static let perpetualConfig = GemstoneConfig.shared.perpetualConfig()
     
-    public static var builderAddress: String {
-        perpetualConfig.builderAddress
-    }
-    
-    public static var referralCode: String {
-        perpetualConfig.referralCode
-    }
-    
-    public static var maxBuilderFeeBps: Int {
-        Int(perpetualConfig.maxBuilderFeeBps)
-    }
+    public static let builderAddress = perpetualConfig.builderAddress
+    public static let referralCode = perpetualConfig.referralCode
+    public static let maxBuilderFeeBps = Int(perpetualConfig.maxBuilderFeeBps)
     
     public init(
         chain: Primitives.Chain = .hyperCore,

--- a/Packages/GemstonePrimitives/Sources/Config.swift
+++ b/Packages/GemstonePrimitives/Sources/Config.swift
@@ -5,6 +5,7 @@ import class Gemstone.Config
 import struct Gemstone.EvmChainConfig
 import struct Gemstone.BitcoinChainConfig
 import struct Gemstone.SwapConfig
+import struct Gemstone.PerpetualConfig
 import enum Gemstone.DocsUrl
 import enum Gemstone.PublicUrl
 import enum Gemstone.SocialUrl
@@ -26,6 +27,10 @@ extension Config {
     
     public func swapConfig() -> SwapConfig {
         getSwapConfig()
+    }
+    
+    public func perpetualConfig() -> Gemstone.PerpetualConfig {
+        getPerpetualConfig()
     }
 }
 

--- a/Packages/Primitives/TestKit/ConfigResponse+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/ConfigResponse+PrimitivesTestKit.swift
@@ -42,3 +42,4 @@ public extension ConfigVersions {
         )
     }
 }
+


### PR DESCRIPTION
## Summary
- Implements PerpetualConfig in gemstone following the same pattern as SwapConfig
- Moves HyperCore hardcoded configuration values to centralized config
- Fixes #1081

## Changes

### Core (Rust)
- Created `PerpetualConfig` struct in `gemstone/src/config/perpetual_config.rs` with:
  - `default_max_leverage`: 10x
  - `fee_bps`: 10 (0.1%)
  - `min_position_size_usd`: $10
  - `builder_address`: "0x0d9dab1a248f63b0a48965ba8435e4de7497a3dc"
  - `referral_code`: "GEMWALLET"
  - `max_builder_fee_bps`: 45 (0.045%)
  - `referral_fee`: Configuration for referral fees

### iOS (Swift)
- Updated `HyperCoreService` to use configuration values instead of hardcoded constants
- Added `perpetualConfig()` method to `GemstonePrimitives/Config.swift`
- Maintains backward compatibility - existing code continues to work

## Architecture
Follows the same pattern as SwapConfig:
- Configuration lives in gemstone as client-side config
- NOT part of ConfigResponse/API response
- Exposed via UniFFI bindings

## Test Plan
- [x] Build core (Rust) successfully
- [x] Generate Swift bindings
- [x] Build iOS project successfully
- [ ] Verify HyperCore functionality with new config values
- [ ] Test perpetual trading features

🤖 Generated with [Claude Code](https://claude.ai/code)