### PR TITLE
Refactor recipient mode handling in transfer view models

### DIFF
--- a/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -98,7 +98,7 @@ public final class ConfirmTransferSceneViewModel {
         AddressListItemViewModel(
             title: dataModel.recipientTitle,
             account: dataModel.recepientAccount,
-            mode: dataModel.recipientMode,
+            mode: .nameOrAddress,
             addressLink: confirmService.getExplorerLink(chain: dataModel.recepientAccount.chain, address: dataModel.recepientAccount.address)
         )
     }

--- a/Features/Transfer/Sources/ViewModels/TransferDataViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/TransferDataViewModel.swift
@@ -72,21 +72,6 @@ struct TransferDataViewModel {
         )
     }
 
-    var recipientMode: AddressListItemViewModel.Mode {
-        switch type {
-        case .transfer,
-                .deposit,
-                .withdrawal,
-                .transferNft,
-                .tokenApprove,
-                .stake,
-                .account,
-                .generic,
-                .perpetual: .auto(addressStyle: .short)
-        case .swap: .nameOrAddress
-        }
-    }
-
     var appValue: String? {
         switch type {
         case .transfer,


### PR DESCRIPTION
Removed the recipientMode property from TransferDataViewModel and set the mode to .nameOrAddress directly in ConfirmTransferSceneViewModel. This simplifies the logic and centralizes the mode assignment for address list items.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1069

Before:
<img width="440" alt="Simulator Screenshot - Gem Main iPhone | 16 Pro - 2025-08-13 at 17 49 36" src="https://github.com/user-attachments/assets/a9e204c3-7a7d-4a7c-aaa3-39306faf2ce3" />

After:
<img width="440" alt="Simulator Screenshot - Gem Main iPhone | 16 Pro - 2025-08-13 at 17 48 54" src="https://github.com/user-attachments/assets/5a254703-02f7-494e-a096-18f04bf0182b" />

