### PR TITLE
Update staking UI and input handling for Tron

### DIFF
--- a/Features/Staking/Sources/Scenes/StakeDetailScene.swift
+++ b/Features/Staking/Sources/Scenes/StakeDetailScene.swift
@@ -43,7 +43,6 @@ public struct StakeDetailScene: View {
                     ListItemView(title: title, subtitle: subtitle)
                 }
             }
-            .listRowInsets(.assetListRowInsets)
 
             if let rewardsText = model.model.rewardsText {
                 Section {
@@ -57,7 +56,6 @@ public struct StakeDetailScene: View {
                         imageStyle: model.assetImageStyle
                     )
                 }
-                .listRowInsets(.assetListRowInsets)
             }
 
             //TODO: Remove NavigationCustomLink usage in favor of NavigationLink()
@@ -84,7 +82,6 @@ public struct StakeDetailScene: View {
                         }
                     }
                 }
-                .listRowInsets(.assetListRowInsets)
             }
         }
         .navigationTitle(model.title)

--- a/Features/Staking/Sources/Scenes/StakeScene.swift
+++ b/Features/Staking/Sources/Scenes/StakeScene.swift
@@ -73,7 +73,6 @@ extension StakeScene {
                 }
             }
         }
-        .listRowInsets(.assetListRowInsets)
     }
 
     private var delegationsSection: some View {
@@ -95,7 +94,6 @@ extension StakeScene {
                 ListItemErrorView(errorTitle: Localized.Errors.errorOccured, error: error)
             }
         }
-        .listRowInsets(.assetListRowInsets)
     }
 
     private var stakeInfoSection: some View {
@@ -110,7 +108,6 @@ extension StakeScene {
                 infoAction: model.onLockTimeInfo
             )
         }
-        .listRowInsets(.assetListRowInsets)
     }
 
     private var resourcesSection: some View {
@@ -125,8 +122,6 @@ extension StakeScene {
                 subtitle: model.bandwidthText
             )
         }
-        .listRowInsets(.assetListRowInsets)
+        
     }
 }
-
-

--- a/Features/Transfer/Sources/Types/AmountInputConfig.swift
+++ b/Features/Transfer/Sources/Types/AmountInputConfig.swift
@@ -21,10 +21,8 @@ struct AmountInputConfig: CurrencyInputConfigurable {
     var placeholder: String { .zero }
     var keyboardType: UIKeyboardType {
         switch sceneType {
-        case .stake, .stakeUnstake where asset.chain == .tron:
-            return .numberPad
-        default:
-            return .decimalPad
+        case .transfer, .deposit, .withdraw, .stakeWithdraw, .perpetual, .stakeRedelegate, .freeze: .decimalPad
+        case .stake, .stakeUnstake: asset.chain == .tron ? .numberPad : .decimalPad
         }
     }
 

--- a/Features/Transfer/Sources/Types/AmountInputConfig.swift
+++ b/Features/Transfer/Sources/Types/AmountInputConfig.swift
@@ -17,9 +17,16 @@ struct AmountInputConfig: CurrencyInputConfigurable {
     let numberSanitizer: NumberSanitizer
     let secondaryText: String
     let onTapActionButton: (() -> Void)?
-    
+
     var placeholder: String { .zero }
-    var keyboardType: UIKeyboardType { .decimalPad }
+    var keyboardType: UIKeyboardType {
+        switch sceneType {
+        case .stake, .stakeUnstake where asset.chain == .tron:
+            return .numberPad
+        default:
+            return .decimalPad
+        }
+    }
 
     var currencyPosition: CurrencyTextField.CurrencyPosition {
         switch inputType {

--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -363,7 +363,6 @@ extension AmountSceneViewModel {
         }
     }
 
-    // TODO: - simple int validator for tron voting(staking)
     private var inputValidators: [any TextValidator] {
         let source: AmountValidator.Source = switch amountInputType {
         case .asset: .asset

--- a/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
@@ -108,8 +108,8 @@ public struct TransactionViewModel: Sendable {
         case .stakeRewards: Localized.Transfer.Rewards.title
         case .stakeWithdraw: Localized.Transfer.Withdraw.title
         case .assetActivation: Localized.Transfer.ActivateAsset.title
-        case .stakeFreeze: "Freeze"
-        case .stakeUnfreeze: "Unfreeze"
+        case .stakeFreeze: Localized.Transfer.Freeze.title
+        case .stakeUnfreeze: Localized.Transfer.Unfreeze.title
         case .perpetualOpenPosition: "Open Position"
         case .perpetualClosePosition: "Close Position"
         }


### PR DESCRIPTION
Removed custom list row insets from staking scenes for cleaner UI. Adjusted AmountInputConfig to use numberPad for Tron staking/unstaking, improving input validation. Updated transaction view model to use localized titles for freeze/unfreeze actions.