### PR TITLE
Update CI workflows to use macOS 26 and Xcode 26.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ env:
 jobs:
   unit_test:
     name: Build and Test iPhone simulator
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
         
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -18,9 +18,12 @@ env:
 jobs:
   unit_test:
     name: Build and UI Test iPhone simulator
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.0.app
+        
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Both the CI and UI test GitHub Actions workflows now run on macOS 26 and use Xcode 26.0. This ensures compatibility with the latest macOS and Xcode versions for building and testing.