### PR TITLE
Fix markdown parsing in localized strings

### DIFF
--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "%@ কিনুন";
 "wallet.import_address_warning" = "আপনি এই ঠিকানার ব্যালেন্স এবং লেনদেন দেখতে পারবেন, কিন্তু **তহবিল পাঠাতে বা বিক্রি করতে পারবেন না**।";
 "info.stake_minimum_amount.title" = "সর্বনিম্ন পরিমাণ";
-"info.stake_minimum_amount.description" = "%@ নেটওয়ার্কে, ন্যূনতম স্টেকিং প্রয়োজনীয়তা হল ** %@ **।";
+"info.stake_minimum_amount.description" = "%@ নেটওয়ার্কে, ন্যূনতম স্টেকিং প্রয়োজনীয়তা হল **%@**।";
 "asset.add_to_wallet" = "ওয়ালেটে যোগ করুন";
 "asset.hide_from_wallet" = "মানিব্যাগ থেকে লুকান";
 "common.details" = "বিস্তারিত";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Koupit %@";
 "wallet.import_address_warning" = "Pro tuto adresu si můžete prohlížet zůstatky a transakce, ale **nemůžete posílat ani prodávat finanční prostředky**.";
 "info.stake_minimum_amount.title" = "Minimální částka";
-"info.stake_minimum_amount.description" = "V síti %@ je minimální požadavek na staking ** %@ **.";
+"info.stake_minimum_amount.description" = "V síti %@ je minimální požadavek na staking **%@**.";
 "asset.add_to_wallet" = "Přidat do peněženky";
 "asset.hide_from_wallet" = "Skrýt z peněženky";
 "common.details" = "Podrobnosti";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Køb %@";
 "wallet.import_address_warning" = "Du kan se saldi og transaktioner for denne adresse, men **kan ikke sende eller sælge penge**.";
 "info.stake_minimum_amount.title" = "Minimumsbeløb";
-"info.stake_minimum_amount.description" = "På netværket %@ er minimumskravet for staking ** %@ **.";
+"info.stake_minimum_amount.description" = "På netværket %@ er minimumskravet for staking **%@**.";
 "asset.add_to_wallet" = "Tilføj til tegnebog";
 "asset.hide_from_wallet" = "Skjul fra tegnebogen";
 "common.details" = "Detaljer";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Kaufen %@";
 "wallet.import_address_warning" = "Sie können Guthaben und Transaktionen für diese Adresse anzeigen, aber **kein Geld senden oder verkaufen**.";
 "info.stake_minimum_amount.title" = "Mindestbetrag";
-"info.stake_minimum_amount.description" = "Im %@ -Netzwerk beträgt die Mindesteinsatzanforderung ** %@ **.";
+"info.stake_minimum_amount.description" = "Im %@ -Netzwerk beträgt die Mindesteinsatzanforderung **%@**.";
 "asset.add_to_wallet" = "Zum Wallet hinzufügen";
 "asset.hide_from_wallet" = "Vor der Brieftasche verstecken";
 "common.details" = "Details";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Comprar %@";
 "wallet.import_address_warning" = "Puede ver los saldos y las transacciones de esta dirección, pero **no puede enviar ni vender fondos**.";
 "info.stake_minimum_amount.title" = "Cantidad mínima";
-"info.stake_minimum_amount.description" = "En la red %@, el requisito mínimo de staking es ** %@ **.";
+"info.stake_minimum_amount.description" = "En la red %@, el requisito mínimo de staking es **%@**.";
 "asset.add_to_wallet" = "Añadir a la billetera";
 "asset.hide_from_wallet" = "Ocultar de la billetera";
 "common.details" = "Detalles";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "خرید %@";
 "wallet.import_address_warning" = "شما می‌توانید موجودی و تراکنش‌های این آدرس را مشاهده کنید، اما **نمی‌توانید وجه ارسال یا بفروشید**.";
 "info.stake_minimum_amount.title" = "حداقل مقدار";
