### PR TITLE
Fix missing image in watch wallet info sheet

### DIFF
--- a/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
+++ b/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
@@ -57,7 +57,7 @@ public struct InfoSheetModelFactory {
             return InfoSheetModel(
                 title: Localized.Info.WatchWallet.title,
                 description: Localized.Info.WatchWallet.description,
-                image: nil,
+                image: .image(Images.Wallets.watch),
                 button: .url(Docs.url(.whatIsWatchWallet))
             )
         case let .stakeLockTime(placeholder):


### PR DESCRIPTION
## Summary
- Adds the watch wallet icon to the watch wallet info sheet, which was previously displaying without any image

## Changes
- Updated `InfoSheetModelFactory.swift` to use `Images.Wallets.watch` instead of `nil` for the `.watchWallet` case

## Screenshot
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-09-30 at 12 11 43" src="https://github.com/user-attachments/assets/57c03ecd-7a23-436c-8f9a-075170c428b1" />


Fixes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)