### PR TITLE
Update toolbar dismiss actions and price alert logic

### DIFF
--- a/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -156,7 +156,7 @@ public final class AssetSceneViewModel: Sendable {
     public var optionsImage: Image { Images.System.ellipsis }
     public var priceAlertsSystemImage: String { assetData.isPriceAlertsEnabled ? SystemImage.bellFill : SystemImage.bell }
     public var priceAlertsImage: Image { Image(systemName: priceAlertsSystemImage) }
-    public var showPriceAlerts: Bool { assetData.isPriceAlertsEnabled && priceAlertsViewModel.hasPriceAlerts }
+    public var showPriceAlerts: Bool { priceAlertsViewModel.hasPriceAlerts }
 
     public var menuItems: [ActionMenuItemType] {
         [.button(title: viewAddressOnTitle, systemImage: SystemImage.globe, action: { self.onSelect(url: self.addressExplorerUrl) }),

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/TextMessageScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/TextMessageScene.swift
@@ -20,7 +20,7 @@ struct TextMessageScene: View {
                 .padding()
         }
         .toolbarContent {
-            ToolbarDismissItem(title: .cancel, placement: .topBarLeading)
+            ToolbarDismissItem(title: .done, placement: .topBarLeading)
             ToolbarItemView(placement: .topBarTrailing) {
                 Button {
                     isPresentingShareSheet.toggle()

--- a/Gem/Navigation/WalletConnector/WalletConnectorNavigationStack.swift
+++ b/Gem/Navigation/WalletConnector/WalletConnectorNavigationStack.swift
@@ -56,7 +56,7 @@ struct WalletConnectorNavigationStack: View {
                 }
             }
             .interactiveDismissDisabled(true)
-            .toolbarDismissItem(title: .done, placement: .topBarLeading)
+            .toolbarDismissItem(title: .cancel, placement: .topBarLeading)
             .navigationBarTitleDisplayMode(.inline)
         }
     }

--- a/Gem/Navigation/WalletConnector/WalletConnectorNavigationStack.swift
+++ b/Gem/Navigation/WalletConnector/WalletConnectorNavigationStack.swift
@@ -56,14 +56,7 @@ struct WalletConnectorNavigationStack: View {
                 }
             }
             .interactiveDismissDisabled(true)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(Localized.Common.cancel) {
-                        presenter.cancelSheet(type: type)
-                    }
-                    .bold()
-                }
-            }
+            .toolbarDismissItem(title: .done, placement: .topBarLeading)
             .navigationBarTitleDisplayMode(.inline)
         }
     }


### PR DESCRIPTION
Replaces 'cancel' with 'done' for toolbar dismiss items in TextMessageScene and WalletConnectorNavigationStack for consistency. Also updates AssetSceneViewModel to show price alerts based solely on the presence of alerts, not the enabled state.