### PR TITLE
Move delegation status to titleExtra

### DIFF
--- a/Features/Staking/Sources/ViewModels/StakeDelegationViewModel.swift
+++ b/Features/Staking/Sources/ViewModels/StakeDelegationViewModel.swift
@@ -76,18 +76,10 @@ public struct StakeDelegationViewModel: Sendable {
         TextStyle(font: .body, color: .primary, fontWeight: .semibold)
     }
     
-    public var stateTagStyle: TextStyle {
-        TextStyle(
-            font: .footnote,
-            color: stateTextColor,
-            background: stateTextColor.opacity(0.15)
-        )
+    public var stateStyle: TextStyle {
+        TextStyle(font: .footnote, color: stateTextColor)
     }
-    
-    public var titleExtraStyle: TextStyle {
-        TextStyle(font: .footnote, color: Colors.gray)
-    }
-    
+
     public var subtitleStyle: TextStyle {
         TextStyle(font: .callout, color: Colors.black, fontWeight: .semibold)
     }

--- a/Features/Staking/Sources/Views/ValidatorDelegationView.swift
+++ b/Features/Staking/Sources/Views/ValidatorDelegationView.swift
@@ -17,10 +17,8 @@ public struct ValidatorDelegationView: View {
         ListItemView(
             title: delegation.validatorText,
             titleStyle: delegation.titleStyle,
-            titleTag: delegation.stateText,
-            titleTagStyle: delegation.stateTagStyle,
-            titleExtra: delegation.completionDateText,
-            titleStyleExtra: delegation.titleExtraStyle,
+            titleExtra: delegation.stateText,
+            titleStyleExtra: delegation.stateStyle,
             subtitle: delegation.balanceText,
             subtitleStyle: delegation.subtitleStyle,
             subtitleExtra: delegation.fiatValueText,


### PR DESCRIPTION
Relocates delegation status display from titleTag to titleExtra position and renames style properties to semantic names.

## Screenshots

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-13 at 12 42 27" src="https://github.com/user-attachments/assets/97114568-0d42-4592-a985-f82de3fa54a1" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-13 at 12 45 06" src="https://github.com/user-attachments/assets/e795ef82-7cf4-4a17-8fe7-fe46d86ad83c" />

Close: https://github.com/gemwalletcom/gem-ios/issues/1300
Close: https://github.com/gemwalletcom/gem-ios/issues/1161
