### PR TITLE
Wrap InfoSheetScene in NavigationStack and update toolbar

### DIFF
--- a/Features/InfoSheet/Sources/Scenes/InfoSheetScene.swift
+++ b/Features/InfoSheet/Sources/Scenes/InfoSheetScene.swift
@@ -16,24 +16,33 @@ public struct InfoSheetScene: View {
     }
 
     public var body: some View {
-        InfoSheetView(model: model)
-            .frame(
-                maxWidth: .infinity,
-                maxHeight: .infinity
-            )
-            .padding(.horizontal, .medium)
-            .safeAreaInset(edge: .top, alignment: .trailing) {
-                closeButton
-                    .padding([.trailing, .top], .medium)
-            }
-            .if(model.shouldShowButton) {
-                $0.safeAreaInset(edge: .bottom) {
-                    actionButton
-                        .padding([.bottom], .medium)
+        NavigationStack {
+            InfoSheetView(model: model)
+                .frame(
+                    maxWidth: .infinity,
+                    maxHeight: .infinity
+                )
+                .padding(.horizontal, .medium)
+                .toolbar(content: {
+                    Button("", systemImage: SystemImage.xmark) {
+                        dismiss()
+                    }
+                    .liquidGlass { view in
+                        view
+                            .buttonStyle(.bordered)
+                            .buttonBorderShape(.circle)
+                            .padding(.top, .medium)
+                    }
+                })
+                .if(model.shouldShowButton) {
+                    $0.safeAreaInset(edge: .bottom) {
+                        actionButton
+                            .padding([.bottom], .medium)
+                    }
                 }
-            }
-            .presentationDetentsForCurrentDeviceSize()
-            .safariSheet(url: $isPresentedUrl)
+                .presentationDetentsForCurrentDeviceSize()
+                .safariSheet(url: $isPresentedUrl)
+        }
     }
 
     private var closeButton: some View {


### PR DESCRIPTION
Refactors InfoSheetScene to use a NavigationStack and moves the close button to the toolbar with updated styling. This improves navigation consistency and aligns the close action with standard toolbar patterns.

Close: https://github.com/gemwalletcom/gem-ios/issues/1160

## iOS 26
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-19 at 17 01 26" src="https://github.com/user-attachments/assets/963e06a6-4ddf-4d25-a134-044bb94f534c" />

## iOS 18.5
<img width="320" alt="Simulator Screenshot - iPhone 16e - 2025-09-19 at 17 15 24" src="https://github.com/user-attachments/assets/6d82abde-5c08-478a-9695-e87dec4b85e4" />
