### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
     runs-on: macos-15
 
     steps:
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+        
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/justfile
+++ b/justfile
@@ -77,7 +77,11 @@ build-package PACKAGE:
     SWIFT_OPTIMIZATION_LEVEL=-Onone \
     build | xcbeautify {{XCBEAUTIFY_ARGS}}
 
-test-all:
+show-simulator:
+    @echo "Destination: {{SIMULATOR_DEST}}"
+    @xcrun simctl list devices | grep "iPhone 16" | head -1 || true
+
+test-all: show-simulator
     @set -o pipefail && xcodebuild -project Gem.xcodeproj \
     -scheme Gem \
     -sdk iphonesimulator \
@@ -99,7 +103,7 @@ test-ui:
     -allowProvisioningDeviceRegistration \
     test | xcbeautify {{XCBEAUTIFY_ARGS}}
 
-test TARGET:
+test TARGET: show-simulator
     @set -o pipefail && xcodebuild -project Gem.xcodeproj \
     -scheme Gem \
     -sdk iphonesimulator \

--- a/justfile
+++ b/justfile
@@ -79,7 +79,7 @@ build-package PACKAGE:
 
 show-simulator:
     @echo "Destination: {{SIMULATOR_DEST}}"
-    @xcrun simctl list devices | grep "iPhone 16" | head -1 || true
+    @xcrun simctl list devices | grep "iPhone" | head -5 || true
 
 test-all: show-simulator
     @set -o pipefail && xcodebuild -project Gem.xcodeproj \


### PR DESCRIPTION
## Summary
Fix GitHub Actions CI build for macOS-15 runner

## Changes
- Add explicit Xcode 16.4 selection in CI workflow
- Add show-simulator command to display selected simulator info
- Update simulator configuration for compatibility

## Test Plan
- [x] Local build succeeds
- [ ] GitHub Actions CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)