-"info.stake_minimum_amount.description" = "در شبکه %@ ، حداقل میزان سپرده‌گذاری ** %@ ** است.";
+"info.stake_minimum_amount.description" = "در شبکه %@ ، حداقل میزان سپرده‌گذاری **%@** است.";
 "asset.add_to_wallet" = "اضافه کردن به کیف پول";
 "asset.hide_from_wallet" = "پنهان شدن از کیف پول";
 "common.details" = "جزئیات";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Bumili ng %@";
 "wallet.import_address_warning" = "Maaari mong tingnan ang mga balanse at transaksyon para sa address na ito, ngunit **hindi maaaring magpadala o magbenta ng mga pondo**.";
 "info.stake_minimum_amount.title" = "Minimum na halaga";
-"info.stake_minimum_amount.description" = "Sa %@ network, ang minimum na kinakailangan sa staking ay ** %@ **.";
+"info.stake_minimum_amount.description" = "Sa %@ network, ang minimum na kinakailangan sa staking ay **%@**.";
 "asset.add_to_wallet" = "Idagdag sa wallet";
 "asset.hide_from_wallet" = "Itago sa wallet";
 "common.details" = "Mga Detalye";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Achetez %@";
 "wallet.import_address_warning" = "Vous pouvez consulter les soldes et les transactions pour cette adresse, mais **vous ne pouvez pas envoyer ou vendre des fonds**.";
 "info.stake_minimum_amount.title" = "Montant minimum";
-"info.stake_minimum_amount.description" = "Sur le réseau %@, l'exigence minimale de jalonnement est de ** %@ **.";
+"info.stake_minimum_amount.description" = "Sur le réseau %@, l'exigence minimale de jalonnement est de **%@**.";
 "asset.add_to_wallet" = "Ajouter au portefeuille";
 "asset.hide_from_wallet" = "Se cacher du portefeuille";
 "common.details" = "Détails";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "קנה %@";
 "wallet.import_address_warning" = "ניתן לצפות ביתרות ועסקאות עבור כתובת זו, אך **לא ניתן לשלוח או למכור כספים**.";
 "info.stake_minimum_amount.title" = "סכום מינימלי";
-"info.stake_minimum_amount.description" = "ברשת %@, דרישת ההימור המינימלית היא ** %@ **.";
+"info.stake_minimum_amount.description" = "ברשת %@, דרישת ההימור המינימלית היא **%@**.";
 "asset.add_to_wallet" = "הוסף לארנק";
 "asset.hide_from_wallet" = "הסתר מהארנק";
 "common.details" = "פרטים";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "%@ खरीदें";
 "wallet.import_address_warning" = "आप इस पते के लिए शेष राशि और लेनदेन देख सकते हैं, लेकिन **धन भेज या बेच नहीं सकते**।";
 "info.stake_minimum_amount.title" = "न्यूनतम राशि";
-"info.stake_minimum_amount.description" = "%@ नेटवर्क पर, न्यूनतम स्टेकिंग आवश्यकता ** %@ ** है.";
+"info.stake_minimum_amount.description" = "%@ नेटवर्क पर, न्यूनतम स्टेकिंग आवश्यकता **%@** है.";
 "asset.add_to_wallet" = "वॉलेट में जोड़ें";
 "asset.hide_from_wallet" = "बटुए से छिपाएँ";
 "common.details" = "विवरण";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Beli %@";
 "wallet.import_address_warning" = "Anda dapat melihat saldo dan transaksi untuk alamat ini, tetapi **tidak dapat mengirim atau menjual dana**.";
 "info.stake_minimum_amount.title" = "Jumlah minimum";
