### PR TITLE
Fix lock screen not showing after inactive→active transition

### DIFF
--- a/Features/LockManager/Sources/ViewModels/LockSceneViewModel.swift
+++ b/Features/LockManager/Sources/ViewModels/LockSceneViewModel.swift
@@ -69,9 +69,9 @@ extension LockSceneViewModel {
             showPlaceholderPreview = false
             if inBackground {
                 inBackground = false
-                if state == .unlocked && shouldLock {
-                    state = .locked
-                }
+            }
+            if state == .unlocked && shouldLock {
+                state = .locked
             }
         case .inactive:
             showPlaceholderPreview = true

--- a/Features/LockManager/Tests/LockSceneViewModelTests.swift
+++ b/Features/LockManager/Tests/LockSceneViewModelTests.swift
@@ -165,7 +165,6 @@ struct LockSceneViewModelTests {
         #expect(viewModel.lastUnlockTime == .distantFuture)
     }
 
-
     func testIsLockedPropertyWhenAuthEnabled() {
         let mockService = MockBiometryAuthenticationService(
             isAuthEnabled: true,
@@ -431,6 +430,24 @@ struct LockSceneViewModelTests {
         #expect(viewModel.state == .unlocked)
         #expect(!viewModel.shouldShowLockScreen)
         #expect(!viewModel.isLocked)
+    }
+
+    @Test
+    func inactiveToActiveTransitionWithoutBackgroundLocksWhenExpired() {
+        let mockService = MockBiometryAuthenticationService(
+            isAuthEnabled: true,
+            availableAuth: .biometrics,
+            lockPeriod: .oneMinute
+        )
+        let viewModel = LockSceneViewModel(service: mockService)
+        viewModel.state = .unlocked
+        viewModel.lastUnlockTime = Date(timeIntervalSince1970: 0)
+
+        viewModel.handleSceneChange(to: .inactive)
+        viewModel.handleSceneChange(to: .active)
+
+        #expect(viewModel.state == .locked)
+        #expect(viewModel.shouldShowLockScreen == true)
     }
 }
 

--- a/Features/LockManager/Tests/LockSceneViewModelTests.swift
+++ b/Features/LockManager/Tests/LockSceneViewModelTests.swift
@@ -447,7 +447,7 @@ struct LockSceneViewModelTests {
         viewModel.handleSceneChange(to: .active)
 
         #expect(viewModel.state == .locked)
-        #expect(viewModel.shouldShowLockScreen == true)
+        #expect(viewModel.shouldShowLockScreen)
     }
 }
 


### PR DESCRIPTION
closes #1077

Fixed a bug where the lock screen would show only a splash placeholder without authentication prompt when the app transitioned directly from inactive to active state (without going through background). This occurred when quickly switching between apps and the lock timer expired.

The issue was that the lock state check only happened when coming from background. Now the lock state is always checked when becoming active, ensuring proper authentication is triggered regardless of the previous scene phase.

- Move lock state check outside the inBackground condition
- Add test for inactive→active transition without background
- Ensure splash placeholder is cleared on active state

🤖 Generated with [Claude Code](https://claude.ai/code)