### PR TITLE
Confirm add sheet for details network fee

### DIFF
--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -114,15 +114,11 @@ extension ConfirmTransferScene {
                 with: SwapDetailsListView(model: swapDetailsViewModel),
                 action: model.onSelectSwapDetails
             )
-        case let .networkFee(model, selectable):
-            if selectable {
-                NavigationCustomLink(
-                    with: ListItemView(model: model),
-                    action: self.model.onSelectFeePicker
-                )
-            } else {
-                ListItemView(model: model)
-            }
+        case let .networkFee(model):
+            NavigationCustomLink(
+                with: ListItemView(model: model),
+                action: self.model.onSelectFeePicker
+            )
         case let .error(title, error, onInfoAction):
             ListItemErrorView(
                 errorTitle: title,

--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -48,7 +48,15 @@ public struct ConfirmTransferScene: View {
             case .networkFeeSelector:
                 NavigationStack {
                     NetworkFeeScene(model: model.feeModel)
-                        .presentationDetentsForCurrentDeviceSize(expandable: true)
+                        .ifElse(
+                            model.feeModel.showFeeRates,
+                            ifContent: {
+                                $0.presentationDetentsForCurrentDeviceSize(expandable: true)
+                            },
+                            elseContent: {
+                                $0.presentationDetents([.height(200)])
+                            }
+                        )
                 }
             case .fiatConnect(let assetAddress, let walletId):
                 NavigationStack {

--- a/Features/Transfer/Sources/Types/ConfirmTransferSection.swift
+++ b/Features/Transfer/Sources/Types/ConfirmTransferSection.swift
@@ -38,7 +38,7 @@ public enum ConfirmTransferItemModel {
     case network(ListItemModel)
     case memo(ListItemModel)
     case swapDetails(SwapDetailsViewModel)
-    case networkFee(ListItemModel, selectable: Bool)
+    case networkFee(ListItemModel)
     case error(title: String, error: Error, onInfoAction: VoidAction)
     case empty
 }

--- a/Features/Transfer/Sources/ViewModels/ConfirmNetworkFeeViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmNetworkFeeViewModel.swift
@@ -8,7 +8,6 @@ struct ConfirmNetworkFeeViewModel: ItemModelProvidable {
     private let title: String
     private let value: String?
     private let fiatValue: String?
-    private let showFeeRatesSelector: Bool
     private let infoAction: VoidAction
 
     init(
@@ -16,14 +15,12 @@ struct ConfirmNetworkFeeViewModel: ItemModelProvidable {
         title: String,
         value: String?,
         fiatValue: String?,
-        showFeeRatesSelector: Bool,
         infoAction: VoidAction
     ) {
         self.state = state
         self.title = title
         self.value = value
         self.fiatValue = fiatValue
-        self.showFeeRatesSelector = showFeeRatesSelector
         self.infoAction = infoAction
     }
 }
@@ -39,8 +36,7 @@ extension ConfirmNetworkFeeViewModel {
                 subtitleExtra: networkFeeFiatValue,
                 placeholders: [.subtitle],
                 infoAction: infoAction
-            ),
-            selectable: showFeeRatesSelector
+            )
         )
     }
 }

--- a/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -138,7 +138,6 @@ extension ConfirmTransferSceneViewModel: ListSectionProvideable {
                 title: feeModel.title,
                 value: feeModel.value,
                 fiatValue: feeModel.fiatValue,
-                showFeeRatesSelector: feeModel.showFeeRatesSelector,
                 infoAction: onSelectNetworkFeeInfo
             )
         case .error:

--- a/Features/Transfer/Tests/ViewModels/ConfirmNetworkFeeViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmNetworkFeeViewModelTests.swift
@@ -18,13 +18,11 @@ struct ConfirmNetworkFeeViewModelTests {
             title: Localized.Transfer.networkFee,
             value: "0.001 ETH",
             fiatValue: fiatValue,
-            showFeeRatesSelector: false,
             infoAction: {}
         )
 
-        guard case .networkFee(let item, let selectable) = model.itemModel else { return }
+        guard case .networkFee(let item) = model.itemModel else { return }
         #expect(item.subtitle == fiatValue)
-        #expect(selectable == false)
     }
 
     @Test
