### PR TITLE
Add numeric transition animations for dynamic text updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,12 @@ just uml-app
 - **SwiftGen**: Code generation for assets and localization
 - **SwiftFormat**: Code formatting
 
+### Apple Documentation Resources
+- **Xcode AI Documentation**: `/Applications/Xcode.app/Contents/PlugIns/IDEIntelligenceChat.framework/Versions/A/Resources/AdditionalDocumentation`
+  - Contains latest SwiftUI, AppKit, UIKit, and framework documentation
+  - Includes guides for new Apple features and APIs
+  - Reference these docs when implementing new iOS features or using latest Apple frameworks
+
 ## Code Architecture Patterns
 
 ### Feature Module Structure

--- a/Features/Perpetuals/Sources/Scenes/PerpetualScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualScene.swift
@@ -45,6 +45,7 @@ public struct PerpetualScene: View {
                         subtitle: position.pnlWithPercentText,
                         subtitleStyle: position.pnlTextStyle
                     )
+                    .numericTransition(for: position.pnlWithPercentText)
                     
                     ListItemView(
                         title: position.sizeTitle,

--- a/Packages/Components/Sources/Extensions/View+NumericTransition.swift
+++ b/Packages/Components/Sources/Extensions/View+NumericTransition.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+public extension View {
+    func numericTransition<V: Equatable>(for value: V) -> some View {
+        self.numericTransition(for: [value])
+    }
+    
+    func numericTransition<V: Equatable>(for values: [V]) -> some View {
+        self
+            .contentTransition(.numericText(countsDown: true))
+            .animation(.default, value: values)
+    }
+}

--- a/Packages/Components/Sources/Lists/ListAssetItemView.swift
+++ b/Packages/Components/Sources/Lists/ListAssetItemView.swift
@@ -58,10 +58,12 @@ extension ListAssetItemView {
                     Text(priceChangePercentage24h.text)
                         .textStyle(priceChangePercentage24h.style)
                 }
+                .numericTransition(for: [price.text, priceChangePercentage24h.text])
             }
         case .type(let textValue):
             Text(textValue.text)
                 .textStyle(textValue.style)
+                .numericTransition(for: textValue.text)
         case .none:
             EmptyView()
         }
@@ -96,9 +98,11 @@ extension ListAssetItemView {
         VStack(alignment: .trailing, spacing: .tiny) {
             PrivacyText(balance.text, isEnabled: model.showBalancePrivacy)
                 .textStyle(balance.style)
+                .numericTransition(for: balance.text)
             if !totalFiat.text.isEmpty {
                 PrivacyText(totalFiat.text, isEnabled: model.showBalancePrivacy)
                     .textStyle(totalFiat.style)
+                    .numericTransition(for: totalFiat.text)
             }
         }
         .lineLimit(1)

--- a/Packages/PrimitivesComponents/Sources/Components/PriceListItemView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/PriceListItemView.swift
@@ -25,6 +25,7 @@ public struct PriceListItemView: View {
                     Text(model.priceChangeView.text)
                         .textStyle(model.priceChangeView.style)
                 }
+                .numericTransition(for: [model.priceAmount.text, model.priceChangeView.text])
             }
         }
     }

--- a/Packages/PrimitivesComponents/Sources/Components/WalletHeaderView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/WalletHeaderView.swift
@@ -44,6 +44,7 @@ public struct WalletHeaderView: View {
                     Text(model.title)
                 }
             }
+            .numericTransition(for: model.title)
             .minimumScaleFactor(0.5)
             .font(.system(size: 42))
             .fontWeight(.semibold)
@@ -58,6 +59,7 @@ public struct WalletHeaderView: View {
                 .font(.system(size: 16))
                 .fontWeight(.medium)
                 .foregroundStyle(Colors.gray)
+                .numericTransition(for: model.subtitle)
             }
 
             switch model.isWatchWallet {


### PR DESCRIPTION
## Summary
- Add `.numericTransition(for:)` view modifier to animate numeric text changes
- Apply numeric animations to wallet balances, prices, and PnL displays
- Support multiple value tracking with array-based API

## Implementation
- Created `View+NumericTransition.swift` extension with `.numericTransition(for:)` modifier
- Updated `WalletHeaderView` to animate balance and subtitle changes
- Updated `ListAssetItemView` to animate balance, fiat value, and price changes
- Updated `PriceListItemView` to animate price and price change percentage
- Updated `PerpetualScene` to animate PnL updates

## Test Plan
- [x] Verify numeric animations work when balance updates from backend
- [x] Check price change animations in asset list
- [x] Verify wallet header animations on value updates
- [x] Test PnL animations in perpetuals view

🤖 Generated with [Claude Code](https://claude.com/claude-code)