### PR TITLE
Fix stake balance validation and reserved fees handling

### DIFF
--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -98,12 +98,10 @@ public final class AmountSceneViewModel {
 
     var infoText: String? {
         switch type {
-        case .transfer, .deposit, .withdraw, .stakeUnstake, .stakeRedelegate, .stakeWithdraw, .perpetual, .freeze:
+        case .transfer, .deposit, .withdraw, .stakeUnstake, .stakeRedelegate, .stakeWithdraw, .perpetual:
             return nil
-        case .stake:
-            guard amountInputModel.text == maxBalance,
-                  availableBalanceForStaking > .zero,
-                  amountInputModel.isValid else { return nil }
+        case .stake, .freeze:
+            guard amountInputModel.text == maxBalance else { return nil }
             return Localized.Transfer.reservedFees(formatter.string(stakingReservedForFees, asset: asset))
         }
     }
@@ -390,7 +388,7 @@ extension AmountSceneViewModel {
                     decimals: asset.decimals.asInt,
                     validators: [
                         PositiveValueValidator<BigInt>().silent,
-                        MinimumValueValidator<BigInt>(minimumValue: minimumValue, asset: asset),
+                        MinimumValueValidator<BigInt>(minimumValue: minimumValue + stakingReservedForFees, asset: asset),
                         BalanceValueValidator<BigInt>(available: availableValue, asset: asset)
                     ]
                 )
@@ -595,10 +593,10 @@ extension AmountSceneViewModel {
                 let staked = BigNumberFormatter.standard.number(from: Int(assetData.balance.metadata?.votes ?? 0), decimals: Int(assetData.asset.decimals))
                 return (assetData.balance.frozen + assetData.balance.locked) - staked
             }
-            return availableBalanceForStaking
+            return assetData.balance.available
         case .freeze(let data):
             switch data.freezeType {
-            case .freeze: return availableBalanceForStaking
+            case .freeze: return assetData.balance.available
             case .unfreeze:
                 switch data.resource {
                 case .bandwidth: return assetData.balance.frozen
@@ -617,7 +615,18 @@ extension AmountSceneViewModel {
     }
 
     private var maxBalance: String {
-        formatter.string(availableValue, decimals: asset.decimals.asInt)
+        let maxValue: BigInt = switch input.type {
+        case .stake:
+            availableBalanceForStaking
+        case .freeze(let data):
+            switch data.freezeType {
+            case .freeze: availableBalanceForStaking
+            case .unfreeze: availableValue
+            }
+        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
+            availableValue
+        }
+        return formatter.string(maxValue, decimals: asset.decimals.asInt)
     }
 
     private var canChangeValue: Bool {

--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -618,6 +618,8 @@ extension AmountSceneViewModel {
 
     private var maxBalance: String {
         let maxValue: BigInt = switch input.type {
+        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
+            availableValue
         case .stake:
             availableBalanceForStaking
         case .freeze(let data):
@@ -625,8 +627,6 @@ extension AmountSceneViewModel {
             case .freeze: availableBalanceForStaking
             case .unfreeze: availableValue
             }
-        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
-            availableValue
         }
         return formatter.string(maxValue, decimals: asset.decimals.asInt)
     }
@@ -659,6 +659,8 @@ extension AmountSceneViewModel {
 
         // For stake/freeze, cap input at max allowed (balance - reserved fees)
         switch input.type {
+        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
+            return amountInputValue
         case .stake, .freeze:
             guard let inputValue = try? formatter.inputNumber(from: amountInputValue, decimals: asset.decimals.asInt) else {
                 return amountInputValue
@@ -666,8 +668,6 @@ extension AmountSceneViewModel {
             if inputValue > availableBalanceForStaking {
                 return formatter.string(availableBalanceForStaking, decimals: asset.decimals.asInt)
             }
-            return amountInputValue
-        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
             return amountInputValue
         }
     }
@@ -678,13 +678,13 @@ extension AmountSceneViewModel {
 
     private var reservedForFee: BigInt {
         switch input.type {
+        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeRedelegate, .stakeWithdraw: .zero
         case .stake: BigInt(Config.shared.getStakeConfig(chain: asset.chain.rawValue).reservedForFees)
         case .freeze(let data):
             switch data.freezeType {
             case .freeze: BigInt(Config.shared.getStakeConfig(chain: asset.chain.rawValue).reservedForFees)
             case .unfreeze: .zero
             }
-        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeRedelegate, .stakeWithdraw: .zero
         }
     }
 

--- a/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
@@ -70,6 +70,55 @@ struct AmountSceneViewModelTests {
 //        let _ = model.amountInputModel.validate()
 //        #expect(model.amountInputModel.isValid)
 //    }
+
+    @Test
+    func transferWithSmallAmount() {
+        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 10_000_000_000_000_000))
+        let model = AmountSceneViewModel.mock(type: .transfer(recipient: .mock()), assetData: assetData)
+
+        model.amountInputModel.update(text: "0.001")
+        #expect(model.amountInputModel.isValid)
+    }
+
+    @Test
+    func stakeWithInsufficientAmount() {
+        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 2_000_000_000_000_000_000))
+        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
+
+        model.amountInputModel.update(text: "0.099")
+        #expect(model.amountInputModel.isValid == false)
+    }
+
+    @Test
+    func stakeWithSufficientAmount() {
+        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 5_000_000_000_000_000_000))
+        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
+
+        model.amountInputModel.update(text: "1.5")
+        #expect(model.amountInputModel.isValid == true)
+    }
+
+    @Test
+    func stakeManualInputNearMax() {
+        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 2_000_000_000_000_000_000))
+        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
+
+        model.amountInputModel.update(text: "2.0")
+        #expect(model.infoText != nil)
+
+        model.amountInputModel.update(text: "1.9")
+        #expect(model.infoText == nil)
+    }
+
+    @Test
+    func stakeUserInputAboveMax() {
+        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 2_000_000_000_000_000_000))
+        let model = AmountSceneViewModel.mock(type: .stake(validators: [.mock()], recommendedValidator: .mock()), assetData: assetData)
+
+        model.amountInputModel.update(text: "2.0")
+        #expect(model.infoText != nil)
+        #expect(model.amountInputModel.isValid == true)
+    }
 }
 
 extension AmountSceneViewModel {
@@ -83,6 +132,7 @@ extension AmountSceneViewModel {
             onTransferAction: { _ in }
         )
         model.assetData = assetData
+        model.onChangeAssetBalance(assetData, assetData)
         return model
     }
 }