-"info.stake_minimum_amount.description" = "Pada jaringan %@, persyaratan staking minimum adalah ** %@ **.";
+"info.stake_minimum_amount.description" = "Pada jaringan %@, persyaratan staking minimum adalah **%@**.";
 "asset.add_to_wallet" = "Tambahkan ke dompet";
 "asset.hide_from_wallet" = "Sembunyikan dari dompet";
 "common.details" = "Rincian";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Acquista %@";
 "wallet.import_address_warning" = "Puoi visualizzare i saldi e le transazioni per questo indirizzo, ma **non puoi inviare o vendere fondi**.";
 "info.stake_minimum_amount.title" = "Importo minimo";
-"info.stake_minimum_amount.description" = "Sulla rete %@, il requisito minimo di staking è ** %@ **.";
+"info.stake_minimum_amount.description" = "Sulla rete %@, il requisito minimo di staking è **%@**.";
 "asset.add_to_wallet" = "Aggiungi al portafoglio";
 "asset.hide_from_wallet" = "Nascondi dal portafoglio";
 "common.details" = "Dettagli";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "%@を購入";
 "wallet.import_address_warning" = "このアドレスの残高と取引は表示できますが、**資金を送信または売却することはできません**。";
 "info.stake_minimum_amount.title" = "最低金額";
-"info.stake_minimum_amount.description" = "%@ネットワークでは、最小ステーキング要件は ** %@ ** です。";
+"info.stake_minimum_amount.description" = "%@ネットワークでは、最小ステーキング要件は **%@** です。";
 "asset.add_to_wallet" = "ウォレットに追加";
 "asset.hide_from_wallet" = "ウォレットから隠す";
 "common.details" = "ディテール";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "%@ 구매";
 "wallet.import_address_warning" = "이 주소에 대한 잔액과 거래 내역은 볼 수 있지만, **자금을 보내거나 판매할 수는 없습니다**.";
 "info.stake_minimum_amount.title" = "최소 금액";
-"info.stake_minimum_amount.description" = "%@ 네트워크에서 최소 스테이킹 요구 사항은 ** %@ **입니다.";
+"info.stake_minimum_amount.description" = "%@ 네트워크에서 최소 스테이킹 요구 사항은 **%@**입니다.";
 "asset.add_to_wallet" = "지갑에 추가";
 "asset.hide_from_wallet" = "지갑에서 숨기기";
 "common.details" = "세부";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Beli %@";
 "wallet.import_address_warning" = "Anda boleh melihat baki dan urus niaga untuk alamat ini, tetapi **tidak boleh menghantar atau menjual dana**.";
 "info.stake_minimum_amount.title" = "Jumlah minimum";
-"info.stake_minimum_amount.description" = "Pada rangkaian %@, keperluan pertaruhan minimum ialah ** %@ **.";
+"info.stake_minimum_amount.description" = "Pada rangkaian %@, keperluan pertaruhan minimum ialah **%@**.";
 "asset.add_to_wallet" = "Tambah pada dompet";
 "asset.hide_from_wallet" = "Sembunyi dari dompet";
 "common.details" = "Butiran";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Koop %@";
 "wallet.import_address_warning" = "U kunt het saldo en de transacties voor dit adres bekijken, maar u kunt geen geld verzenden of verkopen.";
 "info.stake_minimum_amount.title" = "Minimumbedrag";
-"info.stake_minimum_amount.description" = "Op het %@ netwerk is de minimale inzetvereiste ** %@ **.";
+"info.stake_minimum_amount.description" = "Op het %@ netwerk is de minimale inzetvereiste **%@**.";
 "asset.add_to_wallet" = "Toevoegen aan portemonnee";
 "asset.hide_from_wallet" = "Verbergen voor portemonnee";
 "common.details" = "Details";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Kup %@";
 "wallet.import_address_warning" = "Możesz przeglądać salda i transakcje dla tego adresu, ale **nie możesz wysyłać ani sprzedawać środków**.";
 "info.stake_minimum_amount.title" = "Minimalna kwota";