@@ -35,11 +33,10 @@ struct ConfirmNetworkFeeViewModelTests {
             title: Localized.Transfer.networkFee,
             value: value,
             fiatValue: nil,
-            showFeeRatesSelector: false,
             infoAction: {}
         )
 
-        guard case .networkFee(let item, _) = model.itemModel else { return }
+        guard case .networkFee(let item) = model.itemModel else { return }
         #expect(item.subtitle == value)
     }
 
@@ -50,11 +47,10 @@ struct ConfirmNetworkFeeViewModelTests {
             title: Localized.Transfer.networkFee,
             value: nil,
             fiatValue: nil,
-            showFeeRatesSelector: false,
             infoAction: {}
         )
 
-        guard case .networkFee(let item, _) = model.itemModel else { return }
+        guard case .networkFee(let item) = model.itemModel else { return }
         #expect(item.subtitle == "-")
     }
 
@@ -73,28 +69,12 @@ struct ConfirmNetworkFeeViewModelTests {
             title: Localized.Transfer.networkFee,
             value: value,
             fiatValue: fiatValue,
-            showFeeRatesSelector: false,
             infoAction: {}
         )
 
-        guard case .networkFee(let item, _) = model.itemModel else { return }
+        guard case .networkFee(let item) = model.itemModel else { return }
         #expect(item.subtitle == value)
         #expect(item.subtitleExtra == fiatValue)
-    }
-
-    @Test
-    func selectable() {
-        let model = ConfirmNetworkFeeViewModel(
-            state: .data(.mock()),
-            title: "Fee",
-            value: "0.001",
-            fiatValue: nil,
-            showFeeRatesSelector: true,
-            infoAction: {}
-        )
-
-        guard case .networkFee(_, let selectable) = model.itemModel else { return }
-        #expect(selectable == true)
     }
 }
 

