### PR TITLE
Fix wrong background color in SearchableListView

### DIFF
--- a/Packages/Blockchain/Package.swift
+++ b/Packages/Blockchain/Package.swift
@@ -39,7 +39,7 @@ let package = Package(
                 "Preferences",
                 .product(name: "NativeProviderService", package: "SystemServices"),
             ],
-            path: "Sources",
+            path: "Sources"
         ),
         .target(
             name: "BlockchainTestKit",

--- a/Packages/Components/Sources/ListViews/SearchableListView.swift
+++ b/Packages/Components/Sources/ListViews/SearchableListView.swift
@@ -24,20 +24,17 @@ public struct SearchableListView<Item: Identifiable & Hashable, Content: View, E
     }
 
     public var body: some View {
-        VStack {
-            ListView(
-                items: filteredItems,
-                content: content
-            )
-            .searchable(
-                text: $searchQuery,
-                placement: .navigationBarDrawer(displayMode: .always)
-            )
-        }
+        ListView(
+            items: filteredItems,
+            content: content
+        )
+        .searchable(
+            text: $searchQuery,
+            placement: .navigationBarDrawer(displayMode: .always)
+        )
         .autocorrectionDisabled(true)
         .scrollDismissesKeyboard(.interactively)
         .scrollContentBackground(.hidden)
-        .background { Colors.insetGroupedListStyle.ignoresSafeArea() }
         .overlay {
             if filteredItems.isEmpty {
                 emptyContent()


### PR DESCRIPTION
## Summary
Fixes #1090 - Select Networks in the filter has the wrong background color

## Changes
- Removed explicit background color setting from SearchableListView
- Removed unnecessary VStack wrapper (done by linter)
- Background color is now automatically inherited from the screen presentation type

## Technical Details
The previous implementation explicitly set `Colors.insetGroupedListStyle` as background which returned black color for dark mode instead of the proper system background. The new implementation removes the explicit background setting, allowing the background color to be automatically determined by the screen's presentation context, providing consistent appearance across light and dark themes.

## Test Plan
- [x] Verified build succeeds
- [x] Manual testing in light/dark themes to confirm proper background color

## Screenshots
<img width="1456" height="786" alt="collage_3c95e26b-a798-4e46-86d7-f8fe71a64489" src="https://github.com/user-attachments/assets/207a56fa-3c35-49c1-a4e5-48c8a069f381" />
<img width="1456" height="786" alt="collage_929e291a-90f9-4bb5-aabe-cc33f3bd25b8" src="https://github.com/user-attachments/assets/f2b54a14-a9a0-46f1-9ba2-365a4a24aa84" />


🤖 Generated with [Claude Code](https://claude.ai/code)