--- a/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
@@ -46,10 +46,11 @@ struct AmountSceneViewModelTests {
     func stakingMaxWithInsufficientBalance() {
         let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 1_000_000_000_000)) // Less than reserve
         let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
-        
+
         model.onSelectMaxButton()
-        #expect(model.infoText == nil)
+
         #expect(model.amountInputModel.text == "0")
+        #expect(model.infoText != nil)
     }
     
 //    @Test


### PR DESCRIPTION
## Summary
Fix incorrect available balance display for staking. Users now see their full balance with reserved fees automatically handled during submission.

## Problem
- Available balance was pre-reduced by reserved fees, confusing users
- Transfer operations were incorrectly blocked by staking fee validation
- Users couldn't manually enter amounts near their full balance

## Solution
- **Display full balance** for staking (e.g., 2 BNB instead of 1.99975 BNB)
- **Apply reserved fees validation** only to stake/freeze operations
- **Show info banner** when user input is near/at maximum balance
- **Auto-cap amounts** at (balance - fees) during transaction submission

## Changes
- `reservedForFee`: Returns zero for non-stake/freeze operations
- `availableValue`: Returns full balance for stake/freeze
- `infoText`: Shows when input between (balance - fees) and full balance
- `amountTransferValue`: Auto-caps stake/freeze at max allowed

## Tests
- Transfer with small amount not blocked by staking fees
- Stake validation with insufficient/sufficient amounts
- Info text display for manual input near maximum
- Input above max is valid and auto-capped

Closes #1235

🤖 Generated with [Claude Code](https://claude.com/claude-code)