### PR TITLE
Fix banner UI spacing and close button sizing

### DIFF
--- a/Features/Settings/Sources/Settings/Scenes/DeveloperScene.swift
+++ b/Features/Settings/Sources/Settings/Scenes/DeveloperScene.swift
@@ -8,10 +8,10 @@ import Primitives
 import PrimitivesComponents
 
 public struct DeveloperScene: View {
-    private let model: DeveloperViewModel
+    @State private var model: DeveloperViewModel
 
     public init(model: DeveloperViewModel) {
-        self.model = model
+        _model = State(initialValue: model)
     }
 
     public var body: some View {
@@ -63,6 +63,10 @@ public struct DeveloperScene: View {
                     action: model.clearBanners
                 )
                 NavigationCustomLink(
+                    with: ListItemView(title: "Activate All Cancelled Banners"),
+                    action: model.activateAllCancelledBanners
+                )
+                NavigationCustomLink(
                     with: ListItemView(title: "Clear Perpetuals"),
                     action: model.clearPerpetuals
                 )
@@ -100,5 +104,6 @@ public struct DeveloperScene: View {
         }
         .listStyle(.insetGrouped)
         .navigationTitle(model.title)
+        .toast(message: $model.isPresentingToastMessage)
     }
 }

--- a/Features/Settings/Sources/Settings/ViewModels/DeveloperViewModel.swift
+++ b/Features/Settings/Sources/Settings/ViewModels/DeveloperViewModel.swift
@@ -12,8 +12,11 @@ import Primitives
 import BigInt
 import PriceService
 import PerpetualService
+import Components
 
