### PR TITLE
Refactor dialog and button styles in Swap and Transaction scenes

### DIFF
--- a/Features/Swap/Sources/Scenes/SwapScene.swift
+++ b/Features/Swap/Sources/Scenes/SwapScene.swift
@@ -25,22 +25,22 @@ public struct SwapScene: View {
             swapList
                 .padding(.bottom, .scene.button.height)
             bottomActionView
-        }
-        .confirmationDialog(
-            model.swapDetailsViewModel?.highImpactWarningTitle ?? "",
-            presenting: $model.isPresentingPriceImpactConfirmation,
-            sensoryFeedback: .warning,
-            actions: { _ in
-                Button(
-                    model.buttonViewModel.title,
-                    role: .destructive,
-                    action: model.onSelectSwapConfirmation
+                .confirmationDialog(
+                    model.swapDetailsViewModel?.highImpactWarningTitle ?? "",
+                    presenting: $model.isPresentingPriceImpactConfirmation,
+                    sensoryFeedback: .warning,
+                    actions: { _ in
+                        Button(
+                            model.buttonViewModel.title,
+                            role: .destructive,
+                            action: model.onSelectSwapConfirmation
+                        )
+                    },
+                    message: {
+                        Text(model.isPresentingPriceImpactConfirmation ?? "")
+                    }
                 )
-            },
-            message: {
-                Text(model.isPresentingPriceImpactConfirmation ?? "")
-            }
-        )
+        }
         .background(Colors.grayBackground)
         .navigationTitle(model.title)
         .onChangeObserveQuery(

--- a/Features/Transactions/Sources/Scenes/TransactionScene.swift
+++ b/Features/Transactions/Sources/Scenes/TransactionScene.swift
@@ -48,12 +48,15 @@ public struct TransactionScene: View {
                     .tint(Colors.black)
             }
         case let .swapAgain(text):
-            StateButton(
+            let button = StateButton(
                 text: text,
                 type: .primary(.normal),
                 action: model.onSelectTransactionHeader
             )
             .cleanListRow(topOffset: .zero)
+            if #available(iOS 26, *) {
+                button.cornerRadius(.scene.button.height / 2) // TODO: - Think about what to do with this button
+            }
         case .empty:
             EmptyView()
         }

--- a/Features/Transactions/Sources/Scenes/TransactionsFilterScene.swift
+++ b/Features/Transactions/Sources/Scenes/TransactionsFilterScene.swift
@@ -34,13 +34,11 @@ public struct TransactionsFilterScene: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(model.clear, action: onSelectClear)
                         .bold()
-                        .buttonStyle(.plain)
                 }
             }
             ToolbarItem(placement: .primaryAction) {
                 Button(model.done, action: onSelectDone)
                     .bold()
-                    .buttonStyle(.plain)
             }
         }
         .sheet(isPresented: $model.isPresentingChains) {


### PR DESCRIPTION
Moved the confirmationDialog modifier inside the bottomActionView in SwapScene for better structure. In TransactionScene, added conditional corner radius for the swap again button on iOS 26 and above. Removed unnecessary .buttonStyle(.plain) from toolbar buttons in TransactionsFilterScene.

<img width="320" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 23 26 53" src="https://github.com/user-attachments/assets/6fe551e0-b4c8-4f6f-8e30-0fac20538a34" />
<img width="320" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-11 at 23 27 45" src="https://github.com/user-attachments/assets/da434df1-884a-4948-b5cd-b3d79a4b55f3" />

Fix: https://github.com/gemwalletcom/gem-ios/issues/1152