### PR TITLE
Improve Swap button state handling and tests

### DIFF
--- a/Features/Swap/Sources/ViewModels/SwapButtonViewModel.swift
+++ b/Features/Swap/Sources/ViewModels/SwapButtonViewModel.swift
@@ -52,10 +52,12 @@ struct SwapButtonViewModel: StateButtonViewable {
 
     var icon: Image? { nil }
     var type: ButtonType {
-        if canRetrySwap {
-            return .primary(.normal)
+        switch buttonAction {
+        case .retryQuotes: swapState.quotes.isLoading ? .primary(swapState.quotes) : .primary(.normal)
+        case .insufficientBalance: .primary(.disabled)
+        case .retrySwap: swapState.swapTransferData.isLoading ? .primary(swapState.swapTransferData) : .primary(.normal)
+        case .swap: swapState.swapTransferData.isLoading ? .primary(swapState.swapTransferData) : .primary(swapState.quotes)
         }
-        return .primary(swapState.quotes, isDisabled: !isAmountValid && !canRetryQuotes)
     }
     var isVisible: Bool { !swapState.quotes.isNoData }
 
@@ -70,7 +72,7 @@ extension SwapButtonViewModel {
               let retryableError = error as? RetryableError else { return false }
         return retryableError.isRetryAvailable
     }
-    
+
     private var canRetrySwap: Bool {
         guard case .error(let error) = swapState.swapTransferData,
               let retryableError = error as? RetryableError else { return false }

--- a/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
+++ b/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
@@ -167,6 +167,7 @@ extension SwapSceneViewModel {
             )
         } catch {
             swapState.quotes = .noData
+            swapState.swapTransferData = .noData
             swapState.fetch = .idle
             selectedSwapQuote = nil
         }

--- a/Features/Swap/Tests/SwapTests/SwapButtonViewModelTests.swift
+++ b/Features/Swap/Tests/SwapTests/SwapButtonViewModelTests.swift
@@ -35,6 +35,15 @@ struct SwapButtonViewModelTests {
     }
     
     @Test
+    func retrySwapShowsLoadingWhenInProgress() {
+        let swapState = SwapState(availability: .data([]), swapTransferData: .loading)
+        let viewModel = SwapButtonViewModel.mock(swapState: swapState)
+
+        #expect(viewModel.type == ButtonType.primary(.loading()))
+        #expect(viewModel.isVisible == true)
+    }
+    
+    @Test
     func insufficientBalanceWhenAmountInvalid() {
         let asset = AssetData.mock(asset: .mock(symbol: "BTC"))
         let swapState = SwapState(availability: .data([]))


### PR DESCRIPTION
Refactored SwapButtonViewModel to better handle button states based on swap actions and loading status. Updated SwapSceneViewModel to reset swapTransferData on quote fetch error. Added a test to verify loading state for retrySwap in SwapButtonViewModelTests.