### PR TITLE
Sort price alerts and add tests for sorting logic

### DIFF
--- a/Features/PriceAlerts/Sources/ViewModels/AssetPriceAlertsViewModel.swift
+++ b/Features/PriceAlerts/Sources/ViewModels/AssetPriceAlertsViewModel.swift
@@ -46,6 +46,11 @@ public final class AssetPriceAlertsViewModel: Sendable {
     var alertsModel: [PriceAlertItemViewModel] {
         priceAlerts
             .filter { $0.priceAlert.shouldDisplay && $0.priceAlert.type != .auto }
+            .sorted(using: [
+                KeyPathComparator(\.priceAlert.price, order: .reverse),
+                KeyPathComparator(\.priceAlert.priceDirection, order: .reverse),
+                KeyPathComparator(\.priceAlert.pricePercentChange, order: .reverse)
+            ])
             .map { PriceAlertItemViewModel(data: $0) }
     }
     

--- a/Features/PriceAlerts/Tests/PriceAlertsTests/AssetPriceAlertsViewModelTests.swift
+++ b/Features/PriceAlerts/Tests/PriceAlertsTests/AssetPriceAlertsViewModelTests.swift
@@ -1,0 +1,52 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Testing
+import PriceAlertService
+import PriceAlertServiceTestKit
+import Primitives
+import PrimitivesTestKit
+
+@testable import PriceAlerts
+
+@MainActor
+struct AssetPriceAlertsViewModelTests {
+    @Test
+    func alertsModelSorting() {
+        let alert1 = PriceAlertData.mock(priceAlert: .mock(price: 100, priceDirection: .up))
+        let alert2 = PriceAlertData.mock(priceAlert: .mock(price: 200, priceDirection: .down))
+        let alert3 = PriceAlertData.mock(priceAlert: .mock(price: 200, priceDirection: .up))
+        let autoAlert = PriceAlertData.mock(priceAlert: .mock(priceDirection: nil))
+        
+        let model = AssetPriceAlertsViewModel.mock()
+        model.priceAlerts = [alert1, alert2, alert3, autoAlert]
+        
+        #expect(model.alertsModel.map { $0.data } == [alert3, alert2, alert1])
+        #expect(model.autoAlertModel?.data == autoAlert)
+    }
+    
+    @Test
+    func emptyContentModel() {
+        let model = AssetPriceAlertsViewModel.mock()
+        
+        #expect(model.emptyContentModel != nil)
+        
+        model.priceAlerts = [PriceAlertData.mock()]
+        
+        #expect(model.emptyContentModel == nil)
+    }
+}
+
+extension AssetPriceAlertsViewModel {
+    static func mock(
+        priceAlertService: PriceAlertService = .mock(),
+        walletId: WalletId = .mock(),
+        asset: Asset = .mock()
+    ) -> AssetPriceAlertsViewModel {
+        AssetPriceAlertsViewModel(
+            priceAlertService: priceAlertService,
+            walletId: walletId,
+            asset: asset
+        )
+    }
+}

--- a/Packages/Primitives/Sources/Extensions/PriceAlertDirection+Primitives.swift
+++ b/Packages/Primitives/Sources/Extensions/PriceAlertDirection+Primitives.swift
@@ -1,0 +1,16 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+extension PriceAlertDirection: Comparable {
+    public static func < (lhs: PriceAlertDirection, rhs: PriceAlertDirection) -> Bool {
+        lhs.sortPriority < rhs.sortPriority
+    }
+
+    private var sortPriority: Int {
+        switch self {
+        case .down: 0
+        case .up: 1
+        }
+    }
+}


### PR DESCRIPTION
Updated AssetPriceAlertsViewModel to sort alerts by price, direction, and percent change in descending order. Added Comparable conformance to PriceAlertDirection for custom sorting. Introduced unit tests to verify sorting and empty content model behavior.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1167

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-17 at 11 53 59" src="https://github.com/user-attachments/assets/a0bfe65a-8172-4909-a0c1-73ff76e9baa3" />
