### PR TITLE
Remove listRowInsets from ListSectionView

### DIFF
--- a/Packages/Components/Sources/ListViews/ListSectionView.swift
+++ b/Packages/Components/Sources/ListViews/ListSectionView.swift
@@ -39,7 +39,6 @@ public struct ListSectionView<Item: Identifiable & Sendable, Content: View>: Vie
                         }
                     }
                 }
-                .listRowInsets(.assetListRowInsets)
             }
         }
     }


### PR DESCRIPTION
Removes the hardcoded assetListRowInsets modifier from ListSectionView, allowing views to control their own row insets for more flexible layout customization.