### PR TITLE
Fix stake balance to show full available amount

### DIFF
--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -98,12 +98,10 @@ public final class AmountSceneViewModel {
 
     var infoText: String? {
         switch type {
-        case .transfer, .deposit, .withdraw, .stakeUnstake, .stakeRedelegate, .stakeWithdraw, .perpetual, .freeze:
+        case .transfer, .deposit, .withdraw, .stakeUnstake, .stakeRedelegate, .stakeWithdraw, .perpetual:
             return nil
-        case .stake:
-            guard amountInputModel.text == maxBalance,
-                  availableBalanceForStaking > .zero,
-                  amountInputModel.isValid else { return nil }
+        case .stake, .freeze:
+            guard amountInputModel.text == maxBalance else { return nil }
             return Localized.Transfer.reservedFees(formatter.string(stakingReservedForFees, asset: asset))
         }
     }
@@ -390,7 +388,7 @@ extension AmountSceneViewModel {
                     decimals: asset.decimals.asInt,
                     validators: [
                         PositiveValueValidator<BigInt>().silent,
-                        MinimumValueValidator<BigInt>(minimumValue: minimumValue, asset: asset),
+                        MinimumValueValidator<BigInt>(minimumValue: minimumValue + stakingReservedForFees, asset: asset),
                         BalanceValueValidator<BigInt>(available: availableValue, asset: asset)
                     ]
                 )
@@ -595,10 +593,10 @@ extension AmountSceneViewModel {
                 let staked = BigNumberFormatter.standard.number(from: Int(assetData.balance.metadata?.votes ?? 0), decimals: Int(assetData.asset.decimals))
                 return (assetData.balance.frozen + assetData.balance.locked) - staked
             }
-            return availableBalanceForStaking
+            return assetData.balance.available
         case .freeze(let data):
             switch data.freezeType {
-            case .freeze: return availableBalanceForStaking
+            case .freeze: return assetData.balance.available
             case .unfreeze:
                 switch data.resource {
                 case .bandwidth: return assetData.balance.frozen
@@ -617,7 +615,18 @@ extension AmountSceneViewModel {
     }
 
     private var maxBalance: String {
-        formatter.string(availableValue, decimals: asset.decimals.asInt)
+        let maxValue: BigInt = switch input.type {
+        case .stake:
+            availableBalanceForStaking
+        case .freeze(let data):
+            switch data.freezeType {
+            case .freeze: availableBalanceForStaking
+            case .unfreeze: availableValue
+            }
+        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
+            availableValue
+        }
+        return formatter.string(maxValue, decimals: asset.decimals.asInt)
     }
 
     private var canChangeValue: Bool {


### PR DESCRIPTION
## Summary
- Display full available balance for staking without deducting reserved fees
- Reserved fees are only subtracted when user clicks "max" button
- Info message appears explaining the fee reservation when max amount is set

## Changes
- Updated `availableValue` for stake/freeze to return full `assetData.balance.available`
- Modified `maxBalance` to subtract `stakingReservedForFees` only for stake/freeze operations
- Simplified `infoText` logic to show when max balance is set
- Added reserved fees to minimum value validation

## Impact
Users now see their actual available balance for staking instead of a pre-reduced amount. When they tap "max", the amount is set to (available - fees) and an info message explains the reservation.

Closes #1235

## Screenshots

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-01 at 18 13 46" src="https://github.com/user-attachments/assets/36a0744e-498d-4bd0-bbd4-0a26607be13c" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-01 at 18 13 50" src="https://github.com/user-attachments/assets/faa43e6f-f2d0-4776-bda3-1b379da365e5" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)