### PR TITLE
Refactor button backgrounds and add safe area handling

### DIFF
--- a/Features/Assets/Sources/Scenes/AddTokenScene.swift
+++ b/Features/Assets/Sources/Scenes/AddTokenScene.swift
@@ -27,35 +27,33 @@ public struct AddTokenScene: View {
     }
 
     public var body: some View {
-        VStack {
-            addTokenList
-            Spacer()
-            StateButton(
-                text: model.actionButtonTitle,
-                type: .primary(model.state),
-                action: onSelectImportToken
-            )
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .toolbarInfoButton(url: model.customTokenUrl)
-        .onAppear {
-            focusedField = .address
-        }
-        .onChange(of: model.input.address, onAddressClean)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
-        .listSectionSpacing(.compact)
-        .navigationTitle(model.title)
-        .navigationDestination(for: Scenes.NetworksSelector.self) { _ in
-            NetworkSelectorScene(
-                model: $networksModel,
-                onFinishSelection: onFinishChainSelection(chains:)
-            )
-        }
-        .sheet(isPresented: $model.isPresentingScanner) {
-            ScanQRCodeNavigationStack(action: onHandleScan(_:))
-        }
-        .safariSheet(url: $isPresentingUrl)
+        addTokenList
+            .safeAreaView {
+                StateButton(
+                    text: model.actionButtonTitle,
+                    type: .primary(model.state),
+                    action: onSelectImportToken
+                )
+                .frame(maxWidth: .scene.button.maxWidth)
+                .padding(.bottom, .scene.bottom)
+            }
+            .toolbarInfoButton(url: model.customTokenUrl)
+            .onAppear {
+                focusedField = .address
+            }
+            .onChange(of: model.input.address, onAddressClean)
+            .listSectionSpacing(.compact)
+            .navigationTitle(model.title)
+            .navigationDestination(for: Scenes.NetworksSelector.self) { _ in
+                NetworkSelectorScene(
+                    model: $networksModel,
+                    onFinishSelection: onFinishChainSelection(chains:)
+                )
+            }
+            .sheet(isPresented: $model.isPresentingScanner) {
+                ScanQRCodeNavigationStack(action: onHandleScan(_:))
+            }
+            .safariSheet(url: $isPresentingUrl)
     }
 }
 

--- a/Features/FiatConnect/Sources/Scenes/FiatScene.swift
+++ b/Features/FiatConnect/Sources/Scenes/FiatScene.swift
@@ -21,29 +21,27 @@ public struct FiatScene: View {
 
     public var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                CurrencyInputView(
-                    text: $model.amountText,
-                    config: model.currencyInputConfig
-                )
-                .focused($focusedField, equals: model.input.type == .buy ? .amountBuy : .amountSell)
-                .padding(.top, .medium)
-                .listGroupRowStyle()
-                amountSelectorSection
-                providerSection
-            }
-            .contentMargins([.top], .zero, for: .scrollContent)
-            Spacer()
+        List {
+            CurrencyInputView(
+                text: $model.amountText,
+                config: model.currencyInputConfig
+            )
+            .focused($focusedField, equals: model.input.type == .buy ? .amountBuy : .amountSell)
+            .padding(.top, .medium)
+            .listGroupRowStyle()
+            amountSelectorSection
+            providerSection
+        }
+        .safeAreaView {
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.state, showProgress: false),
                 action: model.onSelectContinue
             )
             .frame(maxWidth: .scene.button.maxWidth)
+            .padding(.bottom, .scene.bottom)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .contentMargins([.top], .zero, for: .scrollContent)
         .frame(maxWidth: .infinity)
         .onChange(of: model.focusField, onChangeFocus)
         .onChange(of: model.input.type, model.onChangeType)

