### PR TITLE
Refactor ImportWalletScene button layout

### DIFF
--- a/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
@@ -59,6 +59,7 @@ struct ImportWalletScene: View {
                                         words: model.wordsSuggestion,
                                         selectWord: model.onSelectWord
                                     )
+                                    .padding(.horizontal, .medium)
                                 }
                             }
                         }
@@ -94,15 +95,16 @@ struct ImportWalletScene: View {
                     Text(text)
                 }
             }
-        }
-        .safeAreaView {
-            StateButton(
-                text: Localized.Wallet.Import.action,
-                type: .primary(model.buttonState),
-                action: model.onSelectActionButton
-            )
-            .frame(maxWidth: .scene.button.maxWidth)
-            .padding(.bottom, .scene.bottom)
+            
+            Section {} header: {
+                StateButton(
+                    text: Localized.Wallet.Import.action,
+                    type: .primary(model.buttonState),
+                    action: model.onSelectActionButton
+                )
+                .frame(height: .scene.button.height)
+                .frame(maxWidth: .scene.button.maxWidth)
+            }
         }
         .listSectionSpacing(.compact)
         .contentMargins(.top, .scene.top, for: .scrollContent)


### PR DESCRIPTION
Moved the action button into a Section header and adjusted its frame height. Added horizontal padding to the WordsSuggestionView for improved layout consistency.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1157

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-18 at 23 12 56" src="https://github.com/user-attachments/assets/d7bd9c55-0e4a-425f-8c07-b406f9f7b8fc" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-18 at 23 13 50" src="https://github.com/user-attachments/assets/c09f1076-3045-41a3-9f46-bb7f2c06c8c0" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-18 at 23 13 56" src="https://github.com/user-attachments/assets/167a99ca-1c86-41cd-9877-81246b52a6fd" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-18 at 23 13 59" src="https://github.com/user-attachments/assets/57290707-f69c-4ad5-b1e0-415b4b0ec3b8" />
