### PR TITLE
Update hyperliquid withdrawal flow and minimum amounts

### DIFF
--- a/Features/Perpetuals/Sources/ViewModels/PerpetualsHeaderViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/PerpetualsHeaderViewModel.swift
@@ -35,8 +35,12 @@ extension PerpetualsHeaderViewModel: HeaderViewModel {
 
     public var buttons: [HeaderButton] {
         [
-            HeaderButton(type: .withdraw, isEnabled: false),
+            HeaderButton(type: .withdraw, isEnabled: isWithdrawEnabled),
             HeaderButton(type: .deposit, isEnabled: true)
         ]
+    }
+
+    private var isWithdrawEnabled: Bool {
+        balance.available > 0
     }
 }

--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import BigInt
+import Blockchain
 import Components
 import Formatters
 import Foundation
@@ -16,7 +17,6 @@ import Store
 import Style
 import Validators
 import WalletsService
-import Blockchain
 
 @MainActor
 @Observable
@@ -39,13 +39,14 @@ public final class AmountSceneViewModel {
     var assetRequest: AssetRequest
     var assetData: AssetData = .empty
 
-    var amountInputModel: InputValidationViewModel = InputValidationViewModel()
+    var amountInputModel: InputValidationViewModel = .init()
     var delegation: DelegationValidator?
     var selectedResource: Primitives.Resource = .bandwidth {
         didSet {
             onSelectResource(selectedResource)
         }
     }
+
     var isPresentingSheet: AmountSheetType?
     var focusField: Bool = false
 
@@ -94,7 +95,7 @@ public final class AmountSceneViewModel {
     var nextTitle: String { Localized.Common.next }
     var continueTitle: String { Localized.Common.continue }
     var isNextEnabled: Bool { actionButtonState == .normal }
-    
+
     var infoText: String? {
         switch type {
         case .transfer, .deposit, .withdraw, .stakeUnstake, .stakeRedelegate, .stakeWithdraw, .perpetual, .freeze:
@@ -256,7 +257,6 @@ extension AmountSceneViewModel {
         delegation = currentValidator
     }
 
-
     func onSelectValidator(_ validator: DelegationValidator) {
         cleanInput()
         setSelectedValidator(validator)
@@ -333,7 +333,7 @@ extension AmountSceneViewModel {
         case .none, .some(.hyperCore): ""
         }
     }
-    
+
     private var recipientData: RecipientData {
         switch type {
         case .transfer(recipient: let recipient): recipient
@@ -555,13 +555,18 @@ extension AmountSceneViewModel {
                 return BigInt(5_000_000) // 5 USDC with 6 decimals
             }
         case .stakeWithdraw:
-            // For withdrawals, require minimum 5 USDC
+            // For staking withdrawals, require minimum 5 USDC
             if asset.symbol == "USDC" {
                 return BigInt(5_000_000) // 5 USDC with 6 decimals
             }
+        case .withdraw:
+            if asset.symbol == "USDC" {
+                // withdrawals require a minimum of 2 USDC
+                return BigInt(2_000_000)
+            }
         case .perpetual:
             return BigInt(12_000_000) // 15 USDC with 6 decimals
-        case .stakeUnstake, .withdraw, .transfer:
+        case .stakeUnstake, .transfer:
             break
         }
         return BigInt(0)
@@ -639,11 +644,11 @@ extension AmountSceneViewModel {
     private var minimumAccountReserve: BigInt {
         asset.type == .native ? asset.chain.minimumAccountBalance : .zero
     }
-    
+
     private var stakingReservedForFees: BigInt {
         BigInt(Config.shared.getStakeConfig(chain: asset.chain.rawValue).reservedForFees)
     }
-    
+
     private var availableBalanceForStaking: BigInt {
         assetData.balance.available > stakingReservedForFees
         ? assetData.balance.available - stakingReservedForFees

--- a/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
@@ -34,7 +34,7 @@ struct SelectAssetSceneNavigationStack: View {
     @State private var model: SelectAssetViewModel
     @State private var navigationPath = NavigationPath()
     @Binding private var isPresentingSelectAssetType: SelectAssetType?
-    
+
     init(
         model: SelectAssetViewModel,
         isPresentingSelectType: Binding<SelectAssetType?>
@@ -136,10 +136,9 @@ struct SelectAssetSceneNavigationStack: View {
                         )
                     )
                 case .withdraw:
-                    let recipientAddress = (try? model.wallet.account(for: input.asset.chain).address) ?? ""
                     let withdrawRecipient = Recipient(
                         name: model.wallet.name,
-                        address: recipientAddress,
+                        address: input.assetAddress.address,
                         memo: nil
                     )
                     AmountNavigationView(

--- a/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
@@ -136,12 +136,18 @@ struct SelectAssetSceneNavigationStack: View {
                         )
                     )
                 case .withdraw:
+                    let recipientAddress = (try? model.wallet.account(for: input.asset.chain).address) ?? ""
+                    let withdrawRecipient = Recipient(
+                        name: model.wallet.name,
+                        address: recipientAddress,
+                        memo: nil
+                    )
                     AmountNavigationView(
                         model: viewModelFactory.amountScene(
                             input: AmountInput(
                                 type: .withdraw(
                                     recipient: RecipientData(
-                                        recipient: .hyperliquid,
+                                        recipient: withdrawRecipient,
                                         amount: .none
                                     )
                                 ),
@@ -193,4 +199,3 @@ extension SelectAssetSceneNavigationStack {
         isPresentingFilteringView.toggle()
     }
 }
-

--- a/Packages/GemstonePrimitives/Sources/Extensions/GemTransactionInputType+GemstonePrimitives.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/GemTransactionInputType+GemstonePrimitives.swift
@@ -1,12 +1,12 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import BigInt
 import Foundation
 import Gemstone
 import Primitives
-import BigInt
 
-extension GemTransactionInputType {
-    public func getAsset() -> GemAsset {
+public extension GemTransactionInputType {
+    func getAsset() -> GemAsset {
         switch self {
         case .transfer(let asset): asset
         case .deposit(let asset): asset
@@ -19,29 +19,29 @@ extension GemTransactionInputType {
     }
 }
 
-extension GemTransactionInputType {
-    public func map() throws -> TransferDataType {
+public extension GemTransactionInputType {
+    func map() throws -> TransferDataType {
         switch self {
         case .transfer(let asset):
-            return TransferDataType.transfer(try asset.map())
+            return try TransferDataType.transfer(asset.map())
         case .deposit(let asset):
-            return TransferDataType.deposit(try asset.map())
+            return try TransferDataType.deposit(asset.map())
         case .swap(let fromAsset, let toAsset, let gemSwapData):
-            return TransferDataType.swap(try fromAsset.map(), try toAsset.map(), try gemSwapData.map())
+            return try TransferDataType.swap(fromAsset.map(), toAsset.map(), gemSwapData.map())
         case .stake(let asset, let type):
-            return TransferDataType.stake(try asset.map(), try type.map())
+            return try TransferDataType.stake(asset.map(), type.map())
         case .tokenApprove(let asset, let approvalData):
-            return TransferDataType.tokenApprove(try asset.map(), approvalData.map())
+            return try TransferDataType.tokenApprove(asset.map(), approvalData.map())
         case .generic(let asset, let metadata, let extra):
-            return TransferDataType.generic(asset: try asset.map(), metadata: metadata.map(), extra: try extra.map())
+            return try TransferDataType.generic(asset: asset.map(), metadata: metadata.map(), extra: extra.map())
         case .perpetual(asset: let asset, perpetualType: let perpetualType):
-            return TransferDataType.perpetual(try asset.map(), try perpetualType.map())
+            return try TransferDataType.perpetual(asset.map(), perpetualType.map())
         }
     }
 }
 
-extension TransferDataType {
-    public func map() -> GemTransactionInputType {
+public extension TransferDataType {
+    func map() throws -> GemTransactionInputType {
         switch self {
         case .transfer(let asset):
             return .transfer(asset: asset.map())
@@ -59,9 +59,9 @@ extension TransferDataType {
             if asset.chain == .hyperCore {
                 return .transfer(asset: asset.map())
             }
-            fatalError("Unsupported transaction type: \(self)")
+            throw AnyError("Unsupported transaction type: \(self)")
         case .transferNft, .account:
-            fatalError("Unsupported transaction type: \(self)")
+            throw AnyError("Unsupported transaction type: \(self)")
         case .perpetual(let asset, let perpetualType):
             return .perpetual(asset: asset.map(), perpetualType: perpetualType.map())
         }

--- a/Packages/GemstonePrimitives/Sources/Extensions/GemTransactionInputType+GemstonePrimitives.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/GemTransactionInputType+GemstonePrimitives.swift
@@ -55,7 +55,12 @@ extension TransferDataType {
             return .tokenApprove(asset: asset.map(), approvalData: approvalData.map())
         case .generic(let asset, let metadata, let extra):
             return .generic(asset: asset.map(), metadata: metadata.map(), extra: extra.map())
-        case .withdrawal, .transferNft, .account:
+        case .withdrawal(let asset):
+            if asset.chain == .hyperCore {
+                return .transfer(asset: asset.map())
+            }
+            fatalError("Unsupported transaction type: \(self)")
+        case .transferNft, .account:
             fatalError("Unsupported transaction type: \(self)")
         case .perpetual(let asset, let perpetualType):
             return .perpetual(asset: asset.map(), perpetualType: perpetualType.map())

--- a/Packages/GemstonePrimitives/Sources/Extensions/GemTransactionLoadInput+GemstonePrimitives.swift
+++ b/Packages/GemstonePrimitives/Sources/Extensions/GemTransactionLoadInput+GemstonePrimitives.swift
@@ -22,9 +22,9 @@ extension GemTransactionLoadInput {
 }
 
 extension TransactionInput {
-    public func map() -> GemTransactionLoadInput {
+    public func map() throws -> GemTransactionLoadInput {
         GemTransactionLoadInput(
-            inputType: self.type.map(),
+            inputType: try self.type.map(),
             senderAddress: senderAddress,
             destinationAddress: destinationAddress,
             value: value.description,

--- a/Packages/Signer/Sources/Chains/HyperCoreSigner.swift
+++ b/Packages/Signer/Sources/Chains/HyperCoreSigner.swift
@@ -29,7 +29,7 @@ public class HyperCoreSigner: Signable {
             privateKey: privateKey
         )
     }
-    
+
     public func signTokenTransfer(input: SignerInput, privateKey: Data) throws -> String {
         throw AnyError.notImplemented
     }
@@ -101,8 +101,8 @@ public class HyperCoreSigner: Signable {
 
     public func signWithdrawal(input: SignerInput, privateKey: Data) throws -> String {
         let timestamp = UInt64(Date.getTimestampInMs())
-        // FIXME: make sure input.amount is correct  ("2" means 2 USD)
-        let request = factory.makeWithdraw(amount: input.value.description, address: input.senderAddress.lowercased(), nonce: timestamp)
+        let amount = BigNumberFormatter.standard.string(from: input.value, decimals: Int(input.asset.decimals))
+        let request = factory.makeWithdraw(amount: amount, address: input.senderAddress.lowercased(), nonce: timestamp)
         let eip712Message = hyperCore.withdrawalRequestTypedData(request: request)
         let signature = try signEIP712(messageJson: eip712Message, privateKey: privateKey)
 


### PR DESCRIPTION
Changes: 

- Enabled withdraw button based on available balance in PerpetualsHeaderViewModel. 
- Set minimum withdrawal amount for USDC to 2 in AmountSceneViewModel. 
- Updated withdrawal recipient to use wallet address in SelectAssetSceneNavigationStack. 
- Mapped HyperCore withdrawal to transfer in GemTransactionInputType extension. 
- Fixed withdrawal amount formatting in HyperCoreSigner.

<img width="33%" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-23 at 15 42 40" src="https://github.com/user-attachments/assets/d0d9b353-141c-43bc-a90e-905fc3a23837" /> <img width="33%" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-23 at 15 42 35" src="https://github.com/user-attachments/assets/0821d78e-fcf5-4420-90fe-ebfd3d86044a" /> <img width="33%" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-23 at 15 42 32" src="https://github.com/user-attachments/assets/db9c578e-6622-48d9-b2ee-9924a2f5ecec" />
