### PR TITLE
Update delete confirmation localization format

### DIFF
--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -227,9 +227,9 @@ public enum Localized {
     public static let copy = Localized.tr("Localizable", "common.copy", fallback: "Copy")
     /// Delete
     public static let delete = Localized.tr("Localizable", "common.delete", fallback: "Delete")
-    /// Are sure you want to delete %s?
-    public static func deleteConfirmation(_ p1: UnsafePointer<CChar>) -> String {
-      return Localized.tr("Localizable", "common.delete_confirmation", p1, fallback: "Are sure you want to delete %s?")
+    /// Are sure you want to delete %@?
+    public static func deleteConfirmation(_ p1: Any) -> String {
+      return Localized.tr("Localizable", "common.delete_confirmation", String(describing: p1), fallback: "Are sure you want to delete %@?")
     }
     /// Description
     public static let description = Localized.tr("Localizable", "common.description", fallback: "Description")

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "معجون";
 "transfer.max" = "الأعلى";
 "common.delete" = "يمسح";
-"common.delete_confirmation" = "هل أنت متأكد أنك تريد حذف %s ؟";
+"common.delete_confirmation" = "هل أنت متأكد أنك تريد حذف %@ ؟";
 "settings.community" = "مجتمع";
 "common.hide" = "يخفي";
 "wallet.scan" = "مسح";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "আপনি কি নিশ্চিত যে %@ মুছে ফেলতে চান?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Opravdu chcete smazat %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Er du sikker på, at du vil slette %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Einfügen";
 "transfer.max" = "Max";
 "common.delete" = "Löschen";
-"common.delete_confirmation" = "Sind Sie sicher, dass Sie %s löschen wollen?";
+"common.delete_confirmation" = "Möchten Sie %@ wirklich löschen?";
 "settings.community" = "Community";
 "common.hide" = "Ausblenden";
 "wallet.scan" = "Scannen";

--- a/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Are sure you want to delete %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Pegar";
 "transfer.max" = "máx.";
 "common.delete" = "Borrar";
-"common.delete_confirmation" = "¿Estás seguro de que deseas eliminar %s ?";
+"common.delete_confirmation" = "¿Estás seguro de que deseas eliminar %@?";
 "settings.community" = "Comunidad";
 "common.hide" = "Esconder";
 "wallet.scan" = "Escanear";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "جای گذاری";
 "transfer.max" = "حداکثر";
 "common.delete" = "پاک کردن";
-"common.delete_confirmation" = "آیا از پاک کردن %s مطمن هستید؟";
+"common.delete_confirmation" = "آیا مطمئنید که می‌خواهید %@ را حذف کنید؟";
 "settings.community" = "همبودگاه";
 "common.hide" = "پنهان کن";
 "wallet.scan" = "اسکن کن";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Sigurado ka bang gusto mong tanggalin ang %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Pâte";
 "transfer.max" = "Max.";
 "common.delete" = "Supprimer";
-"common.delete_confirmation" = "Etes-vous sûr de vouloir supprimer %s ?";
+"common.delete_confirmation" = "Êtes-vous sûr de vouloir supprimer %@?";
 "settings.community" = "Communauté";
 "common.hide" = "Cacher";
 "wallet.scan" = "Analyse";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "האם אתה בטוח שאתה רוצה למחוק את %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "क्या आप वाकई %@ हटाना चाहते हैं?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Tempel";
 "transfer.max" = "Maksimum";
 "common.delete" = "Hapus";
-"common.delete_confirmation" = "Apa Anda yakin ingin menghapus %s?";
+"common.delete_confirmation" = "Apakah Anda yakin ingin menghapus %@?";
 "settings.community" = "Komunitas";
 "common.hide" = "Sembunyikan";
 "wallet.scan" = "Pindai";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Sei sicuro di voler eliminare %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "ペースト";
 "transfer.max" = "マックス";
 "common.delete" = "消去";
-"common.delete_confirmation" = "本当に%s削除してもよろしいですか?";
+"common.delete_confirmation" = "%@を削除してもよろしいですか?";
 "settings.community" = "コミュニティ";
 "common.hide" = "隠れる";
 "wallet.scan" = "スキャン";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "반죽";
 "transfer.max" = "맥스";
 "common.delete" = "삭제";
-"common.delete_confirmation" = "%s 삭제하시겠습니까?";
+"common.delete_confirmation" = "%@ (를) 삭제하시겠습니까?";
 "settings.community" = "지역 사회";
 "common.hide" = "숨다";
 "wallet.scan" = "주사";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Adakah anda pasti mahu memadamkan %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Weet u zeker dat u %@ wilt verwijderen?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Pasta";
 "transfer.max" = "Maks";
 "common.delete" = "Usuwać";
-"common.delete_confirmation" = "Czy na pewno chcesz usunąć %s ?";
+"common.delete_confirmation" = "Czy na pewno chcesz usunąć %@?";
 "settings.community" = "Wspólnota";
 "common.hide" = "Ukrywać";
 "wallet.scan" = "Skanowanie";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Colar";
 "transfer.max" = "Máx.";
 "common.delete" = "Excluir";
-"common.delete_confirmation" = "Tem certeza de que deseja excluir %s ?";
+"common.delete_confirmation" = "Tem certeza de que deseja excluir %@?";
 "settings.community" = "Comunidade";
 "common.hide" = "Esconder";
 "wallet.scan" = "Varredura";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Sigur vrei să ștergi %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Вставить";
 "transfer.max" = "Макс";
 "common.delete" = "Удалить";
-"common.delete_confirmation" = "Вы уверены, что хотите удалить %s ?";
+"common.delete_confirmation" = "Вы уверены, что хотите удалить %@?";
 "settings.community" = "Сообщество";
 "common.hide" = "Скрыть";
 "wallet.scan" = "Сканировать";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "Je, una uhakika unataka kufuta %@?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "คุณแน่ใจว่าต้องการลบ %@ หรือไม่?";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Yapıştırmak";
 "transfer.max" = "Maksimum";
 "common.delete" = "Silmek";
-"common.delete_confirmation" = "%s silmek istediğinizden emin misiniz?";
+"common.delete_confirmation" = "%@ silmek istediğinizden emin misiniz?";
 "settings.community" = "Toplum";
 "common.hide" = "Saklamak";
 "wallet.scan" = "Tara";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Вставити";
 "transfer.max" = "Max";
 "common.delete" = "Видалити";
-"common.delete_confirmation" = "Ви впевнені, що хочете видалити %s?";
+"common.delete_confirmation" = "Ви впевнені, що хочете видалити %@?";
 "settings.community" = "Спільнота";
 "common.hide" = "Сховати";
 "wallet.scan" = "Сканувати";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Paste";
 "transfer.max" = "Max";
 "common.delete" = "Delete";
-"common.delete_confirmation" = "Are sure you want to delete %s?";
+"common.delete_confirmation" = "کیا آپ واقعی %@ حذف کرنا چاہتے ہیں؟";
 "settings.community" = "Community";
 "common.hide" = "Hide";
 "wallet.scan" = "Scan";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "Dán";
 "transfer.max" = "Tối đa";
 "common.delete" = "Xóa bỏ";
-"common.delete_confirmation" = "Bạn có chắc chắn muốn xóa %s không?";
+"common.delete_confirmation" = "Bạn có chắc chắn muốn xóa %@ không?";
 "settings.community" = "Cộng đồng";
 "common.hide" = "Trốn";
 "wallet.scan" = "Quét";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "粘贴";
 "transfer.max" = "最大值";
 "common.delete" = "删除";
-"common.delete_confirmation" = "确认删除%s吗？";
+"common.delete_confirmation" = "确定要删除%@吗？";
 "settings.community" = "社区";
 "common.hide" = "隐藏";
 "wallet.scan" = "扫码";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -54,7 +54,7 @@
 "common.paste" = "粘貼";
 "transfer.max" = "最大值";
 "common.delete" = "刪除";
-"common.delete_confirmation" = "確定要刪除%s嗎？";
+"common.delete_confirmation" = "確定要刪除%@嗎？";
 "settings.community" = "社區";
 "common.hide" = "隱藏";
 "wallet.scan" = "掃描";


### PR DESCRIPTION
Changed the delete confirmation string format from %s to %@ in Localized.swift and all Localizable.strings files for supported languages. This ensures proper string interpolation and consistency across all localizations.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1213

TODO:

- [ ] Review localize

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-29 at 23 54 37" src="https://github.com/user-attachments/assets/b8cf929c-c013-4952-9955-992098c34cb5" />
