### PR TITLE
Refactor network fee presentation to NetworkFeeSheet

### DIFF
--- a/Features/Transactions/Sources/TransactionNavigationView.swift
+++ b/Features/Transactions/Sources/TransactionNavigationView.swift
@@ -40,10 +40,7 @@ public struct TransactionNavigationView: View {
             case .share:
                 ShareSheet(activityItems: [model.explorerURL.absoluteString])
             case .feeDetails:
-                NavigationStack {
-                    NetworkFeeScene(model: model.feeDetailsViewModel)
-                        .presentationDetents([.height(200)])
-                }
+                NetworkFeeSheet(model: model.feeDetailsViewModel)
             case .info(let infoType):
                 InfoSheetScene(type: infoType)
             }

--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -46,18 +46,7 @@ public struct ConfirmTransferScene: View {
             case .url(let url):
                 SFSafariView(url: url)
             case .networkFeeSelector:
-                NavigationStack {
-                    NetworkFeeScene(model: model.feeModel)
-                        .ifElse(
-                            model.feeModel.showFeeRates,
-                            ifContent: {
-                                $0.presentationDetentsForCurrentDeviceSize(expandable: true)
-                            },
-                            elseContent: {
-                                $0.presentationDetents([.height(200)])
-                            }
-                        )
-                }
+                NetworkFeeSheet(model: model.feeModel)
             case .fiatConnect(let assetAddress, let walletId):
                 NavigationStack {
                     FiatConnectNavigationView(

--- a/Packages/PrimitivesComponents/Sources/Scenes/NetworkFeeSheet.swift
+++ b/Packages/PrimitivesComponents/Sources/Scenes/NetworkFeeSheet.swift
@@ -1,0 +1,20 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Components
+import Primitives
+
+public struct NetworkFeeSheet: View {
+    private let model: NetworkFeeSceneViewModel
+
+    public init(model: NetworkFeeSceneViewModel) {
+        self.model = model
+    }
+
+    public var body: some View {
+        NavigationStack {
+            NetworkFeeScene(model: model)
+                .presentationDetentsForCurrentDeviceSize(expandable: true)
+        }
+    }
+}


### PR DESCRIPTION
Replaces inline NetworkFeeScene usage with a new NetworkFeeSheet component in TransactionNavigationView and ConfirmTransferScene. This change centralizes network fee sheet logic and presentation, improving code reuse and maintainability.