### PR TITLE
Hide wallet name toolbar when input field is not focused

### DIFF
--- a/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
@@ -53,7 +53,7 @@ struct ImportWalletScene: View {
                         .frame(minHeight: 80, alignment: .top)
                         .focused($focusedField, equals: .input)
                         .toolbar {
-                            if model.importType.showToolbar {
+                            if model.importType.showToolbar, focusedField == .input {
                                 ToolbarItem(placement: .keyboard) {
                                     WordSuggestionView(
                                         words: model.wordsSuggestion,


### PR DESCRIPTION
## Summary
- Fix word suggestion toolbar appearing when wallet name field is focused during wallet import
- Toolbar now only appears when the secret phrase input field is active

## Test plan
- [x] Open wallet import screen
- [x] Focus on wallet name field - verify toolbar does not appear
- [x] Focus on secret phrase input - verify toolbar appears with word suggestions
- [x] Switch between fields - verify toolbar shows/hides correctly

## Screenshots
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-08 at 15 46 46" src="https://github.com/user-attachments/assets/e9a875cb-2bad-400e-ba6c-710d13ac8b17" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-08 at 15 46 49" src="https://github.com/user-attachments/assets/74d8b9bb-5de3-4f7c-ab53-7e29f3e11b18" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-08 at 15 46 54" src="https://github.com/user-attachments/assets/75d20b7a-1fe4-4eb0-b057-7e47c3944669" />
