### PR TITLE
Update macOS runner and simulator version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ env:
 jobs:
   unit_test:
     name: Build and Test iPhone simulator
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app
+        run: |
+          xcrun simctl list devices
         
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ui_tests.yml
+++ b/.github/workflows/ui_tests.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   unit_test:
     name: Build and UI Test iPhone simulator
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Checkout

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 XCBEAUTIFY_ARGS := "--quieter"
 BUILD_THREADS := `sysctl -n hw.ncpu`
-SIMULATOR_DEST := "platform=iOS Simulator,name=iPhone 16"
+SIMULATOR_DEST := "platform=iOS Simulator,name=iPhone 17"
 
 xcbeautify:
     @xcbeautify {{XCBEAUTIFY_ARGS}}


### PR DESCRIPTION
Changed GitHub Actions workflows to use macos-26 instead of macos-15. Updated the simulator destination in justfile from iPhone 16 to iPhone 17 to match the new environment.