### PR TITLE
Add padding and liquidGlass to wallet selector

### DIFF
--- a/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -63,6 +63,8 @@ struct WalletNavigationStack: View {
                             model: model.walletBarModel,
                             action: model.onSelectWalletBar
                         )
+                        .padding(.small)
+                        .liquidGlass()
                     }
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button(action: model.onSelectManage) {


### PR DESCRIPTION
Applied .padding(.small) and .liquidGlass() modifiers to the wallet bar for improved UI appearance.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-23 at 22 53 23" src="https://github.com/user-attachments/assets/384b02d3-45af-424c-a0c4-f85890c16992" />
