### PR TITLE
Fix transaction asset associations cleanup in TransactionStore

### DIFF
--- a/Packages/Store/Sources/Models/TransactionAssetAssociationRecord.swift
+++ b/Packages/Store/Sources/Models/TransactionAssetAssociationRecord.swift
@@ -15,6 +15,7 @@ public struct TransactionAssetAssociationRecord: Codable, TableRecord, Fetchable
     public var transactionId: Int
     public var assetId: AssetId
     
+    static let transaction = belongsTo(TransactionRecord.self, using: ForeignKey(["transactionId"], to: ["id"]))
     static let asset = belongsTo(AssetRecord.self)
     static let price = belongsTo(PriceRecord.self, using: ForeignKey(["assetId"], to: ["assetId"]))
 }

--- a/Packages/Store/Sources/Stores/TransactionStore.swift
+++ b/Packages/Store/Sources/Stores/TransactionStore.swift
@@ -62,6 +62,12 @@ public struct TransactionStore: Sendable {
             for transaction in transactions {
                 let record = try transaction.record(walletId: walletId).upsertAndFetch(db, as: TransactionRecord.self)
                 if let id = record.id {
+                    // Delete old associations before inserting new ones
+                    try TransactionAssetAssociationRecord
+                        .filter(TransactionAssetAssociationRecord.Columns.transactionId == id)
+                        .deleteAll(db)
+                    
+                    // Insert new associations
                     try transaction.assetIds.forEach {
                         try TransactionAssetAssociationRecord(transactionId: id, assetId: $0).upsert(db)
                     }

--- a/Packages/Store/Sources/Stores/TransactionStore.swift
+++ b/Packages/Store/Sources/Stores/TransactionStore.swift
@@ -54,6 +54,15 @@ public struct TransactionStore: Sendable {
         }
     }
 
+    public func getTransactionAssetAssociations(for transactionId: String) throws -> [TransactionAssetAssociationRecord] {
+        try db.read { db in
+            try TransactionAssetAssociationRecord
+                .joining(required: TransactionAssetAssociationRecord.transaction)
+                .filter(TransactionRecord.Columns.transactionId == transactionId)
+                .fetchAll(db)
+        }
+    }
+
     public func addTransactions(walletId: String, transactions: [Transaction]) throws {
         if transactions.isEmpty {
             return

--- a/Packages/Store/Sources/Stores/TransactionStore.swift
+++ b/Packages/Store/Sources/Stores/TransactionStore.swift
@@ -62,12 +62,10 @@ public struct TransactionStore: Sendable {
             for transaction in transactions {
                 let record = try transaction.record(walletId: walletId).upsertAndFetch(db, as: TransactionRecord.self)
                 if let id = record.id {
-                    // Delete old associations before inserting new ones
                     try TransactionAssetAssociationRecord
                         .filter(TransactionAssetAssociationRecord.Columns.transactionId == id)
                         .deleteAll(db)
                     
-                    // Insert new associations
                     try transaction.assetIds.forEach {
                         try TransactionAssetAssociationRecord(transactionId: id, assetId: $0).upsert(db)
                     }

--- a/Packages/Store/TestKit/Transaction+StoreTestKit.swift
+++ b/Packages/Store/TestKit/Transaction+StoreTestKit.swift
@@ -1,0 +1,36 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import PrimitivesTestKit
+
+public extension Transaction {
+    static func mock(
+        id: String,
+        type: TransactionType = .transfer,
+        assetId: AssetId = .mock(),
+        metadata: TransactionMetadata? = nil
+    ) -> Transaction {
+        Transaction(
+            id: id,
+            hash: id,
+            assetId: assetId,
+            from: "from",
+            to: "to",
+            contract: nil,
+            type: type,
+            state: .confirmed,
+            blockNumber: "1",
+            sequence: "1",
+            fee: "1",
+            feeAssetId: assetId,
+            value: "100",
+            memo: nil,
+            direction: .outgoing,
+            utxoInputs: [],
+            utxoOutputs: [],
+            metadata: metadata,
+            createdAt: .now
+        )
+    }
+}

--- a/Packages/Store/TestKit/Transaction+StoreTestKit.swift
+++ b/Packages/Store/TestKit/Transaction+StoreTestKit.swift
@@ -6,7 +6,7 @@ import PrimitivesTestKit
 
 public extension Transaction {
     static func mock(
-        id: String,
+        id: String = "1",
         type: TransactionType = .transfer,
         assetId: AssetId = .mock(),
         metadata: TransactionMetadata? = nil

--- a/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
+++ b/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
@@ -14,35 +14,31 @@ struct TransactionStoreTests {
         let db = DB.mock()
         let store = TransactionStore(db: db)
         
-        // Add swap BTC->ETH
         let btc = AssetId(chain: .bitcoin, tokenId: nil)
         let eth = AssetId(chain: .ethereum, tokenId: nil)
         let sol = AssetId(chain: .solana, tokenId: nil)
         
+        // Add swap BTC->ETH
         try store.addTransactions(walletId: "w1", transactions: [
-            Transaction(
-                id: "tx1", hash: "h1", assetId: btc, from: "f", to: "t", contract: nil,
-                type: .swap, state: .confirmed, blockNumber: "1", sequence: "1",
-                fee: "1", feeAssetId: btc, value: "100", memo: nil, direction: .outgoing,
-                utxoInputs: [], utxoOutputs: [],
+            .mock(
+                id: "tx1",
+                type: .swap,
+                assetId: btc,
                 metadata: .swap(TransactionSwapMetadata(
                     fromAsset: btc, fromValue: "100", toAsset: eth, toValue: "200", provider: nil
-                )),
-                createdAt: Date()
+                ))
             )
         ])
         
         // Update to BTC->SOL
         try store.addTransactions(walletId: "w1", transactions: [
-            Transaction(
-                id: "tx1", hash: "h1", assetId: btc, from: "f", to: "t", contract: nil,
-                type: .swap, state: .confirmed, blockNumber: "1", sequence: "1",
-                fee: "1", feeAssetId: btc, value: "100", memo: nil, direction: .outgoing,
-                utxoInputs: [], utxoOutputs: [],
+            .mock(
+                id: "tx1",
+                type: .swap,
+                assetId: btc,
                 metadata: .swap(TransactionSwapMetadata(
                     fromAsset: btc, fromValue: "100", toAsset: sol, toValue: "300", provider: nil
-                )),
-                createdAt: Date()
+                ))
             )
         ])
         

--- a/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
+++ b/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
@@ -10,67 +10,51 @@ import GRDB
 
 struct TransactionStoreTests {
     
-    @Test func assetAssociationsReplacedOnUpdate() throws {
+    @Test func assetAssociationsReplaced() throws {
         let db = DB.mock()
         let store = TransactionStore(db: db)
-        let walletId = "test-wallet"
         
+        // Add swap BTC->ETH
         let btc = AssetId(chain: .bitcoin, tokenId: nil)
         let eth = AssetId(chain: .ethereum, tokenId: nil)
         let sol = AssetId(chain: .solana, tokenId: nil)
         
-        // Add swap transaction with BTC->ETH
-        let swap1 = Transaction(
-            id: "tx1", hash: "h1", assetId: btc, from: "f", to: "t", contract: nil,
-            type: .swap, state: .confirmed, blockNumber: "1", sequence: "1",
-            fee: "1", feeAssetId: btc, value: "100", memo: nil, direction: .outgoing,
-            utxoInputs: [], utxoOutputs: [],
-            metadata: .swap(TransactionSwapMetadata(
-                fromAsset: btc, fromValue: "100", toAsset: eth, toValue: "200", provider: nil
-            )),
-            createdAt: Date()
-        )
-        try store.addTransactions(walletId: walletId, transactions: [swap1])
+        try store.addTransactions(walletId: "w1", transactions: [
+            Transaction(
+                id: "tx1", hash: "h1", assetId: btc, from: "f", to: "t", contract: nil,
+                type: .swap, state: .confirmed, blockNumber: "1", sequence: "1",
+                fee: "1", feeAssetId: btc, value: "100", memo: nil, direction: .outgoing,
+                utxoInputs: [], utxoOutputs: [],
+                metadata: .swap(TransactionSwapMetadata(
+                    fromAsset: btc, fromValue: "100", toAsset: eth, toValue: "200", provider: nil
+                )),
+                createdAt: Date()
+            )
+        ])
         
-        // Verify BTC and ETH associations exist
-        let recordId = try db.dbQueue.read { db in
-            try TransactionRecord.fetchAll(db).first { $0.transactionId == "tx1" }?.id
-        }
-        #expect(recordId != nil)
+        // Update to BTC->SOL
+        try store.addTransactions(walletId: "w1", transactions: [
+            Transaction(
+                id: "tx1", hash: "h1", assetId: btc, from: "f", to: "t", contract: nil,
+                type: .swap, state: .confirmed, blockNumber: "1", sequence: "1",
+                fee: "1", feeAssetId: btc, value: "100", memo: nil, direction: .outgoing,
+                utxoInputs: [], utxoOutputs: [],
+                metadata: .swap(TransactionSwapMetadata(
+                    fromAsset: btc, fromValue: "100", toAsset: sol, toValue: "300", provider: nil
+                )),
+                createdAt: Date()
+            )
+        ])
         
-        var associations = try db.dbQueue.read { db in
-            try TransactionAssetAssociationRecord
+        // Verify old associations replaced
+        try db.dbQueue.read { db in
+            let recordId = try TransactionRecord.fetchAll(db).first?.id
+            let assetIds = try TransactionAssetAssociationRecord
                 .filter(Column("transactionId") == recordId!)
                 .fetchAll(db)
                 .map(\.assetId)
+            
+            #expect(assetIds == [btc, sol])
         }
-        #expect(associations.count == 2)
-        #expect(associations.contains(btc))
-        #expect(associations.contains(eth))
-        
-        // Update to BTC->SOL swap
-        let swap2 = Transaction(
-            id: "tx1", hash: "h1", assetId: btc, from: "f", to: "t", contract: nil,
-            type: .swap, state: .confirmed, blockNumber: "1", sequence: "1",
-            fee: "1", feeAssetId: btc, value: "100", memo: nil, direction: .outgoing,
-            utxoInputs: [], utxoOutputs: [],
-            metadata: .swap(TransactionSwapMetadata(
-                fromAsset: btc, fromValue: "100", toAsset: sol, toValue: "300", provider: nil
-            )),
-            createdAt: Date()
-        )
-        try store.addTransactions(walletId: walletId, transactions: [swap2])
-        
-        // Verify ETH replaced with SOL
-        associations = try db.dbQueue.read { db in
-            try TransactionAssetAssociationRecord
-                .filter(Column("transactionId") == recordId!)
-                .fetchAll(db)
-                .map(\.assetId)
-        }
-        #expect(associations.count == 2)
-        #expect(associations.contains(btc))
-        #expect(associations.contains(sol))
-        #expect(!associations.contains(eth))
     }
 }

--- a/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
+++ b/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
@@ -1,0 +1,218 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Foundation
+import Store
+import StoreTestKit
+import PrimitivesTestKit
+import Primitives
+import GRDB
+
+struct TransactionStoreTests {
+    
+    @Test func swapAssociationsReplacedOnUpdate() throws {
+        let db = DB.mock()
+        let store = TransactionStore(db: db)
+        let walletId = "test-wallet"
+        
+        // Create initial swap transaction with two asset associations
+        let assetId1 = AssetId(chain: .bitcoin, tokenId: nil)
+        let assetId2 = AssetId(chain: .ethereum, tokenId: nil)
+        let swapMetadata = TransactionSwapMetadata(
+            fromAsset: assetId1,
+            fromValue: "100",
+            toAsset: assetId2,
+            toValue: "200",
+            provider: nil
+        )
+        let transaction = Transaction(
+            id: "tx1",
+            hash: "hash1",
+            assetId: assetId1,
+            from: "from1",
+            to: "to1",
+            contract: nil,
+            type: .swap,
+            state: .confirmed,
+            blockNumber: "1",
+            sequence: "1",
+            fee: "10",
+            feeAssetId: assetId1,
+            value: "100",
+            memo: nil,
+            direction: .outgoing,
+            utxoInputs: [],
+            utxoOutputs: [],
+            metadata: .swap(swapMetadata),
+            createdAt: Date()
+        )
+        
+        // Add initial transaction
+        try store.addTransactions(walletId: walletId, transactions: [transaction])
+        
+        // Verify both associations exist
+        try db.dbQueue.read { db in
+            let records = try TransactionRecord.fetchAll(db)
+            let record = records.first { $0.transactionId == "tx1" }
+            
+            #expect(record != nil)
+            
+            if let recordId = record?.id {
+                let associations = try TransactionAssetAssociationRecord
+                    .filter(Column("transactionId") == recordId)
+                    .fetchAll(db)
+                
+                #expect(associations.count == 2)
+                #expect(associations.contains { $0.assetId == assetId1 })
+                #expect(associations.contains { $0.assetId == assetId2 })
+            }
+        }
+        
+        // Update swap transaction with different assets
+        let assetId3 = AssetId(chain: .solana, tokenId: nil)
+        let updatedSwapMetadata = TransactionSwapMetadata(
+            fromAsset: assetId1,
+            fromValue: "100",
+            toAsset: assetId3,
+            toValue: "300",
+            provider: nil
+        )
+        let updatedTransaction = Transaction(
+            id: "tx1",
+            hash: "hash1",
+            assetId: assetId1,
+            from: "from1",
+            to: "to1",
+            contract: nil,
+            type: .swap,
+            state: .confirmed,
+            blockNumber: "1",
+            sequence: "1",
+            fee: "10",
+            feeAssetId: assetId1,
+            value: "100",
+            memo: nil,
+            direction: .outgoing,
+            utxoInputs: [],
+            utxoOutputs: [],
+            metadata: .swap(updatedSwapMetadata),
+            createdAt: Date()
+        )
+        
+        // Update transaction
+        try store.addTransactions(walletId: walletId, transactions: [updatedTransaction])
+        
+        // Verify associations were replaced
+        try db.dbQueue.read { db in
+            let records = try TransactionRecord.fetchAll(db)
+            let record = records.first { $0.transactionId == "tx1" }
+            
+            #expect(record != nil)
+            
+            if let recordId = record?.id {
+                let associations = try TransactionAssetAssociationRecord
+                    .filter(Column("transactionId") == recordId)
+                    .fetchAll(db)
+                
+                #expect(associations.count == 2)
+                #expect(associations.contains { $0.assetId == assetId1 })
+                #expect(associations.contains { $0.assetId == assetId3 })
+                #expect(!associations.contains { $0.assetId == assetId2 })
+            }
+        }
+    }
+    
+    @Test func transferAssociationsReplaced() throws {
+        let db = DB.mock()
+        let store = TransactionStore(db: db)
+        let walletId = "test-wallet"
+        
+        // Create regular transfer transaction (only one asset)
+        let assetId1 = AssetId(chain: .bitcoin, tokenId: nil)
+        let transaction = Transaction(
+            id: "tx2",
+            hash: "hash2",
+            assetId: assetId1,
+            from: "from2",
+            to: "to2",
+            contract: nil,
+            type: .transfer,
+            state: .confirmed,
+            blockNumber: "2",
+            sequence: "2",
+            fee: "10",
+            feeAssetId: assetId1,
+            value: "100",
+            memo: nil,
+            direction: .incoming,
+            utxoInputs: [],
+            utxoOutputs: [],
+            metadata: nil,
+            createdAt: Date()
+        )
+        
+        // Add transaction
+        try store.addTransactions(walletId: walletId, transactions: [transaction])
+        
+        // Verify association exists
+        try db.dbQueue.read { db in
+            let records = try TransactionRecord.fetchAll(db)
+            let record = records.first { $0.transactionId == "tx2" }
+            
+            #expect(record != nil)
+            
+            if let recordId = record?.id {
+                let associations = try TransactionAssetAssociationRecord
+                    .filter(Column("transactionId") == recordId)
+                    .fetchAll(db)
+                
+                #expect(associations.count == 1)
+                #expect(associations.first?.assetId == assetId1)
+            }
+        }
+        
+        // Update to different asset
+        let assetId2 = AssetId(chain: .ethereum, tokenId: nil)
+        let updatedTransaction = Transaction(
+            id: "tx2",
+            hash: "hash2",
+            assetId: assetId2,
+            from: "from2",
+            to: "to2",
+            contract: nil,
+            type: .transfer,
+            state: .confirmed,
+            blockNumber: "2",
+            sequence: "2",
+            fee: "10",
+            feeAssetId: assetId2,
+            value: "100",
+            memo: nil,
+            direction: .incoming,
+            utxoInputs: [],
+            utxoOutputs: [],
+            metadata: nil,
+            createdAt: Date()
+        )
+        
+        // Update transaction
+        try store.addTransactions(walletId: walletId, transactions: [updatedTransaction])
+        
+        // Verify association was replaced
+        try db.dbQueue.read { db in
+            let records = try TransactionRecord.fetchAll(db)
+            let record = records.first { $0.transactionId == "tx2" }
+            
+            #expect(record != nil)
+            
+            if let recordId = record?.id {
+                let associations = try TransactionAssetAssociationRecord
+                    .filter(Column("transactionId") == recordId)
+                    .fetchAll(db)
+                
+                #expect(associations.count == 1)
+                #expect(associations.first?.assetId == assetId2)
+            }
+        }
+    }
+}

--- a/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
+++ b/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
@@ -18,7 +18,6 @@ struct TransactionStoreTests {
         let eth = AssetId(chain: .ethereum, tokenId: nil)
         let sol = AssetId(chain: .solana, tokenId: nil)
         
-        // Add swap BTC->ETH
         try store.addTransactions(walletId: "w1", transactions: [
             .mock(
                 id: "tx1",
@@ -30,7 +29,6 @@ struct TransactionStoreTests {
             )
         ])
         
-        // Update to BTC->SOL
         try store.addTransactions(walletId: "w1", transactions: [
             .mock(
                 id: "tx1",
@@ -42,7 +40,6 @@ struct TransactionStoreTests {
             )
         ])
         
-        // Verify old associations replaced
         try db.dbQueue.read { db in
             let recordId = try TransactionRecord.fetchAll(db).first?.id
             let assetIds = try TransactionAssetAssociationRecord

--- a/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
+++ b/Packages/Store/Tests/StoreTests/TransactionStoreTests.swift
@@ -11,16 +11,26 @@ import GRDB
 struct TransactionStoreTests {
     
     @Test func assetAssociationsReplaced() throws {
-        let db = DB.mock()
-        let store = TransactionStore(db: db)
-        
         let btc = AssetId(chain: .bitcoin, tokenId: nil)
         let eth = AssetId(chain: .ethereum, tokenId: nil)
         let sol = AssetId(chain: .solana, tokenId: nil)
         
-        try store.addTransactions(walletId: "w1", transactions: [
+        let assets: [AssetBasic] = [
+            .mock(asset: .mock(id: btc)),
+            .mock(asset: .mock(id: eth)),
+            .mock(asset: .mock(id: sol))
+        ]
+        
+        let db = DB.mockAssets(assets: assets)
+        let walletStore = WalletStore(db: db)
+        try walletStore.addWallet(.mock(id: "1", accounts: assets.map { Account.mock(chain: $0.asset.chain) }))
+        
+        let store = TransactionStore(db: db)
+        let transactionId = "1"
+
+        try store.addTransactions(walletId: "1", transactions: [
             .mock(
-                id: "tx1",
+                id: transactionId,
                 type: .swap,
                 assetId: btc,
                 metadata: .swap(TransactionSwapMetadata(
@@ -29,9 +39,9 @@ struct TransactionStoreTests {
             )
         ])
         
-        try store.addTransactions(walletId: "w1", transactions: [
+        try store.addTransactions(walletId: "1", transactions: [
             .mock(
-                id: "tx1",
+                id: transactionId,
                 type: .swap,
                 assetId: btc,
                 metadata: .swap(TransactionSwapMetadata(
@@ -40,14 +50,8 @@ struct TransactionStoreTests {
             )
         ])
         
-        try db.dbQueue.read { db in
-            let recordId = try TransactionRecord.fetchAll(db).first?.id
-            let assetIds = try TransactionAssetAssociationRecord
-                .filter(Column("transactionId") == recordId!)
-                .fetchAll(db)
-                .map(\.assetId)
-            
-            #expect(assetIds == [btc, sol])
-        }
+        let assetIds = try store.getTransactionAssetAssociations(for: transactionId).map(\.assetId)
+        
+        #expect(assetIds == [btc, sol])
     }
 }


### PR DESCRIPTION
## Summary
- Fixes issue #1053 where old transaction asset associations were not being deleted when updating transactions
- Prevents stale association data from accumulating in the database

## Problem
When `addTransactions` updates an existing transaction via `upsertAndFetch`, the old asset associations remained in the database. For example, if a swap transaction was updated from BTC->ETH to BTC->SOL, the ETH association would incorrectly remain.

## Solution
Added code to delete old associations before inserting new ones:
```swift
// Delete old associations before inserting new ones
try TransactionAssetAssociationRecord
    .filter(TransactionAssetAssociationRecord.Columns.transactionId == id)
    .deleteAll(db)
```

## Test plan
- [x] Added unit test that verifies asset associations are properly replaced when updating transactions
- [x] Test confirms old associations are removed and new ones are added correctly

Closes #1053

🤖 Generated with [Claude Code](https://claude.ai/code)