### PR TITLE
Fix WalletConnect continuation leak on cancel

### DIFF
--- a/Gem/Navigation/WalletConnector/WalletConnectorNavigationStack.swift
+++ b/Gem/Navigation/WalletConnector/WalletConnectorNavigationStack.swift
@@ -56,8 +56,15 @@ struct WalletConnectorNavigationStack: View {
                 }
             }
             .interactiveDismissDisabled(true)
-            .toolbarDismissItem(title: .cancel, placement: .topBarLeading)
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(Localized.Common.cancel) {
+                        presenter.cancelSheet(type: type)
+                    }
+                    .bold()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes the WalletConnect continuation leak that occurred when users cancelled connection requests
- Resolves "SWIFT TASK CONTINUATION MISUSE" error that prevented subsequent connection attempts

## Root Cause
The Cancel button in `WalletConnectorNavigationStack` was using `toolbarDismissItem` which only calls `dismiss()` to close the sheet, but never calls the callback to resume the continuation waiting in `WalletConnectorManager`.

**Flow of the bug:**
1. User initiates WalletConnect connection
2. `WalletConnectorManager` creates a continuation and waits for user action
3. Sheet is presented with Cancel button
4. User taps Cancel → `dismiss()` is called → sheet closes
5. **Callback is never invoked** → continuation leaks
6. On second connection attempt, the leaked continuation causes runtime error

## Changes
- Replaced `.toolbarDismissItem(title: .cancel, placement: .topBarLeading)` with custom Cancel button
- Custom button explicitly calls `presenter.cancelSheet(type: type)` which:
  - Invokes the callback with `.failure(ConnectionsError.userCancelled)`
  - Properly resumes the continuation
  - Dismisses the sheet via the callback mechanism

This ensures continuations are always resumed, preventing leaks and allowing subsequent connection attempts to work properly.

Fixes #1225

🤖 Generated with [Claude Code](https://claude.com/claude-code)