### PR TITLE
Integrate banner events into WalletHeaderViewModel

### DIFF
--- a/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -111,7 +111,8 @@ public final class WalletSceneViewModel: Sendable {
         WalletHeaderViewModel(
             walletType: wallet.type,
             value: totalFiatValue,
-            currencyCode: currencyCode
+            currencyCode: currencyCode,
+            bannerEventsViewModel: HeaderBannerEventViewModel(events: banners.map(\.event))
         )
     }
 }

--- a/Packages/PrimitivesComponents/Sources/Components/WalletHeaderView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/WalletHeaderView.swift
@@ -99,7 +99,8 @@ public struct WalletHeaderView: View {
     let model = WalletHeaderViewModel(
         walletType: .multicoin,
         value: 1_000,
-        currencyCode: Currency.usd.rawValue
+        currencyCode: Currency.usd.rawValue,
+        bannerEventsViewModel: HeaderBannerEventViewModel(events: [])
     )
 
     WalletHeaderView(

--- a/Packages/PrimitivesComponents/Sources/ViewModels/WalletHeaderViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/WalletHeaderViewModel.swift
@@ -13,16 +13,19 @@ public struct WalletHeaderViewModel {
     //Remove WalletType from here
     let walletType: WalletType
     let value: Double
+    let bannerEventsViewModel: HeaderBannerEventViewModel
     
     let currencyFormatter: CurrencyFormatter
 
     public init(
         walletType: WalletType,
         value: Double,
-        currencyCode: String
+        currencyCode: String,
+        bannerEventsViewModel: HeaderBannerEventViewModel
     ) {
         self.walletType = walletType
         self.value = value
+        self.bannerEventsViewModel = bannerEventsViewModel
         self.currencyFormatter = CurrencyFormatter(type: .currency, currencyCode: currencyCode)
     }
     
@@ -41,16 +44,10 @@ extension WalletHeaderViewModel: HeaderViewModel {
     public var subtitle: String? { .none }
 
     public var buttons: [HeaderButton] {
-        let values: [(type: HeaderButtonType, isShown: Bool)] = [
-            (.send, true),
-            (.receive, true),
-            (.buy, true),
+        [
+            HeaderButton(type: .send, isEnabled: bannerEventsViewModel.isButtonsEnabled),
+            HeaderButton(type: .receive, isEnabled: bannerEventsViewModel.isButtonsEnabled),
+            HeaderButton(type: .buy, isEnabled: bannerEventsViewModel.isButtonsEnabled)
         ]
-        return values.compactMap {
-            if $0.isShown {
-                return HeaderButton(type: $0.type, isEnabled: true)
-            }
-            return .none
-        }
     }
 }

--- a/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/WalletHeaderViewModelTests.swift
+++ b/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/WalletHeaderViewModelTests.swift
@@ -11,8 +11,21 @@ struct WalletHeaderViewModelTests {
             WalletHeaderViewModel(
                 walletType: .multicoin,
                 value: 1000,
-                currencyCode: Currency.usd.rawValue)
+                currencyCode: Currency.usd.rawValue,
+                bannerEventsViewModel: HeaderBannerEventViewModel(events: []))
             .totalValueText == "$1,000.00"
         )
+    }
+
+    @Test
+    func buttonsDisabledWithActivateAssetEvent() {
+        let model = WalletHeaderViewModel(
+            walletType: .multicoin,
+            value: 1000,
+            currencyCode: Currency.usd.rawValue,
+            bannerEventsViewModel: HeaderBannerEventViewModel(events: [.activateAsset, .accountBlockedMultiSignature])
+        )
+        
+        #expect(model.buttons.allSatisfy { !$0.isEnabled })
     }
 }


### PR DESCRIPTION
Added a bannerEventsViewModel property to WalletHeaderViewModel and updated its initialization in WalletSceneViewModel and WalletHeaderView. The buttons in WalletHeaderViewModel now use bannerEventsViewModel to determine their enabled state, allowing banner events to control button availability.

Close: https://github.com/gemwalletcom/gem-ios/issues/1179

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-22 at 15 30 23" src="https://github.com/user-attachments/assets/2a4a987d-3a19-43e3-ba71-60ceaf9f74ad" />
