### PR TITLE
Job runner Fix retry interval timing in JobRunner

### DIFF
--- a/Packages/Primitives/Sources/JobRunner/JobRunner.swift
+++ b/Packages/Primitives/Sources/JobRunner/JobRunner.swift
@@ -38,6 +38,7 @@ extension JobRunner {
     private func runJob(_ job: Job) async {
         var interval = RetryIntervalCalculator.initialInterval(for: job.configuration)
         let jobStart = clock.now
+        let deadline = job.configuration.timeLimit.map { jobStart.advanced(by: $0) }
 
         while !Task.isCancelled {
             if let limit = job.configuration.timeLimit,
@@ -59,7 +60,6 @@ extension JobRunner {
                 return
             case .retry:
                 let nextAttempt = attemptStart.advanced(by: interval)
-                let deadline = job.configuration.timeLimit.map { jobStart.advanced(by: $0) }
                 let sleepUntil = deadline.map { min(nextAttempt, $0) } ?? nextAttempt
 
                 if clock.now < sleepUntil {

--- a/Packages/Primitives/Tests/PrimitivesTests/JobRunnerTests.swift
+++ b/Packages/Primitives/Tests/PrimitivesTests/JobRunnerTests.swift
@@ -1,0 +1,119 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Testing
+@testable import Primitives
+
+struct JobRunnerTests {
+
+    @Test
+    func jobCompletes() async {
+        let job = MockJob(
+            completeAfter: 1,
+            configuration: .fixed(duration: .milliseconds(5))
+        )
+        let runner = JobRunner()
+
+        await runner.addJob(job: job)
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        #expect(job.runCount == 1)
+        #expect(job.completed)
+    }
+
+    @Test
+    func jobRetriesFixed() async {
+        let job = MockJob(
+            completeAfter: 3,
+            configuration: .fixed(duration: .milliseconds(5))
+        )
+        let runner = JobRunner()
+
+        await runner.addJob(job: job)
+        try? await Task.sleep(nanoseconds: 30_000_000)
+
+        #expect(job.runCount == 3)
+        #expect(job.completed)
+    }
+
+    @Test
+    func jobRetriesAdaptive() async {
+        let job = MockJob(
+            completeAfter: 3,
+            configuration: .adaptive(
+                configuration: AdaptiveConfiguration(
+                    initialInterval: .milliseconds(5),
+                    maxInterval: .milliseconds(20),
+                    stepFactor: 2.0
+                ),
+                timeLimit: .none
+            )
+        )
+        let runner = JobRunner()
+
+        await runner.addJob(job: job)
+        try? await Task.sleep(nanoseconds: 40_000_000)
+
+        #expect(job.runCount == 3)
+        #expect(job.completed)
+    }
+
+    @Test
+    func jobRespectsTimeLimit() async {
+        let job = MockJob(
+            completeAfter: 100,
+            configuration: .fixed(duration: .milliseconds(5), timeLimit: .milliseconds(20))
+        )
+        let runner = JobRunner()
+
+        await runner.addJob(job: job)
+        try? await Task.sleep(nanoseconds: 30_000_000)
+
+        #expect(job.runCount > 0)
+        #expect(job.runCount < 100)
+        #expect(!job.completed)
+    }
+
+    @Test
+    func jobCancels() async {
+        let job = MockJob(
+            completeAfter: 100,
+            configuration: .fixed(duration: .milliseconds(5))
+        )
+        let runner = JobRunner()
+
+        await runner.addJob(job: job)
+        await runner.cancelJob(id: job.id)
+        try? await Task.sleep(nanoseconds: 10_000_000)
+
+        #expect(job.runCount <= 1)
+        #expect(!job.completed)
+    }
+}
+
+// MARK: - Mock
+
+private final class MockJob: Job, @unchecked Sendable {
+    let id = UUID().uuidString
+    let configuration: JobConfiguration
+    let completeAfter: Int
+    
+    private(set) var runCount = 0
+    private(set) var completed = false
+
+    init(completeAfter: Int, configuration: JobConfiguration) {
+        self.completeAfter = completeAfter
+        self.configuration = configuration
+    }
+
+    func run() async -> JobStatus {
+        runCount += 1
+        if runCount >= completeAfter {
+            completed = true
+            return .complete
+        }
+        return .retry
+    }
+
+    func onComplete() async throws {}
+}


### PR DESCRIPTION
Calculate sleep duration from attempt start time instead of current time to ensure consistent intervals between retries. Previously, if job execution took time, the actual interval would be longer than configured.