### PR TITLE
Improve dismiss wallet search 

### DIFF
--- a/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -219,6 +219,10 @@ extension WalletSceneViewModel {
             refresh(for: newWallet)
         }
     }
+
+    public func onWalletTabReselected(_: Bool, _: Bool) {
+         isPresentingSearch = false
+    }
     
     func shouldStartLoadingAssets() {
         let preferences = WalletPreferences(walletId: wallet.id)

--- a/Gem/Navigation/NavigationStateManager.swift
+++ b/Gem/Navigation/NavigationStateManager.swift
@@ -20,6 +20,9 @@ final class NavigationStateManager: Sendable {
     @MainActor
     var previousSelectedTab: TabItem = .wallet
 
+    @MainActor
+    var walletTabReselected = false
+
     init() {}
 }
 
@@ -39,7 +42,9 @@ extension NavigationStateManager {
 
     func backToRoot(tab: TabItem) {
         switch tab {
-        case .wallet: resetPath(&wallet)
+        case .wallet:
+            resetPath(&wallet)
+            walletTabReselected.toggle()
         case .collections: resetPath(&collections)
         case .activity: resetPath(&activity)
         case .settings: resetPath(&settings)

--- a/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -59,6 +59,7 @@ struct WalletNavigationStack: View {
                 }
             }
             .onChange(of: model.currentWallet, model.onChangeWallet)
+            .onChange(of: navigationState.walletTabReselected, model.onWalletTabReselected)
             .observeQuery(
                 request: $model.assetsRequest,
                 value: $model.assets


### PR DESCRIPTION
Handle wallet tab reselection to reset search state

Adds logic to detect when the wallet tab is reselected and resets the search presentation state. Updates NavigationStateManager and WalletSceneViewModel to support this behavior, improving user experience when navigating back to the wallet tab.

closes #1286 