-public struct DeveloperViewModel: Sendable {
+@Observable
+@MainActor
+public final class DeveloperViewModel {
     private let walletId: WalletId
     private let transactionsService: TransactionsService
     private let assetService: AssetsService
@@ -21,6 +24,8 @@ public struct DeveloperViewModel: Sendable {
     private let bannerService: BannerService
     private let priceService: PriceService
     private let perpetualService: PerpetualService
+
+    public var isPresentingToastMessage: ToastMessage?
 
     public init(
         walletId: WalletId,
@@ -43,15 +48,15 @@ public struct DeveloperViewModel: Sendable {
     var title: String {
         Localized.Settings.developer
     }
-    
+
     var deviceId: String {
         (try? SecurePreferences().get(key: .deviceId)) ?? .empty
     }
-    
+
     var deviceToken: String {
         (try? SecurePreferences().get(key: .deviceToken)) ?? .empty
     }
-    
+
     func reset() {
         do {
             try clearDocuments()
@@ -62,78 +67,81 @@ public struct DeveloperViewModel: Sendable {
             NSLog("reset error \(error)")
         }
     }
-    
-    private func clearDocuments() throws {
-        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let fileURLs = try FileManager.default.contentsOfDirectory(at: documentsUrl, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
-        for fileURL in fileURLs {
-            try FileManager.default.removeItem(at: fileURL)
-        }
-    }
 
     func clearCache() {
-        URLCache.shared.removeAllCachedResponses()
+        performAction {
+            URLCache.shared.removeAllCachedResponses()
+        }
     }
     
     // database
     
     func clearTransactions() {
-        do {
+        performAction {
             try transactionsService.transactionStore.clear()
-        } catch { }
+        }
     }
 
     func clearPendingTransactions() {
-        do {
+        performAction {
             let transactionIds = try transactionsService.transactionStore.getTransactions(state: .pending).map { $0.id }
             try transactionsService.transactionStore.deleteTransactionId(ids: transactionIds)
-        } catch { }
+        }
     }
-    
+
     func clearTransactionsTimestamp() {
-        let store = WalletPreferences(walletId: walletId.id)
-        store.transactionsTimestamp = 0
+        performAction {
+            WalletPreferences(walletId: walletId.id).transactionsTimestamp = 0
+        }
     }
-    
+
     func clearWalletPreferences() {
-        WalletPreferences(walletId: walletId.id).clear()
+        performAction {
+            WalletPreferences(walletId: walletId.id).clear()
+        }
     }
-    
+
     func clearAssets() {
-        do {
+        performAction {
             try assetService.assetStore.clearTokens()
-        } catch { }
+        }
     }
-    
+
     func clearDelegations() {
-        do {
+        performAction {
             try stakeService.clearDelegations()
-        } catch { }
+        }
     }
-    
+
     func clearValidators() {
-        do {
+        performAction {
             try stakeService.clearValidators()
-        } catch { }
+        }
     }
 
     func clearBanners() {
-        do {
+        performAction {
             try bannerService.clearBanners()
-        } catch { }
+        }
     }
-    
+
+    func activateAllCancelledBanners() {
+        performAction {
+            try bannerService.activateAllCancelledBanners()
+        }
+    }
+
     func clearPrices() {
-        do {
+        performAction {
             try priceService.clear()
-        } catch { }
+        }
     }
-    
+
     func clearPerpetuals() {
-        do {
+        performAction {
             try perpetualService.clear()
             Preferences.standard.perpetualMarketsUpdatedAt = .none
-        } catch { }
+        }
     }
     
     func addTransactions() {
@@ -281,14 +289,41 @@ public struct DeveloperViewModel: Sendable {
     }
 
     // preferences
-    
+
     func clearAssetsVersion() {
-        Preferences.standard.swapAssetsVersion = 0
+        performAction {
+            Preferences.standard.swapAssetsVersion = 0
+        }
     }
     
     func deeplink(deeplink: DeepLink) {
         Task { @MainActor in
             await UIApplication.shared.open(deeplink.localUrl, options: [:])
+        }
+    }
+}
+
+// MARK: - Private
+
+extension DeveloperViewModel {
+    private func showSuccess() {
+        isPresentingToastMessage = ToastMessage(title: "Success", image: "checkmark.circle")
+    }
+
+    private func performAction(_ action: () throws -> Void) {
+        do {
+            try action()
+            showSuccess()
+        } catch {
+            NSLog("Developer action error: \(error)")
+        }
+    }
+
+    private func clearDocuments() throws {
+        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let fileURLs = try FileManager.default.contentsOfDirectory(at: documentsUrl, includingPropertiesForKeys: nil, options: .skipsHiddenFiles)
+        for fileURL in fileURLs {
+            try FileManager.default.removeItem(at: fileURL)
         }
     }
 }

--- a/Packages/FeatureServices/BannerService/BannerService.swift
+++ b/Packages/FeatureServices/BannerService/BannerService.swift
@@ -26,10 +26,7 @@ public struct BannerService: Sendable {
                 switch event {
                 case .enableNotifications:
                     try await pushNotificationService.requestPermissionsOrOpenSettings()
-                case .accountActivation,
-                    .accountBlockedMultiSignature:
-                    true
-                case .stake, .activateAsset, .suspiciousAsset, .onboarding:
+                case .stake, .activateAsset, .suspiciousAsset, .onboarding, .accountActivation, .accountBlockedMultiSignature:
                     false
                 }
             case .closeBanner: true
@@ -44,6 +41,11 @@ public struct BannerService: Sendable {
     @discardableResult
     public func clearBanners() throws -> Int {
         try store.clear()
+    }
+
+    @discardableResult
+    public func activateAllCancelledBanners() throws -> Int {
+        try store.activateAllCancelledBanners()
     }
 
     private func updateState(id: String, state: BannerState) throws {

--- a/Packages/FeatureServices/BannerService/Tests/BannerServiceTests.swift
+++ b/Packages/FeatureServices/BannerService/Tests/BannerServiceTests.swift
@@ -1,0 +1,64 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import BannerServiceTestKit
+import StoreTestKit
+import NotificationServiceTestKit
+import Primitives
+import Store
+
+@testable import BannerService
+
+struct BannerServiceTests {
+    @Test
+    func closeBannerActions() async throws {
+        let (store, bannerId, service) = try setupTest()
+        let action = BannerAction(id: bannerId, type: .closeBanner, url: nil)
+
+        try await service.handleAction(action)
+
+        #expect(try store.getBanner(id: bannerId)?.state == .cancelled)
+    }
+
+    @Test
+    func doesNotCloseBannerActions() async throws {
+        let nonClosingActions: [BannerActionType] = [
+            .event(.stake),
+            .event(.activateAsset),
+            .event(.suspiciousAsset),
+            .event(.onboarding),
+            .event(.accountActivation),
+            .event(.accountBlockedMultiSignature),
+            .button(.buy),
+            .button(.receive),
+        ]
+
+        for type in nonClosingActions {
+            let (store, bannerId, service) = try setupTest()
+            let action = BannerAction(id: bannerId, type: type, url: nil)
+
+            try await service.handleAction(action)
+
+            #expect(try store.getBanner(id: bannerId)?.state == .active)
+        }
+    }
+}
+
+// MARK: - Private
+
+extension BannerServiceTests {
+    private func setupTest() throws -> (store: BannerStore, bannerId: String, service: BannerService) {
+        let banner = NewBanner(event: .stake, state: .active)
+        let store = try createStore(banner: banner)
+        let bannerId = Banner(wallet: nil, asset: nil, chain: nil, event: banner.event, state: banner.state).id
+        let service = BannerService.mock(store: store)
+        return (store, bannerId, service)
+    }
+
+    private func createStore(banner: NewBanner) throws -> BannerStore {
+        let db = DB.mock()
+        let store = BannerStore.mock(db: db)
+        try store.addBanners([banner])
+        return store
+    }
+}

--- a/Packages/FeatureServices/Package.swift
+++ b/Packages/FeatureServices/Package.swift
@@ -102,7 +102,7 @@ let package = Package(
                 "Preferences"
             ],
             path: "BannerService",
-            exclude: ["TestKit"]
+            exclude: ["TestKit", "Tests"]
         ),
         .target(
             name: "BannerServiceTestKit",
@@ -466,6 +466,17 @@ let package = Package(
                 .product(name: "PrimitivesTestKit", package: "Primitives")
             ],
             path: "PriceAlertService/Tests"
+        ),
+        .testTarget(
+            name: "BannerServiceTests",
+            dependencies: [
+                "BannerService",
+                "BannerServiceTestKit",
+                .product(name: "StoreTestKit", package: "Store"),
+                "NotificationServiceTestKit",
+                "Primitives"
+            ],
+            path: "BannerService/Tests"
         ),
     ]
 )

--- a/Packages/PrimitivesComponents/Sources/Components/BannerView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/BannerView.swift
@@ -47,9 +47,7 @@ private extension BannerView {
                         imageStyle: model.imageStyle
                     )
 
-                    if model.canClose {
-                        Spacer()
-                    }
+                    Spacer(minLength: model.canClose ? .extraLarge : .zero)
                 }
             }
         )
@@ -96,9 +94,11 @@ private extension BannerView {
             action(model.closeAction)
         } label: {
             Images.System.xmark
+                .resizable()
+                .frame(size: .small)
                 .symbolRenderingMode(.hierarchical)
                 .foregroundColor(Colors.gray)
-                .padding(.tiny)
+                .padding(.small)
                 .liquidGlass { _ in
                     ListButton(
                         image: Images.System.xmarkCircle,

--- a/Packages/Store/Sources/Stores/BannerStore.swift
+++ b/Packages/Store/Sources/Stores/BannerStore.swift
@@ -28,10 +28,26 @@ public struct BannerStore: Sendable {
         }
     }
 
+    public func activateAllCancelledBanners() throws -> Int {
+        try db.write {
+            try BannerRecord
+                .filter(BannerRecord.Columns.state == BannerState.cancelled.rawValue)
+                .updateAll($0, [BannerRecord.Columns.state.set(to: BannerState.active.rawValue)])
+        }
+    }
+
     public func clear() throws -> Int {
         try db.write {
             try BannerRecord
                 .deleteAll($0)
+        }
+    }
+
+    public func getBanner(id: String) throws -> BannerRecord? {
+        try db.read {
+            try BannerRecord
+                .filter(BannerRecord.Columns.id == id)
+                .fetchOne($0)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Improve BannerView close button spacing using `Spacer(minLength:)`
- Resize close button icon to `.small` frame size
- Adjust padding from `.tiny` to `.small` for better touch target
- Add developer tools for banner management
- Add "Activate All Cancelled Banners" option to DeveloperScene
- Refactor DeveloperViewModel to use `@Observable` with success toast notifications
- Create BannerServiceTests to verify handleAction logic

## Screenshots
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-02 at 19 45 46" src="https://github.com/user-attachments/assets/099ac1b5-0335-4013-b862-08a6e6ff6573" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-02 at 19 45 53" src="https://github.com/user-attachments/assets/130fde46-4aa6-4036-a7ab-c961592f4548" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)