### PR TITLE
Prevent redundant wallet swap operations

### DIFF
--- a/Features/ManageWallets/Sources/ViewModels/WalletsSceneViewModel.swift
+++ b/Features/ManageWallets/Sources/ViewModels/WalletsSceneViewModel.swift
@@ -160,6 +160,7 @@ extension WalletsSceneViewModel {
     }
 
     private func performSwapOrder(wallets: [Wallet], source: Int, destination: Int) throws {
+        guard source != destination else { return }
         NSLog("swapOrder source: \(source) destination: \(destination)")
 
         let from = try wallets.getElement(safe: source)


### PR DESCRIPTION
Added a guard clause in performSwapOrder to return early if the source and destination indices are the same, avoiding unnecessary operations.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1209