### PR TITLE
Fix UI spacing and disable glass effects

### DIFF
--- a/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -154,6 +154,7 @@ public struct AssetScene: View {
                 Section {
                     Spacer()
                     EmptyContentView(model: model.emptyContentModel)
+                        .padding(.bottom, .extraLarge)
                 }
                 .cleanListRow()
             }

--- a/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/VerifyPhraseWalletScene.swift
@@ -36,7 +36,7 @@ struct VerifyPhraseWalletScene: View {
                                     Button { } label: {
                                         Text(row.word)
                                     }
-                                    .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny, glassEffect: .enabled))
+                                    .buttonStyle(.lightGray(paddingHorizontal: .small, paddingVertical: .tiny, glassEffect: .disabled))
                                     .disabled(true)
                                     .fixedSize()
                                 } else {
@@ -45,7 +45,7 @@ struct VerifyPhraseWalletScene: View {
                                     } label: {
                                         Text(row.word)
                                     }
-                                    .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny, glassEffect: .enabled))
+                                    .buttonStyle(.blueGrayPressed(paddingHorizontal: .small, paddingVertical: .tiny, glassEffect: .disabled))
                                     .fixedSize()
                                 }
                             }

--- a/Packages/Components/Sources/TagsView.swift
+++ b/Packages/Components/Sources/TagsView.swift
@@ -65,6 +65,5 @@ public struct TagView<T: TagItemViewable>: View {
             }
 
         }
-        .liquidGlass(interactive: false)
     }
 }


### PR DESCRIPTION
- Add bottom padding to empty asset state
- Disable glass effect on phrase verification buttons
- Remove glass effect from tag view