### PR TITLE
Refactor support docs to use new WebViewScene

### DIFF
--- a/Features/Support/Sources/Scenes/SupportScene.swift
+++ b/Features/Support/Sources/Scenes/SupportScene.swift
@@ -16,14 +16,13 @@ public struct SupportScene: View {
     
     public var body: some View {
         NavigationView {
-            VStack {
-                switch model.selectedType {
-                case .support:
-                    ChatwootWebScene(model: model.chatwootModel)
-                case .docs:
-                    WebView(url: model.helpCenterURL)
-                }
+            TabView(selection: $model.selectedType) {
+                ChatwootWebScene(model: model.chatwootModel)
+                    .tag(SupportType.support)
+                WebViewScene(url: model.helpCenterURL)
+                    .tag(SupportType.docs)
             }
+            .tabViewStyle(.page(indexDisplayMode: .never))
             .background(Colors.grayBackground)
             .toolbarTitleDisplayMode(.inline)
             .toolbar {

--- a/Features/Support/Sources/Scenes/WebViewScene.swift
+++ b/Features/Support/Sources/Scenes/WebViewScene.swift
@@ -1,0 +1,22 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Components
+
+public struct WebViewScene: View {
+    @State var model: WebSceneViewModel
+    
+    public init(url: URL) {
+        _model = State(initialValue: WebSceneViewModel(url: url))
+    }
+    
+    public var body: some View {
+        ZStack {
+            WebView(model: model)
+            
+            if model.isLoading {
+                LoadingView()
+            }
+        }
+    }
+}

--- a/Features/Support/Sources/ViewModels/WebSceneViewModel.swift
+++ b/Features/Support/Sources/ViewModels/WebSceneViewModel.swift
@@ -1,0 +1,32 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import WebKit
+import SwiftUI
+
+@Observable
+@MainActor
+public final class WebSceneViewModel: NSObject, Sendable {
+    let url: URL
+    var isLoading: Bool = true
+    
+    public init(url: URL) {
+        self.url = url
+    }
+}
+
+// MARK: - WKNavigationDelegate
+
+extension WebSceneViewModel: WKNavigationDelegate {
+    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation) {
+        isLoading = true
+    }
+    
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation) {
+        isLoading = false
+    }
+    
+    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation, withError error: Error) {
+        isLoading = false
+    }
+}

--- a/Features/Support/Sources/Views/WebView.swift
+++ b/Features/Support/Sources/Views/WebView.swift
@@ -3,23 +3,20 @@
 import SwiftUI
 import WebKit
 
-public struct WebView: UIViewRepresentable {
-    let url: URL
+struct WebView: UIViewRepresentable {
+    let model: WebSceneViewModel
     
-    public init(url: URL) {
-        self.url = url
-    }
-    
-    public func makeUIView(context: Context) -> WKWebView {
+    func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView()
         webView.isOpaque = false
         webView.backgroundColor = UIColor.clear
         webView.scrollView.backgroundColor = UIColor.clear
+        webView.navigationDelegate = model
         return webView
     }
     
-    public func updateUIView(_ webView: WKWebView, context: Context) {
-        let request = URLRequest(url: url)
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let request = URLRequest(url: model.url)
         webView.load(request)
     }
 }


### PR DESCRIPTION
Replaces the direct use of WebView in SupportScene with a new WebViewScene, which manages loading state via WebSceneViewModel. Moves and updates WebView implementation to use a view model and navigation delegate for better state handling. Adds WebViewScene and WebSceneViewModel to encapsulate web view logic and loading indicator.