### PR TITLE
Fix RecipientScene button validation for empty address field

### DIFF
--- a/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
@@ -72,7 +72,7 @@ public final class RecipientSceneViewModel {
     var actionButtonTitle: String { Localized.Common.continue }
     var actionButtonState: ButtonState {
         switch nameResolveState {
-        case .none: addressInputModel.isValid || addressInputModel.text.isEmpty ? .normal : .disabled
+        case .none: addressInputModel.isValid && addressInputModel.text.isNotEmpty ? .normal : .disabled
         case .loading, .error: .disabled
         case .complete: .normal
         }

--- a/Features/Transfer/Tests/RecipientSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/RecipientSceneViewModelTests.swift
@@ -52,8 +52,19 @@ struct RecipientSceneViewModelTests {
     @Test
     func actionButtonState() {
         let model = RecipientSceneViewModel.mock()
+
+        #expect(model.actionButtonState == .disabled)
+        
+        model.addressInputModel.text = "0x1234567890123456789012345678901234567890"
+        _ = model.addressInputModel.update()
+
         #expect(model.actionButtonState == .normal)
         
+        model.addressInputModel.text = "invalid"
+        _ = model.addressInputModel.update()
+
+        #expect(model.actionButtonState == .disabled)
+
         model.nameResolveState = .loading
         #expect(model.actionButtonState == .disabled)
         

--- a/Packages/Blockchain/Package.swift
+++ b/Packages/Blockchain/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
                 "Preferences",
                 .product(name: "NativeProviderService", package: "SystemServices"),
             ],
-            path: "Sources",
+            path: "Sources"
         ),
         .target(
             name: "BlockchainTestKit",


### PR DESCRIPTION
## Summary
Fixes #1091 - Continue button should be inactive for empty Address field

## Changes
- Fixed validation logic in `RecipientSceneViewModel.actionButtonState` to properly disable button when address field is empty
- Changed from `(isValid || isEmpty)` to `(isValid && isNotEmpty)` ensuring button is only enabled with valid non-empty content
- Added comprehensive test coverage for button state validation

## Test Plan
- [x] Added unit tests covering:
  - Empty address scenario (button disabled)
  - Valid address scenario (button enabled)  
  - Invalid address scenario (button disabled)
  - Name resolution states (loading/complete)
- [x] All tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)