### PR TITLE
Add search filtering to perpetual positions

### DIFF
--- a/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
@@ -94,14 +94,16 @@ public struct PerpetualsScene: View {
                     }
                 }
             }
-            Section {
-                PerpetualSectionView(
-                    perpetuals: model.sections.markets,
-                    onPin: model.onPinPerpetual,
-                    emptyText: model.noMarketsText
-                )
-            } header: {
-                Text(model.marketsSectionTitle)
+            if model.showMarkets {
+                Section {
+                    PerpetualSectionView(
+                        perpetuals: model.sections.markets,
+                        onPin: model.onPinPerpetual,
+                        emptyText: model.noMarketsText
+                    )
+                } header: {
+                    Text(model.marketsSectionTitle)
+                }
             }
         }
     }

--- a/Features/Perpetuals/Sources/ViewModels/PerpetualsSceneViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/PerpetualsSceneViewModel.swift
@@ -40,7 +40,7 @@ public final class PerpetualsSceneViewModel {
     ) {
         self.wallet = wallet
         self.perpetualService = perpetualService
-        self.positionsRequest = PerpetualPositionsRequest(walletId: wallet.id)
+        self.positionsRequest = PerpetualPositionsRequest(walletId: wallet.id, searchQuery: "")
         self.perpetualsRequest = PerpetualsRequest(searchQuery: "")
         self.walletBalanceRequest = PerpetualWalletBalanceRequest(walletId: wallet.id)
         self.onSelectAssetType = onSelectAssetType
@@ -54,10 +54,19 @@ public final class PerpetualsSceneViewModel {
     var pinImage: Image { Images.System.pin }
     var searchImage: Image { Images.System.search }
 
-    var showPositions: Bool { !isSearching && positions.isNotEmpty }
+    var showPositions: Bool { positions.isNotEmpty }
     var showPinned: Bool { !isSearching && sections.pinned.isNotEmpty }
+    var showMarkets: Bool { !isSearching || sections.markets.isNotEmpty || positions.isEmpty }
 
-    var sections: PerpetualsSections { PerpetualsSections.from(perpetuals) }
+    var sections: PerpetualsSections {
+        if isSearching {
+            // During search, filter out perpetuals that are already in positions
+            let positionPerpetualIds = Set(positions.map { $0.perpetual.id })
+            let filteredPerpetuals = perpetuals.filter { !positionPerpetualIds.contains($0.perpetual.id) }
+            return PerpetualsSections.from(filteredPerpetuals)
+        }
+        return PerpetualsSections.from(perpetuals)
+    }
 
     var headerViewModel: PerpetualsHeaderViewModel {
         PerpetualsHeaderViewModel(
@@ -116,6 +125,7 @@ extension PerpetualsSceneViewModel {
     func onSearchQueryChange(_ _: String, _ newValue: String) {
         let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
         perpetualsRequest = PerpetualsRequest(searchQuery: trimmed)
+        positionsRequest = PerpetualPositionsRequest(walletId: wallet.id, searchQuery: trimmed)
     }
 
     func onSearchPresentedChange(_ _: Bool, _ isPresented: Bool) {

--- a/Packages/Store/Sources/Requests/Perpetuals/PerpetualPositionsRequest.swift
+++ b/Packages/Store/Sources/Requests/Perpetuals/PerpetualPositionsRequest.swift
@@ -7,18 +7,21 @@ import Combine
 import Primitives
 
 public struct PerpetualPositionsRequest: ValueObservationQueryable {
-    
+
     public static var defaultValue: [PerpetualPositionData] { [] }
-    
+
     public var walletId: String
     public var perpetualId: String?
-    
+    public var searchQuery: String
+
     public init(
         walletId: String,
-        perpetualId: String? = .none
+        perpetualId: String? = .none,
+        searchQuery: String = ""
     ) {
         self.walletId = walletId
         self.perpetualId = perpetualId
+        self.searchQuery = searchQuery
     }
     
     public func fetch(_ db: Database) throws -> [PerpetualPositionData] {
@@ -26,11 +29,20 @@ public struct PerpetualPositionsRequest: ValueObservationQueryable {
             .including(required: PerpetualRecord.asset)
             .including(all: PerpetualRecord.positions
                 .filter(PerpetualPositionRecord.Columns.walletId == walletId))
-        
+
         if let perpetualId = perpetualId {
             query = query.filter(PerpetualRecord.Columns.id == perpetualId)
         }
-        
+
+        if !searchQuery.isEmpty {
+            query = query.filter(
+                PerpetualRecord.Columns.name.like("%%\(searchQuery)%%") ||
+                PerpetualRecord.Columns.identifier.like("%%\(searchQuery)%%") ||
+                TableAlias(name: AssetRecord.databaseTableName)[AssetRecord.Columns.name].like("%%\(searchQuery)%%") ||
+                TableAlias(name: AssetRecord.databaseTableName)[AssetRecord.Columns.symbol].like("%%\(searchQuery)%%")
+            )
+        }
+
         return try query
             .asRequest(of: PerpetualPositionsInfo.self)
             .fetchAll(db)


### PR DESCRIPTION
Introduces a searchQuery parameter to PerpetualPositionsRequest and updates PerpetualsSceneViewModel to filter positions and markets based on the search input. The UI now conditionally displays sections and titles depending on search results, improving discoverability and user experience during search.

closes #1282 

images:
<img width="320" height="640" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-10-09 at 19 48 59" src="https://github.com/user-attachments/assets/661f846f-f176-4162-8d21-a528436e52be" /> <img width="320" height="640" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-10-09 at 19 49 12" src="https://github.com/user-attachments/assets/57d2a3df-9ad5-4b10-8cdc-5eaa2d00a3e5" />
