### PR TITLE
Fix reserved fee info text display for zero amounts in staking

### DIFF
--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -102,8 +102,9 @@ public final class AmountSceneViewModel {
             return nil
         case .stake, .freeze:
             guard reservedForFee > .zero else { return nil }
-            guard let inputValue = try? formatter.inputNumber(from: amountInputModel.text, decimals: asset.decimals.asInt) else { return nil }
-            guard inputValue >= availableBalanceForStaking, inputValue <= availableValue else { return nil }
+            guard let inputValue = try? formatter.inputNumber(from: amountInputModel.text, decimals: asset.decimals.asInt),
+                  !inputValue.isZero, inputValue >= availableBalanceForStaking, inputValue <= availableValue
+            else { return nil }
             return Localized.Transfer.reservedFees(formatter.string(reservedForFee, asset: asset))
         }
     }

--- a/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
@@ -40,17 +40,9 @@ struct AmountSceneViewModelTests {
 
         #expect(model.infoText != nil)
         #expect(model.amountInputModel.text == "1.99975")
-    }
-    
-    @Test
-    func stakingMaxWithInsufficientBalance() {
-        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 1_000_000_000_000)) // Less than reserve
-        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
-
-        model.onSelectMaxButton()
-
-        #expect(model.amountInputModel.text == "0")
-        #expect(model.infoText != nil)
+        
+        model.amountInputModel.text = .zero
+        #expect(model.infoText == nil)
     }
     
 //    @Test


### PR DESCRIPTION
Previously, the reserved fee info text would display even when the input amount was zero. This change adds a check to ensure the info text only appears when the user has entered a non-zero amount that would trigger the reserved fee warning.