### PR TITLE
Set icon color to white in RoundButton

### DIFF
--- a/Packages/Components/Sources/Buttons/RoundButton.swift
+++ b/Packages/Components/Sources/Buttons/RoundButton.swift
@@ -27,6 +27,7 @@ public struct RoundButton: View {
         } label: {
             VStack(alignment: .center) {
                 image
+                    .foregroundStyle(Colors.whiteSolid)
                     .frame(width: 48, height: 48)
                     .background(Colors.blue)
                     .cornerRadius(24)


### PR DESCRIPTION
Added a foregroundStyle modifier to the image in RoundButton to ensure the icon is displayed in white, improving visibility against the blue background.

<img width="320" alt="Simulator Screenshot - Gem Main iPhone | 16 Pro - 2025-09-10 at 22 00 12" src="https://github.com/user-attachments/assets/523a8f90-d7bd-45c4-9e29-2490169c467b" />
<img width="320" alt="Simulator Screenshot - Gem Main iPhone | 16 Pro - 2025-09-10 at 22 00 15" src="https://github.com/user-attachments/assets/7edca97d-0ea2-4f4b-80e7-a3f0500c45e4" />
