### PR TITLE
Fix background rendering issue under buttons on macOS

### DIFF
--- a/Features/Assets/Sources/Scenes/AddTokenScene.swift
+++ b/Features/Assets/Sources/Scenes/AddTokenScene.swift
@@ -27,9 +27,8 @@ public struct AddTokenScene: View {
     }
 
     public var body: some View {
-        VStack {
-            addTokenList
-            Spacer()
+        addTokenList
+        .footerView {
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.state),
@@ -42,8 +41,6 @@ public struct AddTokenScene: View {
             focusedField = .address
         }
         .onChange(of: model.input.address, onAddressClean)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .listSectionSpacing(.compact)
         .navigationTitle(model.title)
         .navigationDestination(for: Scenes.NetworksSelector.self) { _ in

--- a/Features/FiatConnect/Sources/Scenes/FiatScene.swift
+++ b/Features/FiatConnect/Sources/Scenes/FiatScene.swift
@@ -21,20 +21,18 @@ public struct FiatScene: View {
 
     public var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                CurrencyInputView(
-                    text: $model.amountText,
-                    config: model.currencyInputConfig
-                )
-                .focused($focusedField, equals: model.input.type == .buy ? .amountBuy : .amountSell)
-                .padding(.top, .medium)
-                .listGroupRowStyle()
-                amountSelectorSection
-                providerSection
-            }
-            .contentMargins([.top], .zero, for: .scrollContent)
-            Spacer()
+        List {
+            CurrencyInputView(
+                text: $model.amountText,
+                config: model.currencyInputConfig
+            )
+            .focused($focusedField, equals: model.input.type == .buy ? .amountBuy : .amountSell)
+            .padding(.top, .medium)
+            .listGroupRowStyle()
+            amountSelectorSection
+            providerSection
+        }
+        .footerView {
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.state, showProgress: false),
@@ -42,8 +40,7 @@ public struct FiatScene: View {
             )
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .contentMargins([.top], .zero, for: .scrollContent)
         .frame(maxWidth: .infinity)
         .onChange(of: model.focusField, onChangeFocus)
         .onChange(of: model.input.type, model.onChangeType)

--- a/Features/Onboarding/Sources/Scenes/AcceptTermsScene.swift
+++ b/Features/Onboarding/Sources/Scenes/AcceptTermsScene.swift
@@ -15,28 +15,23 @@ struct AcceptTermsScene: View {
     }
 
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: model.message))
-                    .cleanListRow()
+        List {
+            CalloutView(style: .header(title: model.message))
+                .cleanListRow()
 
-                ForEach($model.items) { $item in
-                    Section {
-                        Toggle(isOn: $item.isConfirmed) {
-                            Text(item.message)
-                                .textStyle(item.style)
-                        }
-                        .accessibilityIdentifier(item.id)
-                        .toggleStyle(CheckboxStyle(position: .left))
+            ForEach($model.items) { $item in
+                Section {
+                    Toggle(isOn: $item.isConfirmed) {
+                        Text(item.message)
+                            .textStyle(item.style)
                     }
-                    .listRowInsets(.assetListRowInsets)
+                    .accessibilityIdentifier(item.id)
+                    .toggleStyle(CheckboxStyle(position: .left))
                 }
+                .listRowInsets(.assetListRowInsets)
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-            
-            Spacer()
-            
+        }
+        .footerView {
             StateButton(
                 text: Localized.Onboarding.AcceptTerms.continue,
                 type: .primary(model.state),
@@ -44,8 +39,8 @@ struct AcceptTermsScene: View {
             )
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .navigationTitle(model.title)
         .toolbarTitleDisplayMode(.inline)
         .toolbarInfoButton(url: model.termsAndServicesURL)

--- a/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
@@ -21,84 +21,82 @@ struct ImportWalletScene: View {
     }
 
     var body: some View {
-        VStack {
-            Form {
-                Section {
-                    FloatTextField(
-                        model.walletFieldTitle,
-                        text: $model.name,
-                        allowClean: focusedField == .name
-                    )
-                    .focused($focusedField, equals: .name)
-                }
-                Section {
-                    VStack {
-                        if model.showImportTypes {
-                            Picker("", selection: $model.importType) {
-                                ForEach(model.importTypes) { type in
-                                    Text(type.title).tag(type)
-                                }
-                            }
-                            .pickerStyle(.segmented)
-                        }
-                        HStack {
-                            TextField(
-                                model.importType.description,
-                                text: $model.input,
-                                axis: .vertical
-                            )
-                            .autocorrectionDisabled(true)
-                            .textInputAutocapitalization(.never)
-                            .lineLimit(8)
-                            .keyboardType(.asciiCapable)
-                            .frame(minHeight: 80, alignment: .top)
-                            .focused($focusedField, equals: .input)
-                            .toolbar {
-                                if model.importType.showToolbar {
-                                    ToolbarItem(placement: .keyboard) {
-                                        WordSuggestionView(
-                                            words: model.wordsSuggestion,
-                                            selectWord: model.onSelectWord
-                                        )
-                                    }
-                                }
-                            }
-                            .padding(.top, .small + .tiny)
-
-                            if let nameRecordViewModel = model.nameRecordViewModel, model.importType == .address {
-                                NameRecordView(
-                                    model: nameRecordViewModel,
-                                    state: $model.nameResolveState,
-                                    address: $model.input
-                                )
+        Form {
+            Section {
+                FloatTextField(
+                    model.walletFieldTitle,
+                    text: $model.name,
+                    allowClean: focusedField == .name
+                )
+                .focused($focusedField, equals: .name)
+            }
+            Section {
+                VStack {
+                    if model.showImportTypes {
+                        Picker("", selection: $model.importType) {
+                            ForEach(model.importTypes) { type in
+                                Text(type.title).tag(type)
                             }
                         }
-
-                        HStack(alignment: .center, spacing: .medium) {
-                            ListButton(
-                                title: model.pasteButtonTitle,
-                                image: model.pasteButtonImage,
-                                action: model.onPaste
-                            )
-                            if model.type != .multicoin {
-                                ListButton(
-                                    title: model.qrButtonTitle,
-                                    image: model.qrButtonImage,
-                                    action: model.onSelectScanQR
-                                )
+                        .pickerStyle(.segmented)
+                    }
+                    HStack {
+                        TextField(
+                            model.importType.description,
+                            text: $model.input,
+                            axis: .vertical
+                        )
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
+                        .lineLimit(8)
+                        .keyboardType(.asciiCapable)
+                        .frame(minHeight: 80, alignment: .top)
+                        .focused($focusedField, equals: .input)
+                        .toolbar {
+                            if model.importType.showToolbar {
+                                ToolbarItem(placement: .keyboard) {
+                                    WordSuggestionView(
+                                        words: model.wordsSuggestion,
+                                        selectWord: model.onSelectWord
+                                    )
+                                }
                             }
+                        }
+                        .padding(.top, .small + .tiny)
+
+                        if let nameRecordViewModel = model.nameRecordViewModel, model.importType == .address {
+                            NameRecordView(
+                                model: nameRecordViewModel,
+                                state: $model.nameResolveState,
+                                address: $model.input
+                            )
                         }
                     }
-                    .listRowBackground(Colors.white)
-                } footer: {
-                    if let text = model.footerText {
-                        Text(text)
-                    } 
-                }
-            }
-            .listSectionSpacing(.compact)
 
-            Spacer()
+                    HStack(alignment: .center, spacing: .medium) {
+                        ListButton(
+                            title: model.pasteButtonTitle,
+                            image: model.pasteButtonImage,
+                            action: model.onPaste
+                        )
+                        if model.type != .multicoin {
+                            ListButton(
+                                title: model.qrButtonTitle,
+                                image: model.qrButtonImage,
+                                action: model.onSelectScanQR
+                            )
+                        }
+                    }
+                }
+                .listRowBackground(Colors.white)
+            } footer: {
+                if let text = model.footerText {
+                    Text(text)
+                } 
+            }
+        }
+        .listSectionSpacing(.compact)
+        .footerView {
             StateButton(
                 text: Localized.Wallet.Import.action,
                 type: .primary(model.buttonState),
@@ -107,8 +105,6 @@ struct ImportWalletScene: View {
             .frame(maxWidth: .scene.button.maxWidth)
         }
         .contentMargins(.top, .scene.top, for: .scrollContent)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationBarTitle(model.title)
         .alertSheet($model.isPresentingAlertMessage)
         .sheet(isPresented: $model.isPresentingScanner) {

--- a/Features/Onboarding/Sources/Scenes/SecurityReminderScene.swift
+++ b/Features/Onboarding/Sources/Scenes/SecurityReminderScene.swift
@@ -15,35 +15,30 @@ struct SecurityReminderScene: View {
     }
     
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: model.message))
-                    .cleanListRow()
-                
-                ForEach(model.items) { item in
-                    Section {
-                        ListItemView(
-                            title: TextValue(text: item.title, style: .headline),
-                            titleExtra: TextValue(text: item.subtitle, style: .bodySecondary),
-                            imageStyle: item.image
-                        )
-                    }
-                    .listRowInsets(.assetListRowInsets)
+        List {
+            CalloutView(style: .header(title: model.message))
+                .cleanListRow()
+            
+            ForEach(model.items) { item in
+                Section {
+                    ListItemView(
+                        title: TextValue(text: item.title, style: .headline),
+                        titleExtra: TextValue(text: item.subtitle, style: .bodySecondary),
+                        imageStyle: item.image
+                    )
                 }
+                .listRowInsets(.assetListRowInsets)
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-            
-            Spacer()
-            
+        }
+        .footerView {
             StateButton(
                 text: Localized.Common.continue,
                 action: model.onNext
             )
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .navigationTitle(model.title)
         .toolbarTitleDisplayMode(.inline)
         .toolbarInfoButton(url: model.docsUrl)

--- a/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
@@ -13,31 +13,28 @@ struct ShowSecretDataScene: View {
     @State private var isPresentingCopyToast = false
 
     var body: some View {
-        VStack {
-            List {
-                if let calloutViewStyle = model.calloutViewStyle {
-                    CalloutView(style: calloutViewStyle)
-                        .cleanListRow()
-                }
-
-                Section {
-                    SecretDataTypeView(
-                        type: model.type
-                    )
-                }
-                .cleanListRow()
-
-                ListButton(
-                    title: Localized.Common.copy,
-                    image: Images.System.copy,
-                    action: copy
-                )
-                .frame(maxWidth: .infinity, alignment: .center)
-                .cleanListRow()
+        List {
+            if let calloutViewStyle = model.calloutViewStyle {
+                CalloutView(style: calloutViewStyle)
+                    .cleanListRow()
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-            
+
+            Section {
+                SecretDataTypeView(
+                    type: model.type
+                )
+            }
+            .cleanListRow()
+
+            ListButton(
+                title: Localized.Common.copy,
+                image: Images.System.copy,
+                action: copy
+            )
+            .frame(maxWidth: .infinity, alignment: .center)
+            .cleanListRow()
+        }
+        .footerView {
             if model.continueAction != nil {
                 StateButton(
                     text: Localized.Common.continue,
@@ -46,9 +43,9 @@ struct ShowSecretDataScene: View {
                 .frame(maxWidth: .scene.button.maxWidth)
             }
         }
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .toolbarInfoButton(url: model.docsUrl)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationTitle(model.title)
         .copyToast(
             model: model.copyModel,

--- a/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
@@ -15,50 +15,49 @@ struct VerifyPhraseWalletScene: View {
     }
 
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: Localized.SecretPhrase.Confirm.QuickTest.title))
-                    .cleanListRow()
-                
-                Section {
-                    SecretPhraseGridView(
-                        rows: model.rows,
-                        highlightIndex: model.wordsIndex
-                    )
-                }
+        List {
+            CalloutView(style: .header(title: Localized.SecretPhrase.Confirm.QuickTest.title))
                 .cleanListRow()
-                
-                Section {
-                    Grid(alignment: .center) {
-                        ForEach(model.rowsSections, id: \.self) { section in
-                            GridRow(alignment: .center) {
-                                ForEach(section) { row in
-                                    if model.isVerified(index: row) {
-                                        Button { } label: {
-                                            Text(row.word)
-                                        }
-                                        .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny))
-                                        .disabled(true)
-                                        .fixedSize()
-                                    } else {
-                                        Button {
-                                            model.pickWord(index: row)
-                                        } label: {
-                                            Text(row.word)
-                                        }
-                                        .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny))
-                                        .fixedSize()
+            
+            Section {
+                SecretPhraseGridView(
+                    rows: model.rows,
+                    highlightIndex: model.wordsIndex
+                )
+            }
+            .cleanListRow()
+            
+            Section {
+                Grid(alignment: .center) {
+                    ForEach(model.rowsSections, id: \.self) { section in
+                        GridRow(alignment: .center) {
+                            ForEach(section) { row in
+                                if model.isVerified(index: row) {
+                                    Button { } label: {
+                                        Text(row.word)
                                     }
+                                    .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny))
+                                    .disabled(true)
+                                    .fixedSize()
+                                } else {
+                                    Button {
+                                        model.pickWord(index: row)
+                                    } label: {
+                                        Text(row.word)
+                                    }
+                                    .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny))
+                                    .fixedSize()
                                 }
                             }
                         }
                     }
                 }
-                .cleanListRow()
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-
+            .cleanListRow()
+        }
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
+        .footerView {
             StateButton(
                 text: Localized.Common.continue,
                 type: .primary(model.buttonState),
@@ -66,8 +65,6 @@ struct VerifyPhraseWalletScene: View {
             )
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationTitle(model.title)
         .alertSheet($model.isPresentingAlertMessage)
     }

--- a/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
+++ b/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
@@ -24,30 +24,27 @@ public struct SetPriceAlertScene: View {
     }
     
     public var body: some View {
-        VStack(spacing: .zero) {
-            List {
-                Section {
-                    VStack(spacing: .small) {
-                        Text(model.alertDirectionTitle)
-                            .textStyle(.subheadline)
-                        
-                        CurrencyInputView(
-                            text: $model.state.amount,
-                            config: model.currencyInputConfig(for: assetData)
-                        )
-                        .focused($focusedField)
-                    }
+        List {
+            Section {
+                VStack(spacing: .small) {
+                    Text(model.alertDirectionTitle)
+                        .textStyle(.subheadline)
                     
-                    if model.showPercentagePreselectedPicker {
-                        preselectedPercentagePickerView
-                            .padding(.top, Spacing.medium)
-                    }
+                    CurrencyInputView(
+                        text: $model.state.amount,
+                        config: model.currencyInputConfig(for: assetData)
+                    )
+                    .focused($focusedField)
                 }
-                .cleanListRow()
+                
+                if model.showPercentagePreselectedPicker {
+                    preselectedPercentagePickerView
+                        .padding(.top, Spacing.medium)
+                }
             }
-            
-            Spacer()
-            
+            .cleanListRow()
+        }
+        .footerView {
             StateButton(
                 text: Localized.Transfer.confirm,
                 type: .primary(model.confirmButtonState),
@@ -55,8 +52,6 @@ public struct SetPriceAlertScene: View {
             )
             .frame(maxWidth: Spacing.scene.button.maxWidth)
         }
-        .padding(.bottom, Spacing.scene.bottom)
-        .background(Colors.grayBackground)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 alertTypePickerView

--- a/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
+++ b/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
@@ -24,13 +24,12 @@ public struct AddNodeScene: View {
     }
 
     public var body: some View {
-        VStack {
-            List {
-                networkSection
-                inputView
-                nodeInfoView
-            }
-            Spacer()
+        List {
+            networkSection
+            inputView
+            nodeInfoView
+        }
+        .footerView {
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.state),
@@ -41,8 +40,6 @@ public struct AddNodeScene: View {
         .onAppear {
             focusedField = .address
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .frame(maxWidth: .infinity)
         .navigationTitle(model.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/Features/Transfer/Sources/Scenes/AmountScene.swift
+++ b/Features/Transfer/Sources/Scenes/AmountScene.swift
@@ -20,61 +20,58 @@ struct AmountScene: View {
 
     var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                CurrencyInputValidationView(
-                    model: $model.amountInputModel,
-                    config: model.inputConfig,
-                    infoAction: model.infoAction(for:)
-                )
-                .padding(.top, .medium)
-                .listGroupRowStyle()
-                .disabled(model.isInputDisabled)
-                .focused($focusedField)
+        List {
+            CurrencyInputValidationView(
+                model: $model.amountInputModel,
+                config: model.inputConfig,
+                infoAction: model.infoAction(for:)
+            )
+            .padding(.top, .medium)
+            .listGroupRowStyle()
+            .disabled(model.isInputDisabled)
+            .focused($focusedField)
 
-                if model.isBalanceViewEnabled {
-                    Section {
-                        AssetBalanceView(
-                            image: model.assetImage,
-                            title: model.assetName,
-                            balance: model.balanceText,
-                            secondary: {
-                                Button(
-                                    model.maxTitle,
-                                    action: model.onSelectMaxButton
-                                )
-                                .buttonStyle(.lightGray(paddingHorizontal: .medium, paddingVertical: .small))
-                                .fixedSize()
-                            }
-                        )
-                    }
-                }
-
-                switch model.type {
-                case .transfer, .deposit, .withdraw:
-                    EmptyView()
-                case .stake, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
-                    if let viewModel = model.stakeValidatorViewModel  {
-                        Section(model.validatorTitle) {
-                            if model.isSelectValidatorEnabled {
-                                NavigationCustomLink(
-                                    with: ValidatorView(model: viewModel),
-                                    action: model.onSelectCurrentValidator
-                                )
-                            } else {
-                                ValidatorView(model: viewModel)
-                            }
+            if model.isBalanceViewEnabled {
+                Section {
+                    AssetBalanceView(
+                        image: model.assetImage,
+                        title: model.assetName,
+                        balance: model.balanceText,
+                        secondary: {
+                            Button(
+                                model.maxTitle,
+                                action: model.onSelectMaxButton
+                            )
+                            .buttonStyle(.lightGray(paddingHorizontal: .medium, paddingVertical: .small))
+                            .fixedSize()
                         }
-                        .listRowInsets(.assetListRowInsets)
-                    }
-                case .perpetual:
-                    // PositionView()
-                    EmptyView()
+                    )
                 }
             }
-            .contentMargins([.top], .zero, for: .scrollContent)
 
-            Spacer()
+            switch model.type {
+            case .transfer, .deposit, .withdraw:
+                EmptyView()
+            case .stake, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
+                if let viewModel = model.stakeValidatorViewModel  {
+                    Section(model.validatorTitle) {
+                        if model.isSelectValidatorEnabled {
+                            NavigationCustomLink(
+                                with: ValidatorView(model: viewModel),
+                                action: model.onSelectCurrentValidator
+                            )
+                        } else {
+                            ValidatorView(model: viewModel)
+                        }
+                    }
+                    .listRowInsets(.assetListRowInsets)
+                }
+            case .perpetual:
+                // PositionView()
+                EmptyView()
+            }
+        }
+        .footerView {
             StateButton(
                 text: model.continueTitle,
                 type: .primary(model.actionButtonState),
@@ -82,8 +79,7 @@ struct AmountScene: View {
             )
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .contentMargins([.top], .zero, for: .scrollContent)
         .frame(maxWidth: .infinity)
         .navigationTitle(model.title)
         .onAppear(perform: model.onAppear)

--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -17,14 +17,11 @@ public struct ConfirmTransferScene: View {
     }
 
     public var body: some View {
-        VStack {
-            transactionsList
-            Spacer()
+        transactionsList
+        .footerView {
             StateButton(model.confirmButtonModel)
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .frame(maxWidth: .infinity)
         .debounce(
             value: model.feeModel.priority,

--- a/Features/Transfer/Sources/Scenes/RecipientScene.swift
+++ b/Features/Transfer/Sources/Scenes/RecipientScene.swift
@@ -22,77 +22,76 @@ struct RecipientScene: View {
 
     var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                Section {
-                    InputValidationField(
-                        model: $model.addressInputModel,
-                        placeholder: model.recipientField,
-                        allowClean: true,
-                        trailingView: {
-                            HStack(spacing: .large/2) {
-                                NameRecordView(
-                                    model: model.nameRecordViewModel,
-                                    state: $model.nameResolveState,
-                                    address: $model.addressInputModel.text
+        List {
+            Section {
+                InputValidationField(
+                    model: $model.addressInputModel,
+                    placeholder: model.recipientField,
+                    allowClean: true,
+                    trailingView: {
+                        HStack(spacing: .large/2) {
+                            NameRecordView(
+                                model: model.nameRecordViewModel,
+                                state: $model.nameResolveState,
+                                address: $model.addressInputModel.text
+                            )
+                            if model.shouldShowInputActions {
+                                ListButton(
+                                    image: model.pasteImage,
+                                    action: { model.onSelectPaste(field: .address) }
                                 )
-                                if model.shouldShowInputActions {
-                                    ListButton(
-                                        image: model.pasteImage,
-                                        action: { model.onSelectPaste(field: .address) }
-                                    )
-                                    ListButton(
-                                        image: model.qrImage,
-                                        action: { model.onSelectScan(field: .address) }
-                                    )
-                                }
+                                ListButton(
+                                    image: model.qrImage,
+                                    action: { model.onSelectScan(field: .address) }
+                                )
                             }
                         }
+                    }
+                )
+                .focused($focusedField, equals: .address)
+                .keyboardType(.alphabet)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            }
+
+            if model.showMemo {
+                Section {
+                    FloatTextField(
+                        model.memoField,
+                        text: $model.memo,
+                        allowClean: focusedField == .memo,
+                        trailingView: {
+                            ListButton(
+                                image: model.qrImage,
+                                action: { model.onSelectScan(field: .memo) }
+                            )
+                        }
                     )
-                    .focused($focusedField, equals: .address)
+                    .focused($focusedField, equals: .memo)
                     .keyboardType(.alphabet)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                 }
+            }
 
-                if model.showMemo {
-                    Section {
-                        FloatTextField(
-                            model.memoField,
-                            text: $model.memo,
-                            allowClean: focusedField == .memo,
-                            trailingView: {
-                                ListButton(
-                                    image: model.qrImage,
-                                    action: { model.onSelectScan(field: .memo) }
-                                )
-                            }
+            ForEach(model.recipientSections) { section in
+                Section {
+                    ForEach(section.values) { item in
+                        NavigationCustomLink(
+                            with: ListItemView(title: item.value.name),
+                            action: { model.onSelectRecipient(item.value) }
                         )
-                        .focused($focusedField, equals: .memo)
-                        .keyboardType(.alphabet)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
                     }
-                }
-
-                ForEach(model.recipientSections) { section in
-                    Section {
-                        ForEach(section.values) { item in
-                            NavigationCustomLink(
-                                with: ListItemView(title: item.value.name),
-                                action: { model.onSelectRecipient(item.value) }
-                            )
-                        }
-                    } header: {
-                        Label {
-                            Text(section.section)
-                        } icon: {
-                            section.image
-                        }
+                } header: {
+                    Label {
+                        Text(section.section)
+                    } icon: {
+                        section.image
                     }
                 }
             }
-            Spacer()
+        }
+        .footerView {
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.actionButtonState),
@@ -101,8 +100,6 @@ struct RecipientScene: View {
             .frame(maxWidth: .scene.button.maxWidth)
         }
         .contentMargins(.top, .scene.top, for: .scrollContent)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationTitle(model.tittle)
         .onChange(of: model.addressInputModel.text, model.onChangeAddressText)
         .onChange(of: model.nameResolveState, model.onChangeNameResolverState)

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
@@ -15,34 +15,32 @@ public struct ConnectionProposalScene: View {
     }
 
     public var body: some View {
-        VStack {
-            List {
-                Section { } header: {
-                    VStack(alignment: .center) {
-                        AsyncImageView(url: model.imageUrl, size: 64)
-                    }
-                    .padding(.top, 8)
+        List {
+            Section { } header: {
+                VStack(alignment: .center) {
+                    AsyncImageView(url: model.imageUrl, size: 64)
                 }
-                .cleanListRow()
-
-                Section {
-                    NavigationLink(value: Scenes.SelectWallet()) {
-                        ListItemView(
-                            title: model.walletTitle,
-                            subtitle: model.walletName
-                        )
-                    }
-                    ListItemView(title: model.appTitle, subtitle: model.appText)
-                }
+                .padding(.top, 8)
             }
+            .cleanListRow()
 
-            Button(model.buttonTitle, action: onAccept)
-                .buttonStyle(.blue())
-                .padding(.bottom, .scene.bottom)
-                .frame(maxWidth: .scene.button.maxWidth)
+            Section {
+                NavigationLink(value: Scenes.SelectWallet()) {
+                    ListItemView(
+                        title: model.walletTitle,
+                        subtitle: model.walletName
+                    )
+                }
+                ListItemView(title: model.appTitle, subtitle: model.appText)
+            }
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .footerView {
+            StateButton(
+                text: model.buttonTitle,
+                action: onAccept
+            )
+            .frame(maxWidth: .scene.button.maxWidth)
+        }
         .navigationTitle(model.title)
         .navigationDestination(for: Scenes.SelectWallet.self) { _ in
             SelectWalletScene(model: $model.walletSelectorModel)

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
@@ -16,60 +16,53 @@ public struct SignMessageScene: View {
     }
 
     public var body: some View {
-        VStack {
-            List {
-                Section {
-                    ListItemImageView(
-                        title: Localized.WalletConnect.app,
-                        subtitle: model.appText,
-                        assetImage: model.appAssetImage
-                    )
-                    .contextMenu(
-                        .url(title: Localized.WalletConnect.website, onOpen: model.onViewWebsite)
-                    )
-                    ListItemView(title: Localized.Common.wallet, subtitle: model.walletText)
-                    ListItemView(title: Localized.Transfer.network, subtitle: model.networkText)
-                }
+        List {
+            Section {
+                ListItemImageView(
+                    title: Localized.WalletConnect.app,
+                    subtitle: model.appText,
+                    assetImage: model.appAssetImage
+                )
+                .contextMenu(
+                    .url(title: Localized.WalletConnect.website, onOpen: model.onViewWebsite)
+                )
+                ListItemView(title: Localized.Common.wallet, subtitle: model.walletText)
+                ListItemView(title: Localized.Transfer.network, subtitle: model.networkText)
+            }
 
-                switch model.messageDisplayType {
-                case .sections(let sections):
-                    ForEach(sections) { section in
-                        Section {
-                            ForEach(section.values) { item in
-                                ListItemView(
-                                    title: item.title,
-                                    subtitle: item.value
-                                )
-                                
-                            }
-                        } header: {
-                            if let title = section.title {
-                                Text(title)
-                            }
+            switch model.messageDisplayType {
+            case .sections(let sections):
+                ForEach(sections) { section in
+                    Section {
+                        ForEach(section.values) { item in
+                            ListItemView(
+                                title: item.title,
+                                subtitle: item.value
+                            )
+                            
+                        }
+                    } header: {
+                        if let title = section.title {
+                            Text(title)
                         }
                     }
-                    NavigationCustomLink(with: ListItemView(title: Localized.SignMessage.viewFullMessage)) {
-                        model.onViewFullMessage()
-                    }
-                case .text(let string):
-                    Section(Localized.SignMessage.message) {
-                        Text(string)
-                    }
+                }
+                NavigationCustomLink(with: ListItemView(title: Localized.SignMessage.viewFullMessage)) {
+                    model.onViewFullMessage()
+                }
+            case .text(let string):
+                Section(Localized.SignMessage.message) {
+                    Text(string)
                 }
             }
-            
-            Button(role: .none) { sign() } label: {
-                HStack {
-                    //Image(systemName: model.buttonImage)
-                    Text(model.buttonTitle)
-                }
-            }
-            .buttonStyle(.blue())
-            .padding(.bottom, .scene.bottom)
+        }
+        .footerView {
+            StateButton(
+                text: model.buttonTitle,
+                action: sign
+            )
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationTitle(Localized.SignMessage.title)
         .safariSheet(url: $model.isPresentingUrl)
         .sheet(isPresented: $model.isPresentingMessage) {

--- a/Packages/Components/Sources/ViewModifiers/FooterViewModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/FooterViewModifier.swift
@@ -1,0 +1,30 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Style
+
+public struct FooterViewModifier<FooterContent: View>: ViewModifier {
+    private let footerContent: () -> FooterContent
+    
+    public init(@ViewBuilder footerContent: @escaping () -> FooterContent) {
+        self.footerContent = footerContent
+    }
+    
+    public func body(content: Content) -> some View {
+        VStack(spacing: .medium) {
+            content
+                .scrollContentBackground(.hidden)
+            Spacer()
+            footerContent()
+        }
+        .padding(.bottom, .scene.bottom)
+    }
+}
+
+public extension View {
+    func footerView<FooterContent: View>(
+        @ViewBuilder footer: @escaping () -> FooterContent
+    ) -> some View {
+        modifier(FooterViewModifier(footerContent: footer))
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #840 - Invalid background color under "Agree and Continue" button on macOS

Created reusable `FooterViewModifier` to eliminate VStack + List + Spacer + Button duplication pattern and fix background color rendering issues.

## Changes
- Added `FooterViewModifier` with proper background and padding handling
- Refactored 14 scene files to use new `footerView` modifier
- Replaced `Button` with `StateButton` for consistency  
- Removed redundant VStack wrappers and background modifiers

## Files changed
- `Packages/Components/Sources/ViewModifiers/FooterViewModifier.swift` (new)
- 14 scene files refactored to use the new pattern

🤖 Generated with [Claude Code](https://claude.ai/code)