### PR TITLE
Add wallet and eye icons to recipient section headers

### DIFF
--- a/Features/Transfer/Sources/Scenes/RecipientScene.swift
+++ b/Features/Transfer/Sources/Scenes/RecipientScene.swift
@@ -85,6 +85,7 @@ struct RecipientScene: View {
                 } header: {
                     HStack {
                         section.image
+                            .frame(size: .image.small)
                         Text(section.section)
                     }
                 }

--- a/Features/Transfer/Sources/Scenes/RecipientScene.swift
+++ b/Features/Transfer/Sources/Scenes/RecipientScene.swift
@@ -83,10 +83,9 @@ struct RecipientScene: View {
                         )
                     }
                 } header: {
-                    Label {
-                        Text(section.section)
-                    } icon: {
+                    HStack {
                         section.image
+                        Text(section.section)
                     }
                 }
             }

--- a/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
@@ -256,7 +256,8 @@ extension RecipientSceneViewModel {
     private func sectionImage(for type: RecipientAddressType) -> Image? {
         switch type {
         case .pinned: Images.System.pin
-        case .wallets, .view: nil
+        case .wallets: Images.System.wallet
+        case .view: Images.System.eyeCircle
         }
     }
 

--- a/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/RecipientSceneViewModel.swift
@@ -253,11 +253,11 @@ extension RecipientSceneViewModel {
         }
     }
 
-    private func sectionImage(for type: RecipientAddressType) -> Image? {
+    private func sectionImage(for type: RecipientAddressType) -> Image {
         switch type {
         case .pinned: Images.System.pin
         case .wallets: Images.System.wallet
-        case .view: Images.System.eyeCircle
+        case .view: Images.System.eye
         }
     }
 

--- a/Packages/Style/Sources/Extentions/Images+SystemImage.swift
+++ b/Packages/Style/Sources/Extentions/Images+SystemImage.swift
@@ -47,5 +47,7 @@ public extension Images {
         public static let checkmarkCircle = Image(systemName: SystemImage.checkmarkCircle)
         public static let circle = Image(systemName: SystemImage.circle)
         public static let dollar = Image(systemName: SystemImage.dollarsign)
+        public static let wallet = Image(systemName: SystemImage.wallet)
+        public static let eyeCircle = Image(systemName: SystemImage.eyeCircle)
     }
 }

--- a/Packages/Style/Sources/SystemImage.swift
+++ b/Packages/Style/Sources/SystemImage.swift
@@ -50,6 +50,8 @@ public struct SystemImage {
     public static let checkmarkCircle = "checkmark.circle"
     public static let circle = "circle"
     public static let dollarsign = "dollarsign"
+    public static let wallet = "wallet.pass"
+    public static let eyeCircle = "eye.circle"
 
     // specific to Gem style
     public static let errorOccurred = exclamationmarkTriangleFill


### PR DESCRIPTION
Updated RecipientScene to use custom wallet and eye icons for section headers. Added new system images 'wallet' and 'eyeCircle' to the style package and updated the view model to assign these images to the appropriate recipient address types.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-19 at 18 31 05" src="https://github.com/user-attachments/assets/3db5eee2-7626-420d-8e7c-a92daec6d2bb" />
