### PR TITLE
Refactor navigation for ConfirmTransferScene

### DIFF
--- a/Features/Transfer/Sources/Navigation/RecipientNavigationView.swift
+++ b/Features/Transfer/Sources/Navigation/RecipientNavigationView.swift
@@ -39,15 +39,5 @@ public struct RecipientNavigationView: View {
                 )
             )
         }
-        .navigationDestination(for: TransferData.self) { data in
-            ConfirmTransferScene(
-                model: ConfirmTransferSceneViewModel(
-                    wallet: model.wallet,
-                    data: data,
-                    confirmService: confirmService,
-                    onComplete: onComplete
-                )
-            )
-        }
     }
 }

--- a/Features/Transfer/Sources/Navigation/RecipientNavigationView.swift
+++ b/Features/Transfer/Sources/Navigation/RecipientNavigationView.swift
@@ -9,16 +9,13 @@ import QRScanner
 public struct RecipientNavigationView: View {
     @State private var model: RecipientSceneViewModel
     private let confirmService: ConfirmService
-    private let onComplete: VoidAction
 
     public init(
         confirmService: ConfirmService,
-        model: RecipientSceneViewModel,
-        onComplete: VoidAction
+        model: RecipientSceneViewModel
     ) {
         self.confirmService = confirmService
         _model = State(initialValue: model)
-        self.onComplete = onComplete
     }
 
     public var body: some View {

--- a/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
@@ -96,10 +96,7 @@ struct SelectAssetSceneNavigationStack: View {
                             onTransferAction: {
                                 navigationPath.append($0)
                             }
-                        ),
-                        onComplete: {
-                            isPresentingSelectAssetType = nil
-                        }
+                        )
                     )
                 case .receive:
                     ReceiveScene(

--- a/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
@@ -73,8 +73,7 @@ struct SelectedAssetNavigationStack: View  {
                             onTransferAction: {
                                 navigationPath.append($0)
                             }
-                        ),
-                        onComplete: onComplete
+                        )
                     )
                 case .receive:
                     ReceiveScene(
@@ -114,8 +113,7 @@ struct SelectedAssetNavigationStack: View  {
                             onSwap: {
                                 navigationPath.append($0)
                             }
-                        ),
-                        onComplete: onComplete
+                        )
                     )
                 case .stake:
                     StakeNavigationView(
@@ -123,8 +121,7 @@ struct SelectedAssetNavigationStack: View  {
                             wallet: wallet,
                             chain: input.asset.id.chain
                         ),
-                        navigationPath: $navigationPath,
-                        onComplete: onComplete
+                        navigationPath: $navigationPath
                     )
                 }
             }

--- a/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
@@ -130,6 +130,15 @@ struct SelectedAssetNavigationStack: View  {
             }
             .toolbarDismissItem(title: .done, placement: .topBarLeading)
             .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(for: TransferData.self) { data in
+                ConfirmTransferScene(
+                    model: viewModelFactory.confirmTransferScene(
+                        wallet: wallet,
+                        data: data,
+                        onComplete: onComplete
+                    )
+                )
+            }
         }
     }
 }

--- a/Gem/Navigation/Staking/StakeNavigationView.swift
+++ b/Gem/Navigation/Staking/StakeNavigationView.swift
@@ -5,10 +5,6 @@ import Primitives
 import SwiftUI
 import Transfer
 import Staking
-import ChainService
-import NodeService
-import ExplorerService
-import Signer
 import InfoSheet
 
 struct StakeNavigationView: View {
@@ -46,16 +42,6 @@ struct StakeNavigationView: View {
         )
         .sheet(item: $model.isPresentingInfoSheet) {
             InfoSheetScene(type: $0)
-        }
-        .navigationDestination(for: TransferData.self) { data in
-            ConfirmTransferScene(
-                model: viewModelFactory.confirmTransferScene(
-                    wallet: model.wallet,
-                    data: data,
-                    confirmTransferDelegate: nil,
-                    onComplete: onComplete
-                )
-            )
         }
         .navigationDestination(for: AmountInput.self) { input in
             AmountNavigationView(

--- a/Gem/Navigation/Staking/StakeNavigationView.swift
+++ b/Gem/Navigation/Staking/StakeNavigationView.swift
@@ -16,16 +16,12 @@ struct StakeNavigationView: View {
     @State private var model: StakeSceneViewModel
     @Binding private var navigationPath: NavigationPath
 
-    private let onComplete: VoidAction
-
     public init(
         model: StakeSceneViewModel,
-        navigationPath: Binding<NavigationPath>,
-        onComplete: VoidAction
+        navigationPath: Binding<NavigationPath>
     ) {
         _model = State(initialValue: model)
         _navigationPath = navigationPath
-        self.onComplete = onComplete
     }
 
     var body: some View {

--- a/Gem/Navigation/Swap/SwapNavigationView.swift
+++ b/Gem/Navigation/Swap/SwapNavigationView.swift
@@ -14,14 +14,8 @@ struct SwapNavigationView: View {
 
     @State private var model: SwapSceneViewModel
 
-    private let onComplete: VoidAction
-
-    init(
-        model: SwapSceneViewModel,
-        onComplete: VoidAction
-    ) {
+    init(model: SwapSceneViewModel) {
         _model = State(initialValue: model)
-        self.onComplete = onComplete
     }
 
     var body: some View {
@@ -51,17 +45,5 @@ struct SwapNavigationView: View {
                     }
                 }
             }
-    }
-}
-
-// MARK: - Actions
-
-extension SwapNavigationView {
-    private func onSwapComplete(type: TransferDataType) {
-        switch type {
-        case .swap, .tokenApprove:
-            onComplete?()
-        default: break
-        }
     }
 }

--- a/Gem/Navigation/Swap/SwapNavigationView.swift
+++ b/Gem/Navigation/Swap/SwapNavigationView.swift
@@ -2,14 +2,10 @@
 
 import SwiftUI
 import Primitives
-import ChainService
 import Components
 import InfoSheet
 import Swap
 import Assets
-import Transfer
-import ExplorerService
-import Signer
 
 struct SwapNavigationView: View {
     @Environment(\.viewModelFactory) private var viewModelFactory
@@ -30,17 +26,6 @@ struct SwapNavigationView: View {
 
     var body: some View {
         SwapScene(model: model)
-            .navigationDestination(for: TransferData.self) { data in
-                ConfirmTransferScene(
-                    model: viewModelFactory.confirmTransferScene(
-                        wallet: model.wallet,
-                        data: data,
-                        onComplete: {
-                            onSwapComplete(type: data.type)
-                        }
-                    )
-                )
-            }
             .sheet(item: $model.isPresentingInfoSheet) {
                 switch $0 {
                 case let .info(type):


### PR DESCRIPTION
Moved the TransferData navigation destination for ConfirmTransferScene from RecipientNavigationView, StakeNavigationView, and SwapNavigationView to SelectedAssetNavigationStack. 
This centralizes navigation logic and simplifies individual navigation views. 
Fixes navigationDestination issue with multiple same navigation destinations

closes #1104 