--- a/Features/Onboarding/Sources/Scenes/AcceptTermsScene.swift
+++ b/Features/Onboarding/Sources/Scenes/AcceptTermsScene.swift
@@ -15,37 +15,33 @@ struct AcceptTermsScene: View {
     }
 
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: model.message))
-                    .cleanListRow()
-
-                ForEach($model.items) { $item in
-                    Section {
-                        Toggle(isOn: $item.isConfirmed) {
-                            Text(item.message)
-                                .textStyle(item.style)
-                        }
-                        .accessibilityIdentifier(item.id)
-                        .toggleStyle(CheckboxStyle(position: .left))
+        List {
+            CalloutView(style: .header(title: model.message))
+                .cleanListRow()
+            
+            ForEach($model.items) { $item in
+                Section {
+                    Toggle(isOn: $item.isConfirmed) {
+                        Text(item.message)
+                            .textStyle(item.style)
                     }
-                    .listRowInsets(.assetListRowInsets)
+                    .accessibilityIdentifier(item.id)
+                    .toggleStyle(CheckboxStyle(position: .left))
                 }
+                .listRowInsets(.assetListRowInsets)
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-            
-            Spacer()
-            
+        }
+        .safeAreaView {
             StateButton(
                 text: Localized.Onboarding.AcceptTerms.continue,
                 type: .primary(model.state),
                 action: { model.onNext?() }
             )
             .frame(maxWidth: .scene.button.maxWidth)
+            .padding(.bottom, .scene.bottom)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .navigationTitle(model.title)
         .toolbarTitleDisplayMode(.inline)
         .toolbarInfoButton(url: model.termsAndServicesURL)

--- a/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
@@ -21,94 +21,91 @@ struct ImportWalletScene: View {
     }
 
     var body: some View {
-        VStack {
-            Form {
-                Section {
-                    FloatTextField(
-                        model.walletFieldTitle,
-                        text: $model.name,
-                        allowClean: focusedField == .name
-                    )
-                    .focused($focusedField, equals: .name)
-                }
-                Section {
-                    VStack {
-                        if model.showImportTypes {
-                            Picker("", selection: $model.importType) {
-                                ForEach(model.importTypes) { type in
-                                    Text(type.title).tag(type)
-                                }
-                            }
-                            .pickerStyle(.segmented)
-                        }
-                        HStack {
-                            TextField(
-                                model.importType.description,
-                                text: $model.input,
-                                axis: .vertical
-                            )
-                            .autocorrectionDisabled(true)
-                            .textInputAutocapitalization(.never)
-                            .lineLimit(8)
-                            .keyboardType(.asciiCapable)
-                            .frame(minHeight: 80, alignment: .top)
-                            .focused($focusedField, equals: .input)
-                            .toolbar {
-                                if model.importType.showToolbar {
-                                    ToolbarItem(placement: .keyboard) {
-                                        WordSuggestionView(
-                                            words: model.wordsSuggestion,
-                                            selectWord: model.onSelectWord
-                                        )
-                                    }
-                                }
-                            }
-                            .padding(.top, .small + .tiny)
-
-                            if let nameRecordViewModel = model.nameRecordViewModel, model.importType == .address {
-                                NameRecordView(
-                                    model: nameRecordViewModel,
-                                    state: $model.nameResolveState,
-                                    address: $model.input
-                                )
+        Form {
+            Section {
+                FloatTextField(
+                    model.walletFieldTitle,
+                    text: $model.name,
+                    allowClean: focusedField == .name
+                )
+                .focused($focusedField, equals: .name)
+            }
+            Section {
+                VStack {
+                    if model.showImportTypes {
+                        Picker("", selection: $model.importType) {
+                            ForEach(model.importTypes) { type in
+                                Text(type.title).tag(type)
                             }
                         }
-
-                        HStack(alignment: .center, spacing: .medium) {
-                            ListButton(
-                                title: model.pasteButtonTitle,
-                                image: model.pasteButtonImage,
-                                action: model.onPaste
-                            )
-                            if model.type != .multicoin {
-                                ListButton(
-                                    title: model.qrButtonTitle,
-                                    image: model.qrButtonImage,
-                                    action: model.onSelectScanQR
-                                )
+                        .pickerStyle(.segmented)
+                    }
+                    HStack {
+                        TextField(
+                            model.importType.description,
+                            text: $model.input,
+                            axis: .vertical
+                        )
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
+                        .lineLimit(8)
+                        .keyboardType(.asciiCapable)
+                        .frame(minHeight: 80, alignment: .top)
+                        .focused($focusedField, equals: .input)
+                        .toolbar {
+                            if model.importType.showToolbar {
+                                ToolbarItem(placement: .keyboard) {
+                                    WordSuggestionView(
+                                        words: model.wordsSuggestion,
+                                        selectWord: model.onSelectWord
+                                    )
+                                }
                             }
+                        }
+                        .padding(.top, .small + .tiny)
+                        
+                        if let nameRecordViewModel = model.nameRecordViewModel, model.importType == .address {
+                            NameRecordView(
+                                model: nameRecordViewModel,
+                                state: $model.nameResolveState,
+                                address: $model.input
+                            )
                         }
                     }
-                    .listRowBackground(Colors.white)
-                } footer: {
-                    if let text = model.footerText {
-                        Text(text)
-                    } 
+                    
+                    HStack(alignment: .center, spacing: .medium) {
+                        ListButton(
+                            title: model.pasteButtonTitle,
+                            image: model.pasteButtonImage,
+                            action: model.onPaste
+                        )
+                        if model.type != .multicoin {
+                            ListButton(
+                                title: model.qrButtonTitle,
+                                image: model.qrButtonImage,
+                                action: model.onSelectScanQR
+                            )
+                        }
+                    }
+                }
+                .listRowBackground(Colors.white)
+            } footer: {
+                if let text = model.footerText {
+                    Text(text)
                 }
             }
-            .listSectionSpacing(.compact)
-
-            Spacer()
+        }
+        .safeAreaView {
             StateButton(
                 text: Localized.Wallet.Import.action,
                 type: .primary(model.buttonState),
                 action: model.onSelectActionButton
             )
             .frame(maxWidth: .scene.button.maxWidth)
+            .padding(.bottom, .scene.bottom)
         }
+        .listSectionSpacing(.compact)
         .contentMargins(.top, .scene.top, for: .scrollContent)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationBarTitle(model.title)
         .alertSheet($model.isPresentingAlertMessage)
         .sheet(isPresented: $model.isPresentingScanner) {

--- a/Features/Onboarding/Sources/Scenes/OnboardingScene.swift
+++ b/Features/Onboarding/Sources/Scenes/OnboardingScene.swift
@@ -15,10 +15,14 @@ public struct OnboardingScene: View {
         VStack {
             Spacer()
             VStack(alignment: .center, spacing: 24) {
-                Button(model.createWalletTitle, action: model.onCreateWallet)
-                    .buttonStyle(.blue())
-                Button(model.importWalletTitle, action: model.onImportWallet)
-                    .buttonStyle(.blue())
+                StateButton(
+                    text: model.createWalletTitle,
+                    action: model.onCreateWallet
+                )
+                StateButton(
+                    text: model.importWalletTitle,
+                    action: model.onImportWallet
+                )
             }
             .frame(maxWidth: .scene.button.maxWidth)
             .padding(.scene.bottom * 2)

--- a/Features/Onboarding/Sources/Scenes/SecurityReminderScene.swift
+++ b/Features/Onboarding/Sources/Scenes/SecurityReminderScene.swift
@@ -15,35 +15,30 @@ struct SecurityReminderScene: View {
     }
     
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: model.message))
-                    .cleanListRow()
-                
-                ForEach(model.items) { item in
-                    Section {
-                        ListItemView(
-                            title: TextValue(text: item.title, style: .headline),
-                            titleExtra: TextValue(text: item.subtitle, style: .bodySecondary),
-                            imageStyle: item.image
-                        )
-                    }
-                    .listRowInsets(.assetListRowInsets)
+        List {
+            CalloutView(style: .header(title: model.message))
+                .cleanListRow()
+            
+            ForEach(model.items) { item in
+                Section {
+                    ListItemView(
+                        title: TextValue(text: item.title, style: .headline),
+                        titleExtra: TextValue(text: item.subtitle, style: .bodySecondary),
+                        imageStyle: item.image
+                    )
                 }
+                .listRowInsets(.assetListRowInsets)
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-            
-            Spacer()
-            
+        }
+        .safeAreaView {
             StateButton(
                 text: Localized.Common.continue,
                 action: model.onNext
             )
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .navigationTitle(model.title)
         .toolbarTitleDisplayMode(.inline)
         .toolbarInfoButton(url: model.docsUrl)

--- a/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
@@ -13,42 +13,40 @@ struct ShowSecretDataScene: View {
     @State private var isPresentingCopyToast = false
 
     var body: some View {
-        VStack {
-            List {
-                if let calloutViewStyle = model.calloutViewStyle {
-                    CalloutView(style: calloutViewStyle)
-                        .cleanListRow()
-                }
-
-                Section {
-                    SecretDataTypeView(
-                        type: model.type
-                    )
-                }
-                .cleanListRow()
-
-                ListButton(
-                    title: Localized.Common.copy,
-                    image: Images.System.copy,
-                    action: copy
-                )
-                .frame(maxWidth: .infinity, alignment: .center)
-                .cleanListRow()
+        List {
+            if let calloutViewStyle = model.calloutViewStyle {
+                CalloutView(style: calloutViewStyle)
+                    .cleanListRow()
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
             
+            Section {
+                SecretDataTypeView(
+                    type: model.type
+                )
+            }
+            .cleanListRow()
+            
+            ListButton(
+                title: Localized.Common.copy,
+                image: Images.System.copy,
+                action: copy
+            )
+            .frame(maxWidth: .infinity, alignment: .center)
+            .cleanListRow()
+        }
+        .safeAreaView {
             if model.continueAction != nil {
                 StateButton(
                     text: Localized.Common.continue,
                     action: continueAction
                 )
                 .frame(maxWidth: .scene.button.maxWidth)
+                .padding(.bottom, .scene.bottom)
             }
         }
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .toolbarInfoButton(url: model.docsUrl)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationTitle(model.title)
         .copyToast(
             model: model.copyModel,

--- a/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
@@ -15,59 +15,57 @@ struct VerifyPhraseWalletScene: View {
     }
 
     var body: some View {
-        VStack(spacing: .medium) {
-            List {
-                CalloutView(style: .header(title: Localized.SecretPhrase.Confirm.QuickTest.title))
-                    .cleanListRow()
-                
-                Section {
-                    SecretPhraseGridView(
-                        rows: model.rows,
-                        highlightIndex: model.wordsIndex
-                    )
-                }
+        List {
+            CalloutView(style: .header(title: Localized.SecretPhrase.Confirm.QuickTest.title))
                 .cleanListRow()
-                
-                Section {
-                    Grid(alignment: .center) {
-                        ForEach(model.rowsSections, id: \.self) { section in
-                            GridRow(alignment: .center) {
-                                ForEach(section) { row in
-                                    if model.isVerified(index: row) {
-                                        Button { } label: {
-                                            Text(row.word)
-                                        }
-                                        .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny))
-                                        .disabled(true)
-                                        .fixedSize()
-                                    } else {
-                                        Button {
-                                            model.pickWord(index: row)
-                                        } label: {
-                                            Text(row.word)
-                                        }
-                                        .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny))
-                                        .fixedSize()
+            
+            Section {
+                SecretPhraseGridView(
+                    rows: model.rows,
+                    highlightIndex: model.wordsIndex
+                )
+            }
+            .cleanListRow()
+            
+            Section {
+                Grid(alignment: .center) {
+                    ForEach(model.rowsSections, id: \.self) { section in
+                        GridRow(alignment: .center) {
+                            ForEach(section) { row in
+                                if model.isVerified(index: row) {
+                                    Button { } label: {
+                                        Text(row.word)
                                     }
+                                    .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny))
+                                    .disabled(true)
+                                    .fixedSize()
+                                } else {
+                                    Button {
+                                        model.pickWord(index: row)
+                                    } label: {
+                                        Text(row.word)
+                                    }
+                                    .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny))
+                                    .fixedSize()
                                 }
                             }
                         }
                     }
                 }
-                .cleanListRow()
             }
-            .contentMargins([.top], .extraSmall, for: .scrollContent)
-            .listSectionSpacing(.custom(.medium))
-
+            .cleanListRow()
+        }
+        .safeAreaView {
             StateButton(
                 text: Localized.Common.continue,
                 type: .primary(model.buttonState),
                 action: model.onImportWallet
             )
             .frame(maxWidth: .scene.button.maxWidth)
+            .padding(.bottom, .scene.bottom)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.custom(.medium))
         .navigationTitle(model.title)
         .alertSheet($model.isPresentingAlertMessage)
     }

--- a/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
+++ b/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
@@ -24,39 +24,35 @@ public struct SetPriceAlertScene: View {
     }
     
     public var body: some View {
-        VStack(spacing: .zero) {
-            List {
-                Section {
-                    VStack(spacing: .small) {
-                        Text(model.alertDirectionTitle)
-                            .textStyle(.subheadline)
-                        
-                        CurrencyInputView(
-                            text: $model.state.amount,
-                            config: model.currencyInputConfig(for: assetData)
-                        )
-                        .focused($focusedField)
-                    }
+        List {
+            Section {
+                VStack(spacing: .small) {
+                    Text(model.alertDirectionTitle)
+                        .textStyle(.subheadline)
                     
-                    if model.showPercentagePreselectedPicker {
-                        preselectedPercentagePickerView
-                            .padding(.top, Spacing.medium)
-                    }
+                    CurrencyInputView(
+                        text: $model.state.amount,
+                        config: model.currencyInputConfig(for: assetData)
+                    )
+                    .focused($focusedField)
                 }
-                .cleanListRow()
+                
+                if model.showPercentagePreselectedPicker {
+                    preselectedPercentagePickerView
+                        .padding(.top, Spacing.medium)
+                }
             }
-            
-            Spacer()
-            
+            .cleanListRow()
+        }
+        .safeAreaView {
             StateButton(
                 text: Localized.Transfer.confirm,
                 type: .primary(model.confirmButtonState),
                 action: confirm
             )
             .frame(maxWidth: Spacing.scene.button.maxWidth)
+            .padding(.bottom, Spacing.scene.bottom)
         }
-        .padding(.bottom, Spacing.scene.bottom)
-        .background(Colors.grayBackground)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 alertTypePickerView

--- a/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
+++ b/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
@@ -24,25 +24,23 @@ public struct AddNodeScene: View {
     }
 
     public var body: some View {
-        VStack {
-            List {
-                networkSection
-                inputView
-                nodeInfoView
-            }
-            Spacer()
+        List {
+            networkSection
+            inputView
+            nodeInfoView
+        }
+        .safeAreaView {
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.state),
                 action: onSelectImport
             )
             .frame(maxWidth: .scene.button.maxWidth)
+            .padding(.bottom, .scene.bottom)
         }
         .onAppear {
             focusedField = .address
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .frame(maxWidth: .infinity)
         .navigationTitle(model.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/Features/Transfer/Sources/Scenes/AmountScene.swift
+++ b/Features/Transfer/Sources/Scenes/AmountScene.swift
@@ -20,84 +20,81 @@ struct AmountScene: View {
 
     var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                CurrencyInputValidationView(
-                    model: $model.amountInputModel,
-                    config: model.inputConfig,
-                    infoAction: model.infoAction(for:)
-                )
-                .padding(.top, .medium)
-                .listGroupRowStyle()
-                .disabled(model.isInputDisabled)
-                .focused($focusedField)
-
-                if model.isBalanceViewEnabled {
-                    Section {
-                        AssetBalanceView(
-                            image: model.assetImage,
-                            title: model.assetName,
-                            balance: model.balanceText,
-                            secondary: {
-                                Button(
-                                    model.maxTitle,
-                                    action: model.onSelectMaxButton
-                                )
-                                .buttonStyle(.lightGray(paddingHorizontal: .medium, paddingVertical: .small))
-                                .fixedSize()
-                            }
-                        )
+        List {
+            CurrencyInputValidationView(
+                model: $model.amountInputModel,
+                config: model.inputConfig,
+                infoAction: model.infoAction(for:)
+            )
+            .padding(.top, .medium)
+            .listGroupRowStyle()
+            .disabled(model.isInputDisabled)
+            .focused($focusedField)
+            
+            if model.isBalanceViewEnabled {
+                Section {
+                    AssetBalanceView(
+                        image: model.assetImage,
+                        title: model.assetName,
+                        balance: model.balanceText,
+                        secondary: {
+                            Button(
+                                model.maxTitle,
+                                action: model.onSelectMaxButton
+                            )
+                            .buttonStyle(.lightGray(paddingHorizontal: .medium, paddingVertical: .small))
+                            .fixedSize()
+                        }
+                    )
+                }
+            }
+            
+            if let infoText = model.infoText {
+                Section {
+                    HStack {
+                        Images.System.info
+                            .foregroundStyle(Colors.gray)
+                            .frame(width: .list.image, height: .list.image)
+                        Text(infoText)
+                            .textStyle(.calloutSecondary)
                     }
                 }
-                
-                if let infoText = model.infoText {
-                    Section {
-                        HStack {
-                            Images.System.info
-                                .foregroundStyle(Colors.gray)
-                                .frame(width: .list.image, height: .list.image)
-                            Text(infoText)
-                                .textStyle(.calloutSecondary)
+                .listRowInsets(.assetListRowInsets)
+            }
+            
+            switch model.type {
+            case .transfer, .deposit, .withdraw:
+                EmptyView()
+            case .stake, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
+                if let viewModel = model.stakeValidatorViewModel  {
+                    Section(model.validatorTitle) {
+                        if model.isSelectValidatorEnabled {
+                            NavigationCustomLink(
+                                with: ValidatorView(model: viewModel),
+                                action: model.onSelectCurrentValidator
+                            )
+                        } else {
+                            ValidatorView(model: viewModel)
                         }
                     }
                     .listRowInsets(.assetListRowInsets)
                 }
-
-                switch model.type {
-                case .transfer, .deposit, .withdraw:
-                    EmptyView()
-                case .stake, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
-                    if let viewModel = model.stakeValidatorViewModel  {
-                        Section(model.validatorTitle) {
-                            if model.isSelectValidatorEnabled {
-                                NavigationCustomLink(
-                                    with: ValidatorView(model: viewModel),
-                                    action: model.onSelectCurrentValidator
-                                )
-                            } else {
-                                ValidatorView(model: viewModel)
-                            }
-                        }
-                        .listRowInsets(.assetListRowInsets)
-                    }
-                case .perpetual:
-                    // PositionView()
-                    EmptyView()
-                }
+            case .perpetual:
+                // PositionView()
+                EmptyView()
             }
-            .contentMargins([.top], .zero, for: .scrollContent)
-
-            Spacer()
+        }
+        .safeAreaView {
             StateButton(
                 text: model.continueTitle,
                 type: .primary(model.actionButtonState),
                 action: model.onSelectNextButton
             )
             .frame(maxWidth: .scene.button.maxWidth)
+            .padding(.bottom, .scene.bottom)
         }
+        .contentMargins([.top], .zero, for: .scrollContent)
         .listSectionSpacing(.compact)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .frame(maxWidth: .infinity)
         .navigationTitle(model.title)
         .onAppear(perform: model.onAppear)

--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -17,62 +17,60 @@ public struct ConfirmTransferScene: View {
     }
 
     public var body: some View {
-        VStack {
-            transactionsList
-            Spacer()
-            StateButton(model.confirmButtonModel)
-            .frame(maxWidth: .scene.button.maxWidth)
-        }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
-        .frame(maxWidth: .infinity)
-        .debounce(
-            value: model.feeModel.priority,
-            interval: nil,
-            action: model.onChangeFeePriority
-        )
-        .taskOnce { model.fetch() }
-        .navigationTitle(model.title)
+        transactionsList
+            .safeAreaView {
+                StateButton(model.confirmButtonModel)
+                    .frame(maxWidth: .scene.button.maxWidth)
+                    .padding(.bottom, .scene.bottom)
+            }
+            .frame(maxWidth: .infinity)
+            .debounce(
+                value: model.feeModel.priority,
+                interval: nil,
+                action: model.onChangeFeePriority
+            )
+            .taskOnce { model.fetch() }
+            .navigationTitle(model.title)
         // TODO: - move to navigation view
-        .navigationBarTitleDisplayMode(.inline)
-        .activityIndicator(isLoading: model.confirmingState.isLoading, message: model.progressMessage)
-        .sheet(item: $model.isPresentingSheet) {
-            switch $0 {
-            case .info(let type):
-                InfoSheetScene(type: type)
-            case .url(let url):
-                SFSafariView(url: url)
-            case .networkFeeSelector:
-                NavigationStack {
-                    NetworkFeeScene(model: model.feeModel)
-                        .presentationDetentsForCurrentDeviceSize(expandable: true)
-                }
-            case .fiatConnect(let assetAddress, let walletId):
-                NavigationStack {
-                    FiatConnectNavigationView(
-                        model: FiatSceneViewModel(
-                            assetAddress: assetAddress,
-                            walletId: walletId.id
-                        )
-                    )
-                    .navigationBarTitleDisplayMode(.inline)
-                    .toolbar {
-                        ToolbarDismissItem(
-                            title: .done,
-                            placement: .topBarLeading
-                        )
-                    }
-                }
-            case .swapDetails:
-                if let swapDetailsViewModel = model.swapDetailsViewModel {
+            .navigationBarTitleDisplayMode(.inline)
+            .activityIndicator(isLoading: model.confirmingState.isLoading, message: model.progressMessage)
+            .sheet(item: $model.isPresentingSheet) {
+                switch $0 {
+                case .info(let type):
+                    InfoSheetScene(type: type)
+                case .url(let url):
+                    SFSafariView(url: url)
+                case .networkFeeSelector:
                     NavigationStack {
-                        SwapDetailsView(model: Bindable(swapDetailsViewModel))
+                        NetworkFeeScene(model: model.feeModel)
                             .presentationDetentsForCurrentDeviceSize(expandable: true)
+                    }
+                case .fiatConnect(let assetAddress, let walletId):
+                    NavigationStack {
+                        FiatConnectNavigationView(
+                            model: FiatSceneViewModel(
+                                assetAddress: assetAddress,
+                                walletId: walletId.id
+                            )
+                        )
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarDismissItem(
+                                title: .done,
+                                placement: .topBarLeading
+                            )
+                        }
+                    }
+                case .swapDetails:
+                    if let swapDetailsViewModel = model.swapDetailsViewModel {
+                        NavigationStack {
+                            SwapDetailsView(model: Bindable(swapDetailsViewModel))
+                                .presentationDetentsForCurrentDeviceSize(expandable: true)
+                        }
                     }
                 }
             }
-        }
-        .alertSheet($model.isPresentingAlertMessage)
+            .alertSheet($model.isPresentingAlertMessage)
     }
 }
 

--- a/Features/Transfer/Sources/Scenes/ReceiveScene.swift
+++ b/Features/Transfer/Sources/Scenes/ReceiveScene.swift
@@ -21,10 +21,10 @@ public struct ReceiveScene: View {
                         .frame(maxWidth: model.qrWidth)
                 }
                 Spacer()
-                Button(action: model.onShareSheet) {
-                    Text(model.shareTitle)
-                }
-                .buttonStyle(.blue())
+                StateButton(
+                    text: model.shareTitle,
+                    action: model.onShareSheet
+                )
             }
             .frame(maxWidth: .scene.button.maxWidth)
         }

--- a/Features/Transfer/Sources/Scenes/RecipientScene.swift
+++ b/Features/Transfer/Sources/Scenes/RecipientScene.swift
@@ -22,87 +22,85 @@ struct RecipientScene: View {
 
     var body: some View {
         @Bindable var model = model
-        VStack {
-            List {
-                Section {
-                    InputValidationField(
-                        model: $model.addressInputModel,
-                        placeholder: model.recipientField,
-                        allowClean: true,
-                        trailingView: {
-                            HStack(spacing: .large/2) {
-                                NameRecordView(
-                                    model: model.nameRecordViewModel,
-                                    state: $model.nameResolveState,
-                                    address: $model.addressInputModel.text
+        List {
+            Section {
+                InputValidationField(
+                    model: $model.addressInputModel,
+                    placeholder: model.recipientField,
+                    allowClean: true,
+                    trailingView: {
+                        HStack(spacing: .large/2) {
+                            NameRecordView(
+                                model: model.nameRecordViewModel,
+                                state: $model.nameResolveState,
+                                address: $model.addressInputModel.text
+                            )
+                            if model.shouldShowInputActions {
+                                ListButton(
+                                    image: model.pasteImage,
+                                    action: { model.onSelectPaste(field: .address) }
                                 )
-                                if model.shouldShowInputActions {
-                                    ListButton(
-                                        image: model.pasteImage,
-                                        action: { model.onSelectPaste(field: .address) }
-                                    )
-                                    ListButton(
-                                        image: model.qrImage,
-                                        action: { model.onSelectScan(field: .address) }
-                                    )
-                                }
+                                ListButton(
+                                    image: model.qrImage,
+                                    action: { model.onSelectScan(field: .address) }
+                                )
                             }
                         }
+                    }
+                )
+                .focused($focusedField, equals: .address)
+                .keyboardType(.alphabet)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            }
+            
+            if model.showMemo {
+                Section {
+                    FloatTextField(
+                        model.memoField,
+                        text: $model.memo,
+                        allowClean: focusedField == .memo,
+                        trailingView: {
+                            ListButton(
+                                image: model.qrImage,
+                                action: { model.onSelectScan(field: .memo) }
+                            )
+                        }
                     )
-                    .focused($focusedField, equals: .address)
+                    .focused($focusedField, equals: .memo)
                     .keyboardType(.alphabet)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
                 }
-
-                if model.showMemo {
-                    Section {
-                        FloatTextField(
-                            model.memoField,
-                            text: $model.memo,
-                            allowClean: focusedField == .memo,
-                            trailingView: {
-                                ListButton(
-                                    image: model.qrImage,
-                                    action: { model.onSelectScan(field: .memo) }
-                                )
-                            }
+            }
+            
+            ForEach(model.recipientSections) { section in
+                Section {
+                    ForEach(section.values) { item in
+                        NavigationCustomLink(
+                            with: ListItemView(title: item.value.name),
+                            action: { model.onSelectRecipient(item.value) }
                         )
-                        .focused($focusedField, equals: .memo)
-                        .keyboardType(.alphabet)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
                     }
-                }
-
-                ForEach(model.recipientSections) { section in
-                    Section {
-                        ForEach(section.values) { item in
-                            NavigationCustomLink(
-                                with: ListItemView(title: item.value.name),
-                                action: { model.onSelectRecipient(item.value) }
-                            )
-                        }
-                    } header: {
-                        Label {
-                            Text(section.section)
-                        } icon: {
-                            section.image
-                        }
+                } header: {
+                    Label {
+                        Text(section.section)
+                    } icon: {
+                        section.image
                     }
                 }
             }
-            Spacer()
+        }
+        .safeAreaView {
             StateButton(
                 text: model.actionButtonTitle,
                 type: .primary(model.actionButtonState),
                 action: model.onContinue
             )
             .frame(maxWidth: .scene.button.maxWidth)
+            .padding(.bottom, .scene.bottom)
         }
         .contentMargins(.top, .scene.top, for: .scrollContent)
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationTitle(model.tittle)
         .onChange(of: model.addressInputModel.text, model.onChangeAddressText)
         .onChange(of: model.nameResolveState, model.onChangeNameResolverState)

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
@@ -15,34 +15,33 @@ public struct ConnectionProposalScene: View {
     }
 
     public var body: some View {
-        VStack {
-            List {
-                Section { } header: {
-                    VStack(alignment: .center) {
-                        AsyncImageView(url: model.imageUrl, size: 64)
-                    }
-                    .padding(.top, 8)
+        List {
+            Section { } header: {
+                VStack(alignment: .center) {
+                    AsyncImageView(url: model.imageUrl, size: 64)
                 }
-                .cleanListRow()
-
-                Section {
-                    NavigationLink(value: Scenes.SelectWallet()) {
-                        ListItemView(
-                            title: model.walletTitle,
-                            subtitle: model.walletName
-                        )
-                    }
-                    ListItemView(title: model.appTitle, subtitle: model.appText)
-                }
+                .padding(.top, 8)
             }
-
-            Button(model.buttonTitle, action: onAccept)
-                .buttonStyle(.blue())
-                .padding(.bottom, .scene.bottom)
-                .frame(maxWidth: .scene.button.maxWidth)
+            .cleanListRow()
+            
+            Section {
+                NavigationLink(value: Scenes.SelectWallet()) {
+                    ListItemView(
+                        title: model.walletTitle,
+                        subtitle: model.walletName
+                    )
+                }
+                ListItemView(title: model.appTitle, subtitle: model.appText)
+            }
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
+        .safeAreaView {
+            StateButton(
+                text: model.buttonTitle,
+                action: onAccept
+            )
+            .padding(.bottom, .scene.bottom)
+            .frame(maxWidth: .scene.button.maxWidth)
+        }
         .navigationTitle(model.title)
         .navigationDestination(for: Scenes.SelectWallet.self) { _ in
             SelectWalletScene(model: $model.walletSelectorModel)

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
@@ -16,60 +16,54 @@ public struct SignMessageScene: View {
     }
 
     public var body: some View {
-        VStack {
-            List {
-                Section {
-                    ListItemImageView(
-                        title: Localized.WalletConnect.app,
-                        subtitle: model.appText,
-                        assetImage: model.appAssetImage
-                    )
-                    .contextMenu(
-                        .url(title: Localized.WalletConnect.website, onOpen: model.onViewWebsite)
-                    )
-                    ListItemView(title: Localized.Common.wallet, subtitle: model.walletText)
-                    ListItemView(title: Localized.Transfer.network, subtitle: model.networkText)
-                }
-
-                switch model.messageDisplayType {
-                case .sections(let sections):
-                    ForEach(sections) { section in
-                        Section {
-                            ForEach(section.values) { item in
-                                ListItemView(
-                                    title: item.title,
-                                    subtitle: item.value
-                                )
-                                
-                            }
-                        } header: {
-                            if let title = section.title {
-                                Text(title)
-                            }
-                        }
-                    }
-                    NavigationCustomLink(with: ListItemView(title: Localized.SignMessage.viewFullMessage)) {
-                        model.onViewFullMessage()
-                    }
-                case .text(let string):
-                    Section(Localized.SignMessage.message) {
-                        Text(string)
-                    }
-                }
+        List {
+            Section {
+                ListItemImageView(
+                    title: Localized.WalletConnect.app,
+                    subtitle: model.appText,
+                    assetImage: model.appAssetImage
+                )
+                .contextMenu(
+                    .url(title: Localized.WalletConnect.website, onOpen: model.onViewWebsite)
+                )
+                ListItemView(title: Localized.Common.wallet, subtitle: model.walletText)
+                ListItemView(title: Localized.Transfer.network, subtitle: model.networkText)
             }
             
-            Button(role: .none) { sign() } label: {
-                HStack {
-                    //Image(systemName: model.buttonImage)
-                    Text(model.buttonTitle)
+            switch model.messageDisplayType {
+            case .sections(let sections):
+                ForEach(sections) { section in
+                    Section {
+                        ForEach(section.values) { item in
+                            ListItemView(
+                                title: item.title,
+                                subtitle: item.value
+                            )
+                            
+                        }
+                    } header: {
+                        if let title = section.title {
+                            Text(title)
+                        }
+                    }
+                }
+                NavigationCustomLink(with: ListItemView(title: Localized.SignMessage.viewFullMessage)) {
+                    model.onViewFullMessage()
+                }
+            case .text(let string):
+                Section(Localized.SignMessage.message) {
+                    Text(string)
                 }
             }
-            .buttonStyle(.blue())
+        }
+        .safeAreaView {
+            StateButton(
+                text: model.buttonTitle,
+                action: sign
+            )
             .padding(.bottom, .scene.bottom)
             .frame(maxWidth: .scene.button.maxWidth)
         }
-        .padding(.bottom, .scene.bottom)
-        .background(Colors.grayBackground)
         .navigationTitle(Localized.SignMessage.title)
         .safariSheet(url: $model.isPresentingUrl)
         .sheet(isPresented: $model.isPresentingMessage) {

--- a/Packages/PrimitivesComponents/Sources/Extensions/View+SafeAreaView.swift
+++ b/Packages/PrimitivesComponents/Sources/Extensions/View+SafeAreaView.swift
@@ -1,0 +1,23 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import SwiftUI
+import Style
+
+public extension View {
+    @ViewBuilder
+    func safeAreaView<Content: View>(
+        edge: VerticalEdge = .bottom,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        if #available(iOS 26.0, *) {
+            safeAreaBar(edge: edge) {
+                content()
+            }
+        } else {
+            safeAreaInset(edge: edge) {
+                content()
+            }
+        }
+    }
+}

--- a/Packages/Style/Sources/Button/Types/ButtonStylePallete.swift
+++ b/Packages/Style/Sources/Button/Types/ButtonStylePallete.swift
@@ -32,7 +32,7 @@ extension ButtonStylePalette {
         foregroundPressed: Colors.whiteSolid,
         background: Colors.blue,
         backgroundPressed: Colors.blueDark,
-        backgroundDisabled: Colors.blueDark.opacity(0.6)
+        backgroundDisabled: Colors.blueDarkFaded
     )
 
     static let blue = ButtonStylePalette(
@@ -40,7 +40,7 @@ extension ButtonStylePalette {
         foregroundPressed: Colors.whiteSolid,
         background: Colors.blue,
         backgroundPressed: Colors.blueDark,
-        backgroundDisabled: .clear
+        backgroundDisabled: Colors.blueFaded
     )
 
     static let blueGrayPressed = ButtonStylePalette(
@@ -48,7 +48,7 @@ extension ButtonStylePalette {
         foregroundPressed: Colors.whiteSolid,
         background: Colors.blue,
         backgroundPressed: Colors.gray,
-        backgroundDisabled: .clear
+        backgroundDisabled: Colors.blueFaded
     )
 
     static let gray = ButtonStylePalette(
@@ -56,15 +56,15 @@ extension ButtonStylePalette {
         foregroundPressed: Colors.whiteSolid,
         background: Colors.grayLight,
         backgroundPressed: Colors.gray,
-        backgroundDisabled: .clear
+        backgroundDisabled: Colors.grayLightFaded
     )
 
     static let lightGray = ButtonStylePalette(
         foreground: Colors.gray,
         foregroundPressed: Colors.whiteSolid,
         background: Colors.grayVeryLight,
-        backgroundPressed: Colors.grayLight.opacity(0.3),
-        backgroundDisabled: .clear
+        backgroundPressed: Colors.grayLightFaded,
+        backgroundDisabled: Colors.grayVeryLightFaded
     )
 
     static let white = ButtonStylePalette(
@@ -72,23 +72,23 @@ extension ButtonStylePalette {
         foregroundPressed: Colors.whiteSolid,
         background: Colors.white,
         backgroundPressed: Colors.grayVeryLight,
-        backgroundDisabled: .clear
+        backgroundDisabled: Colors.whiteFaded
     )
 
     static let empty = ButtonStylePalette(
         foreground: Colors.black,
-        foregroundPressed: Colors.black.opacity(0.5),
+        foregroundPressed: Colors.blackFaded,
         background: Colors.Empty.buttonsBackground,
-        backgroundPressed: Colors.Empty.buttonsBackground.opacity(0.5),
-        backgroundDisabled: .clear
+        backgroundPressed: Colors.Empty.buttonsBackground,
+        backgroundDisabled: Colors.Empty.buttonsBackground
     )
 
     static let amount = ButtonStylePalette(
         foreground: Colors.black,
-        foregroundPressed: Colors.black.opacity(0.5),
+        foregroundPressed: Colors.blackFaded,
         background: Colors.grayVeryLight,
-        backgroundPressed: Colors.grayVeryLight.opacity(0.5),
-        backgroundDisabled: .clear
+        backgroundPressed: Colors.grayVeryLightFaded,
+        backgroundDisabled: Colors.grayVeryLightFaded
     )
 
     static let listStyleColor = ButtonStylePalette(
@@ -96,23 +96,23 @@ extension ButtonStylePalette {
         foregroundPressed: Colors.whiteSolid,
         background: Colors.listStyleColor,
         backgroundPressed: Colors.grayVeryLight,
-        backgroundDisabled: .clear
+        backgroundDisabled: Colors.grayFaded
     )
     
     static let red = ButtonStylePalette(
         foreground: Colors.whiteSolid,
         foregroundPressed: Colors.whiteSolid,
         background: Colors.red,
-        backgroundPressed: Colors.red.opacity(0.8),
-        backgroundDisabled: Colors.red.opacity(0.6)
+        backgroundPressed: Colors.redFaded,
+        backgroundDisabled: Colors.redFadedLight
     )
     
     static let green = ButtonStylePalette(
         foreground: Colors.whiteSolid,
         foregroundPressed: Colors.whiteSolid,
         background: Colors.green,
-        backgroundPressed: Colors.green.opacity(0.8),
-        backgroundDisabled: Colors.green.opacity(0.6)
+        backgroundPressed: Colors.greenFaded,
+        backgroundDisabled: Colors.greenFadedLight
     )
 
 }

--- a/Packages/Style/Sources/Colors.swift
+++ b/Packages/Style/Sources/Colors.swift
@@ -31,6 +31,22 @@ extension Colors {
     }
 }
 
+// MARK: - Faded Variants
+
+extension Colors {
+    public static let blueFaded = Color.dynamicColor("#6BA3F1", dark: "#5A96ED")
+    public static let blueDarkFaded = Color.dynamicColor("#6085E9", dark: "#5A7CE6")
+    public static let whiteFaded = Color.dynamicColor("#F0F0F0", dark: "#444444")
+    public static let grayFaded = Color.dynamicColor("#C0C0C0", dark: "#606060")
+    public static let grayLightFaded = Color.dynamicColor("#CACBCA", dark: "#4D524D")
+    public static let grayVeryLightFaded = Color.dynamicColor("#F9F9F9", dark: "#666666")
+    public static let blackFaded = Color.dynamicColor("#919191", dark: "#7F7F7F")
+    public static let redFaded = Color.dynamicColor("#FB7676", dark: "#FB7676")
+    public static let redFadedLight = Color.dynamicColor("#FC8E8E", dark: "#FC8E8E")
+    public static let greenFaded = Color.dynamicColor("#4EAC84", dark: "#4EAC84")
+    public static let greenFadedLight = Color.dynamicColor("#67B593", dark: "#67B593")
+}
+
 #Preview {
     let colors: [(name: String, color: Color)] = [
         ("White", Colors.white),


### PR DESCRIPTION
Introduces a View+SafeAreaView extension to handle safe area insets for bottom-aligned buttons across scenes. Refactors multiple scenes to use StateButton and the new safeAreaView, removing manual padding and background color logic. Updates ButtonStylePalette to use new faded color variants for disabled and pressed states, and adds these variants to Colors. Updates core submodule.

Fix: https://github.com/gemwalletcom/gem-ios/issues/840

## iOS 18.5
<img width="320" alt="Simulator Screenshot - iPhone 16e - 2025-09-16 at 14 15 13" src="https://github.com/user-attachments/assets/c8d598cf-2b98-42d5-9b09-01a26b2f9efc" />
<img width="320" alt="Simulator Screenshot - iPhone 16e - 2025-09-16 at 14 15 41" src="https://github.com/user-attachments/assets/0e96ac15-5b2e-41c4-b088-717761ac6d9b" />
<img width="320" alt="Simulator Screenshot - iPhone 16e - 2025-09-16 at 14 15 55" src="https://github.com/user-attachments/assets/59c4581d-a135-4329-acbd-4f4572274957" />
<img width="320" alt="Simulator Screenshot - iPhone 16e - 2025-09-16 at 14 16 04" src="https://github.com/user-attachments/assets/3a60d6f5-9758-421d-b854-ef32c7f01d1c" />

## iOS 26
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-16 at 14 16 21" src="https://github.com/user-attachments/assets/fca4f09b-e193-4f3b-b437-4c152aafb53c" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-16 at 14 16 30" src="https://github.com/user-attachments/assets/5cfc4afc-29e7-4add-a48e-e2a218e109a2" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-16 at 14 16 40" src="https://github.com/user-attachments/assets/c2e0665e-e4cd-4d3e-89c9-583240b453d9" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-16 at 14 16 47" src="https://github.com/user-attachments/assets/af8e1f0f-fc58-4740-abb4-5038f6a4170f" />

## macOS 26.0 (25A354)

<img width="720" alt="Screenshot 2025-09-16 at 14 19 06" src="https://github.com/user-attachments/assets/5f2e96dc-23b4-4794-a8a0-26346ea2413b" />
<img width="720" alt="Screenshot 2025-09-16 at 14 19 13" src="https://github.com/user-attachments/assets/bbb90f94-9e25-482b-bed4-4be6ee0b5c5d" />
<img width="720" alt="Screenshot 2025-09-16 at 14 18 22" src="https://github.com/user-attachments/assets/97f0f2c8-b7dd-40d2-98d1-c38caaa113f3" />
<img width="720" alt="Screenshot 2025-09-16 at 14 18 34" src="https://github.com/user-attachments/assets/f1db2105-14da-4af3-8ed7-b61e15f28fc1" />