--- a/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
@@ -176,7 +176,7 @@ struct ConfirmTransferSceneViewModelTests {
         model.state = .error(AnyError("test"))
         let errorFeeItem = model.itemModel(for: .networkFee) as? ConfirmNetworkFeeViewModel
 
-        if case .networkFee(let listItem, _) = errorFeeItem?.itemModel {
+        if case .networkFee(let listItem) = errorFeeItem?.itemModel {
             #expect(listItem.subtitle == "-")
             #expect(listItem.subtitleExtra == nil)
         } else {
@@ -187,7 +187,7 @@ struct ConfirmTransferSceneViewModelTests {
         model.state = .data(TransactionInputViewModel.mock())
         let feeWithFiatItem = model.itemModel(for: .networkFee) as? ConfirmNetworkFeeViewModel
 
-        if case .networkFee(let listItem, _) = feeWithFiatItem?.itemModel {
+        if case .networkFee(let listItem) = feeWithFiatItem?.itemModel {
             #expect(listItem.subtitle == "$2.50")
             #expect(listItem.subtitleExtra == nil)
         } else {
@@ -197,7 +197,7 @@ struct ConfirmTransferSceneViewModelTests {
         model.feeModel.update(value: "0.001 ETH", fiatValue: nil)
         let feeNoFiatItem = model.itemModel(for: .networkFee) as? ConfirmNetworkFeeViewModel
 
-        if case .networkFee(let listItem, _) = feeNoFiatItem?.itemModel {
+        if case .networkFee(let listItem) = feeNoFiatItem?.itemModel {
             #expect(listItem.subtitle == "0.001 ETH")
             #expect(listItem.subtitleExtra == nil)
         } else {

--- a/Packages/PrimitivesComponents/Sources/Scenes/NetworkFeeScene.swift
+++ b/Packages/PrimitivesComponents/Sources/Scenes/NetworkFeeScene.swift
@@ -27,20 +27,27 @@ public struct NetworkFeeScene: View {
                             )
                             .frame(width: Sizing.image.asset, height: Sizing.image.asset)
 
-                            ListItemSelectionView(
-                                title: feeRate.title,
-                                titleExtra: feeRate.valueText,
-                                titleTag: .none,
-                                titleTagType: .none,
-                                subtitle: .none,
-                                subtitleExtra: .none,
-                                value: feeRate.feeRate.priority,
-                                selection: model.priority,
-                                action: {
-                                    model.priority = $0
-                                    dismiss()
-                                }
-                            )
+                            if model.showFeeRatesSelector {
+                                ListItemSelectionView(
+                                    title: feeRate.title,
+                                    titleExtra: feeRate.valueText,
+                                    titleTag: .none,
+                                    titleTagType: .none,
+                                    subtitle: .none,
+                                    subtitleExtra: .none,
+                                    value: feeRate.feeRate.priority,
+                                    selection: model.priority,
+                                    action: {
+                                        model.priority = $0
+                                        dismiss()
+                                    }
+                                )
+                            } else {
+                                ListItemView(
+                                    title: feeRate.title,
+                                    titleExtra: feeRate.valueText
+                                )
+                            }
                         }
                     }
                 } footer: {

--- a/Packages/PrimitivesComponents/Sources/Scenes/NetworkFeeScene.swift
+++ b/Packages/PrimitivesComponents/Sources/Scenes/NetworkFeeScene.swift
@@ -27,27 +27,20 @@ public struct NetworkFeeScene: View {
                             )
                             .frame(width: Sizing.image.asset, height: Sizing.image.asset)
 
-                            if model.showFeeRatesSelector {
-                                ListItemSelectionView(
-                                    title: feeRate.title,
-                                    titleExtra: feeRate.valueText,
-                                    titleTag: .none,
-                                    titleTagType: .none,
-                                    subtitle: .none,
-                                    subtitleExtra: .none,
-                                    value: feeRate.feeRate.priority,
-                                    selection: model.priority,
-                                    action: {
-                                        model.priority = $0
-                                        dismiss()
-                                    }
-                                )
-                            } else {
-                                ListItemView(
-                                    title: feeRate.title,
-                                    titleExtra: feeRate.valueText
-                                )
-                            }
+                            ListItemSelectionView(
+                                title: feeRate.title,
+                                titleExtra: feeRate.valueText,
+                                titleTag: .none,
+                                titleTagType: .none,
+                                subtitle: .none,
+                                subtitleExtra: .none,
+                                value: feeRate.feeRate.priority,
+                                selection: model.priority,
+                                action: {
+                                    model.priority = $0
+                                    dismiss()
+                                }
+                            )
                         }
                     }
                 } footer: {
@@ -65,7 +58,7 @@ public struct NetworkFeeScene: View {
                 placeholders: [.subtitle]
             )
         }
-        
+
         .contentMargins(.top, .scene.top, for: .scrollContent)
         .navigationTitle(model.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeSceneViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/NetworkFeeSceneViewModel.swift
@@ -33,8 +33,6 @@ public final class NetworkFeeSceneViewModel {
     public var doneTitle: String { Localized.Common.done }
     public var infoIcon: String { Localized.FeeRates.info }
 
-    public var showFeeRatesSelector: Bool { rates.count > 1 }
-
     public var feeRatesViewModels: [FeeRateViewModel] {
         rates.map {
             FeeRateViewModel(
@@ -51,7 +49,7 @@ public final class NetworkFeeSceneViewModel {
     }
 
     public var showFeeRates: Bool {
-        feeRatesViewModels.isNotEmpty
+        rates.count > 1
     }
 }
 

--- a/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/NetworkFeeSceneViewModelTests.swift
+++ b/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ViewModels/NetworkFeeSceneViewModelTests.swift
@@ -14,12 +14,12 @@ struct NetworkFeeSceneViewModelTests {
             chain: .ethereum,
             priority: .normal
         )
-        
+
         model.update(rates: [.defaultRate()])
-        #expect(model.showFeeRatesSelector == false)
-        
+        #expect(model.showFeeRates == false)
+
         model.update(rates: [.defaultRate(), .defaultRate()])
-        #expect(model.showFeeRatesSelector)
+        #expect(model.showFeeRates)
     }
     
     @Test


### PR DESCRIPTION
Refactored ConfirmTransferSection and related view models to eliminate the 'selectable' flag from the network fee item. 
The network fee is now always rendered as a selectable link in ConfirmTransferScene, and tests have been updated accordingly.
NetworkFeeScene now conditionally displays a selection view or a simple list item based on the model's showFeeRatesSelector property.

images:
<img width="360" height="860" alt="1931" src="https://github.com/user-attachments/assets/c61a77b5-92aa-4c1e-954e-a4192b42fcf8" />