-"info.stake_minimum_amount.description" = "W sieci %@ minimalne wymagania dotyczące stakingu to ** %@ **.";
+"info.stake_minimum_amount.description" = "W sieci %@ minimalne wymagania dotyczące stakingu to **%@**.";
 "asset.add_to_wallet" = "Dodaj do portfela";
 "asset.hide_from_wallet" = "Ukryj w portfelu";
 "common.details" = "Bliższe dane";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Comprar %@";
 "wallet.import_address_warning" = "Você pode visualizar saldos e transações para este endereço, mas **não pode enviar ou vender fundos**.";
 "info.stake_minimum_amount.title" = "Quantidade mínima";
-"info.stake_minimum_amount.description" = "Na rede %@, o requisito mínimo de staking é ** %@ **.";
+"info.stake_minimum_amount.description" = "Na rede %@, o requisito mínimo de staking é **%@**.";
 "asset.add_to_wallet" = "Adicionar à carteira";
 "asset.hide_from_wallet" = "Esconder da carteira";
 "common.details" = "Detalhes";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Cumpără %@";
 "wallet.import_address_warning" = "Puteți vizualiza soldurile și tranzacțiile pentru această adresă, dar **nu puteți trimite sau vinde fonduri**.";
 "info.stake_minimum_amount.title" = "Suma minimă";
-"info.stake_minimum_amount.description" = "În rețeaua %@, cerința minimă de staking este ** %@ **.";
+"info.stake_minimum_amount.description" = "În rețeaua %@, cerința minimă de staking este **%@**.";
 "asset.add_to_wallet" = "Adaugă în portofel";
 "asset.hide_from_wallet" = "Ascunde din portofel";
 "common.details" = "Detalii";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Купить %@";
 "wallet.import_address_warning" = "Вы можете просматривать балансы и транзакции для этого адреса, но **не можете отправлять или продавать средства**.";
 "info.stake_minimum_amount.title" = "Минимальная сумма";
-"info.stake_minimum_amount.description" = "В сети %@ минимальное требование к стейкингу составляет ** %@ **.";
+"info.stake_minimum_amount.description" = "В сети %@ минимальное требование к стейкингу составляет **%@**.";
 "asset.add_to_wallet" = "Добавить в кошелек";
 "asset.hide_from_wallet" = "Скрыть из кошелька";
 "common.details" = "Детали";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Nunua %@";
 "wallet.import_address_warning" = "Unaweza kuangalia salio na miamala ya anwani hii, lakini **haiwezi kutuma au kuuza fedha**.";
 "info.stake_minimum_amount.title" = "Kiasi cha chini";
-"info.stake_minimum_amount.description" = "Kwenye mtandao %@, hitaji la chini kabisa la kuweka hisa ni ** %@ **.";
+"info.stake_minimum_amount.description" = "Kwenye mtandao %@, hitaji la chini kabisa la kuweka hisa ni **%@**.";
 "asset.add_to_wallet" = "Ongeza kwenye mkoba";
 "asset.hide_from_wallet" = "Ficha kutoka kwa mkoba";
 "common.details" = "Maelezo";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "ซื้อ %@";
 "wallet.import_address_warning" = "คุณสามารถดูยอดคงเหลือและธุรกรรมสำหรับที่อยู่นี้ แต่ **ไม่สามารถส่งหรือขายเงินได้**";
 "info.stake_minimum_amount.title" = "จำนวนเงินขั้นต่ำ";
-"info.stake_minimum_amount.description" = "บนเครือข่าย %@ ข้อกำหนดการเดิมพันขั้นต่ำคือ ** %@ **";
+"info.stake_minimum_amount.description" = "บนเครือข่าย %@ ข้อกำหนดการเดิมพันขั้นต่ำคือ **%@**";
 "asset.add_to_wallet" = "เพิ่มลงในกระเป๋าสตางค์";
 "asset.hide_from_wallet" = "ซ่อนจากกระเป๋าสตางค์";
 "common.details" = "รายละเอียด";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "%@ satın al";
 "wallet.import_address_warning" = "Bu adrese ait bakiyeleri ve işlemleri görüntüleyebilirsiniz, ancak **para gönderemez veya satamazsınız**.";
 "info.stake_minimum_amount.title" = "Asgari tutar";
