### PR TITLE
Fix import button alignment on iPad

### DIFF
--- a/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
@@ -97,14 +97,18 @@ struct ImportWalletScene: View {
             }
             
             Section {} header: {
-                StateButton(
-                    text: Localized.Wallet.Import.action,
-                    type: .primary(model.buttonState),
-                    action: model.onSelectActionButton
-                )
-                .frame(height: .scene.button.height)
-                .frame(maxWidth: .scene.button.maxWidth)
+                VStack(alignment: .center) {
+                    StateButton(
+                        text: Localized.Wallet.Import.action,
+                        type: .primary(model.buttonState),
+                        action: model.onSelectActionButton
+                    )
+                    .frame(height: .scene.button.height)
+                    .frame(maxWidth: .scene.button.maxWidth)
+                }
+                .frame(maxWidth: .infinity)
             }
+            .textCase(nil)
         }
         .listSectionSpacing(.compact)
         .contentMargins(.top, .scene.top, for: .scrollContent)


### PR DESCRIPTION
## Summary
- Center the import button on wallet import screen for iPad
- Wrap button in VStack with full-width frame and center alignment
- Prevent section header text capitalization

## Test plan
- [x] Open wallet import screen on iPad simulator
- [x] Verify import button is centered horizontally
- [x] Test on iPhone to ensure no regression
- [x] Verify section header text is not capitalized

## Screenshots
<img width="640" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2025-10-08 at 16 06 21" src="https://github.com/user-attachments/assets/f8edae14-678f-49c8-af2f-c220bf102d23" />
