### PR TITLE
Replace confirmationDialog with custom alert modifier

### DIFF
--- a/Features/ManageWallets/Sources/Scenes/WalletDetailScene.swift
+++ b/Features/ManageWallets/Sources/Scenes/WalletDetailScene.swift
@@ -104,7 +104,7 @@ public struct WalletDetailScene: View {
         .frame(maxWidth: .infinity)
         .onChange(of: model.nameInput, model.onChangeWalletName)
         .navigationTitle(model.title)
-        .confirmationDialog(
+        .alert(
             Localized.Common.deleteConfirmation(model.name),
             presenting: $model.isPresentingDeleteConfirmation,
             sensoryFeedback: .warning,

--- a/Features/ManageWallets/Sources/Scenes/WalletsScene.swift
+++ b/Features/ManageWallets/Sources/Scenes/WalletsScene.swift
@@ -78,7 +78,7 @@ public struct WalletsScene: View {
         }
         .contentMargins(.top, .scene.top, for: .scrollContent)
         .alertSheet($model.isPresentingAlertMessage)
-        .confirmationDialog(
+        .alert(
             Localized.Common.deleteConfirmation(model.walletDelete?.name ?? ""),
             presenting: $model.walletDelete,
             sensoryFeedback: .warning,

--- a/Features/Settings/Sources/ChainSettings/Scenes/ChainSettingsScene.swift
+++ b/Features/Settings/Sources/ChainSettings/Scenes/ChainSettingsScene.swift
@@ -64,7 +64,7 @@ public struct ChainSettingsScene: View {
         .refreshable {
             await model.fetch()
         }
-        .confirmationDialog(
+        .alert(
             model.deleteConfirmationTitle(for: model.nodeDelete?.host ?? ""),
             presenting: $model.nodeDelete,
             sensoryFeedback: .warning,

--- a/Gem/Scenes/RootScene.swift
+++ b/Gem/Scenes/RootScene.swift
@@ -40,7 +40,7 @@ struct RootScene: View {
                 presenter: model.walletConnectorPresenter
             )
         }
-        .confirmationDialog(
+        .alert(
             Localized.WalletConnect.brandName,
             presenting: $model.isPresentingConnectorError,
             actions: { _ in

--- a/Packages/PrimitivesComponents/Sources/Extensions/View+Alert.swift
+++ b/Packages/PrimitivesComponents/Sources/Extensions/View+Alert.swift
@@ -1,0 +1,43 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Localization
+
+public extension View {
+    func alert<S, A, T, M>(
+        _ title: S,
+        presenting data: Binding<T?>,
+        sensoryFeedback: SensoryFeedback? = nil,
+        @ViewBuilder actions: (T) -> A,
+        @ViewBuilder message: () -> M = { EmptyView() }
+    )
+    -> some View where S: StringProtocol, A: View, M: View {
+        let isPresented: Binding<Bool> = Binding(
+            get: { data.wrappedValue != nil },
+            set: { newValue in
+                guard !newValue else { return }
+                data.wrappedValue = nil
+            }
+        )
+
+        return alert(
+            title,
+            isPresented: isPresented,
+            presenting: data.wrappedValue,
+            actions: { value in
+                VStack {
+                    actions(value)
+                    Button(Localized.Common.cancel, role: .cancel) {
+                        isPresented.wrappedValue = false
+                    }
+                }
+            },
+            message: { _ in
+                message()
+            }
+        )
+        .ifLet(sensoryFeedback) { view, value in
+            view.sensoryFeedback(value, trigger: isPresented.wrappedValue) { $1 }
+        }
+    }
+}


### PR DESCRIPTION
Refactored several scenes to use a new custom .alert view modifier instead of .confirmationDialog for delete confirmations and error alerts. Introduced View+Alert.swift extension to provide a reusable alert implementation with sensory feedback and cancel actions.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1202

## iOS 26

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-25 at 17 16 45" src="https://github.com/user-attachments/assets/bb72fc82-0db9-48da-b348-313e80cc9006" />

## iOS 18.5

<img width="320" alt="Simulator Screenshot - iPhone 16e - 2025-09-25 at 17 12 53" src="https://github.com/user-attachments/assets/2b6a4907-a94b-4b18-b298-d910fdc843f1" />
