### PR TITLE
Fix Tron unfreeze validation when switching resources

### DIFF
--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -271,6 +271,7 @@ extension AmountSceneViewModel {
             ),
             asset: input.asset
         )
+        amountInputModel.update(validators: inputValidators)
     }
 
     func onSelectInputButton() {

--- a/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
@@ -122,6 +122,26 @@ struct AmountSceneViewModelTests {
         model.amountInputModel.update(text: "10")
         #expect(model.amountInputModel.isValid == true)
     }
+
+    @Test
+    func unfreezeResourceSwitchUpdatesValidators() {
+        let assetData = AssetData.mock(
+            asset: .mockTron(),
+            balance: .mock(frozen: 0, locked: 5_000_000)
+        )
+        let model = AmountSceneViewModel.mock(
+            type: .freeze(data: .init(freezeType: .unfreeze, resource: .bandwidth)),
+            assetData: assetData
+        )
+
+        model.onSelectResource(.energy)
+        model.amountInputModel.update(text: "2.0")
+        #expect(model.amountInputModel.isValid == true)
+
+        model.onSelectResource(.bandwidth)
+        model.amountInputModel.update(text: "2.0")
+        #expect(model.amountInputModel.isValid == false)
+    }
 }
 
 extension AmountSceneViewModel {


### PR DESCRIPTION
Fixes #1289

Update validators after resource selection to ensure balance checks use the correct resource's available amount.