-"info.stake_minimum_amount.description" = "%@ ağında, minimum stake gereksinimi ** %@ **'dir.";
+"info.stake_minimum_amount.description" = "%@ ağında, minimum stake gereksinimi **%@**'dir.";
 "asset.add_to_wallet" = "Cüzdana ekle";
 "asset.hide_from_wallet" = "Cüzdandan gizle";
 "common.details" = "Detaylar";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "خریدیں %@";
 "wallet.import_address_warning" = "آپ اس پتے کے بیلنس اور لین دین دیکھ سکتے ہیں، لیکن **فنڈز بھیج یا فروخت نہیں کر سکتے**۔";
 "info.stake_minimum_amount.title" = "کم از کم رقم";
-"info.stake_minimum_amount.description" = "%@ نیٹ ورک پر، اسٹیکنگ کی کم از کم ضرورت ** %@ ** ہے۔";
+"info.stake_minimum_amount.description" = "%@ نیٹ ورک پر، اسٹیکنگ کی کم از کم ضرورت **%@** ہے۔";
 "asset.add_to_wallet" = "بٹوے میں شامل کریں۔";
 "asset.hide_from_wallet" = "بٹوے سے چھپائیں۔";
 "common.details" = "تفصیلات";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "Mua %@";
 "wallet.import_address_warning" = "Bạn có thể xem số dư và giao dịch của địa chỉ này, nhưng **không thể gửi hoặc bán tiền**.";
 "info.stake_minimum_amount.title" = "Số tiền tối thiểu";
-"info.stake_minimum_amount.description" = "Trên mạng %@, yêu cầu đặt cược tối thiểu là ** %@ **.";
+"info.stake_minimum_amount.description" = "Trên mạng %@, yêu cầu đặt cược tối thiểu là **%@**.";
 "asset.add_to_wallet" = "Thêm vào ví";
 "asset.hide_from_wallet" = "Ẩn khỏi ví";
 "common.details" = "Chi tiết";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "购买%@";
 "wallet.import_address_warning" = "您可以查看此地址的余额和交易，但**不能发送或出售资金**。";
 "info.stake_minimum_amount.title" = "最低金额";
-"info.stake_minimum_amount.description" = "在%@网络上，最低质押要求为 ** %@ **。";
+"info.stake_minimum_amount.description" = "在%@网络上，最低质押要求为 **%@**。";
 "asset.add_to_wallet" = "添加到钱包";
 "asset.hide_from_wallet" = "隐藏钱包";
 "common.details" = "详情";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 "asset.buy_asset" = "購買%@";
 "wallet.import_address_warning" = "您可以查看此地址的餘額和交易，但**不能發送或出售資金**。";
 "info.stake_minimum_amount.title" = "最低金額";
-"info.stake_minimum_amount.description" = "在%@網路上，最低質押要求為 ** %@ **。";
+"info.stake_minimum_amount.description" = "在%@網路上，最低質押要求為 **%@**。";
 "asset.add_to_wallet" = "加入錢包";
 "asset.hide_from_wallet" = "隱藏錢包";
 "common.details" = "詳情";


### PR DESCRIPTION
## Summary
Fix InfoSheet description not showing in Russian and other locales due to markdown parsing failure

## Root Cause
Markdown parsing failed because localized strings had spaces inside bold markdown syntax: `** %@ **` instead of `**%@**`

## Changes
Remove spaces around placeholders in markdown bold syntax across all localized strings:
- Before: `** %@ **`
- After: `**%@**`

## Screenshot
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-03 at 12 14 15" src="https://github.com/user-attachments/assets/9b8dd1d0-d7b9-420a-a538-e2b362ddb872" />


Fixes https://github.com/gemwalletcom/gem-ios/issues/1249