### PR TITLE
Fix transaction status colors for confirmed state

### DIFF
--- a/Packages/PrimitivesComponents/Sources/ViewModels/TransactionStateViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/TransactionStateViewModel.swift
@@ -40,7 +40,7 @@ public struct TransactionStateViewModel {
 
     public var color: Color {
         switch state {
-        case .confirmed: Colors.gray
+        case .confirmed: Colors.green
         case .pending: Colors.orange
         case .failed, .reverted: Colors.red
         }
@@ -48,7 +48,7 @@ public struct TransactionStateViewModel {
 
     public var background: Color {
         switch state {
-        case .confirmed: Colors.gray
+        case .confirmed: Colors.green.opacity(0.15)
         case .pending: Colors.orange.opacity(0.15)
         case .failed, .reverted: Colors.red.opacity(0.15)
         }


### PR DESCRIPTION
## Summary
- Fix confirmed transaction status color from gray to green
- Update background color opacity to match

Fixes #1236

## Changes
- `TransactionStateViewModel.swift`: Changed `.confirmed` case to use `Colors.green` instead of `Colors.gray`

## Screenshots

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-03 at 14 11 25" src="https://github.com/user-attachments/assets/b7049eae-697d-40b2-995e-0120062a418c" />

🤖 [Claude Code](https://claude.com/claude-code)