### PR TITLE
Add toast notifications for transfer execution

### DIFF
--- a/Features/Transfer/Sources/Protocols/TransferHandleable.swift
+++ b/Features/Transfer/Sources/Protocols/TransferHandleable.swift
@@ -1,0 +1,9 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+
+public protocol TransferHandleable: Sendable {
+    @MainActor
+    func handle(state: TransferState) async
+}

--- a/Features/Transfer/Sources/Services/ConfirmService.swift
+++ b/Features/Transfer/Sources/Services/ConfirmService.swift
@@ -67,6 +67,10 @@ public struct ConfirmService: Sendable {
         try await transferExecutor.execute(input: input)
     }
 
+    public func executeTransferAsync(input: TransferConfirmationInput) {
+        transferExecutor.executeAsync(input: input)
+    }
+
     public func getPasswordAuthentication() throws -> KeystoreAuthentication {
         try keystore.getPasswordAuthentication()
     }

--- a/Features/Transfer/Sources/Services/ConfirmServiceFactory.swift
+++ b/Features/Transfer/Sources/Services/ConfirmServiceFactory.swift
@@ -24,6 +24,7 @@ public struct ConfirmServiceFactory {
         priceService: PriceService,
         transactionService: TransactionService,
         addressNameService: AddressNameService,
+        transferHandler: any TransferHandleable,
         chain: Chain
     ) -> ConfirmService {
         let chainService = ChainServiceFactory(nodeProvider: nodeService).service(for: chain)
@@ -42,7 +43,8 @@ public struct ConfirmServiceFactory {
                 signer: TransactionSigner(keystore: keystore),
                 chainService: chainService,
                 walletsService: walletsService,
-                transactionService: transactionService
+                transactionService: transactionService,
+                handler: transferHandler
             ),
             keystore: keystore,
             chainService: chainService,

--- a/Features/Transfer/TestKit/TransferHandlerMock.swift
+++ b/Features/Transfer/TestKit/TransferHandlerMock.swift
@@ -1,0 +1,11 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+@testable import Transfer
+
+public struct TransferHandlerMock: TransferHandleable {
+    public init() {}
+
+    public func handle(state: TransferState) async {}
+}

--- a/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
@@ -317,6 +317,7 @@ private extension ConfirmTransferSceneViewModel {
                 priceService: .mock(),
                 transactionService: .mock(),
                 addressNameService: addressNameService,
+                transferHandler: TransferHandlerMock(),
                 chain: data.chain
             ),
             onComplete: {}

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionsScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionsScene.swift
@@ -72,10 +72,10 @@ public struct ConnectionsScene: View {
             isPresenting: $model.isPresentingConnectorBar,
             message: ToastMessage(
                 title: "\(Localized.WalletConnect.brandName)...",
-                image: SystemImage.network
-            ),
-            duration: .infinity,
-            tapToDismiss: false
+                image: SystemImage.network,
+                duration: .infinity,
+                tapToDismiss: false
+            )
         )
         .navigationTitle(model.title)
         .taskOnce { model.updateSessions() }

--- a/Gem.xcodeproj/project.pbxproj
+++ b/Gem.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		B66AFC6C2DDB260A0082C026 /* AppService in Frameworks */ = {isa = PBXBuildFile; productRef = B66AFC6B2DDB260A0082C026 /* AppService */; };
 		B66DEDB02D49F0EA00309D53 /* ImageGalleryService in Frameworks */ = {isa = PBXBuildFile; productRef = B66DEDAF2D49F0EA00309D53 /* ImageGalleryService */; };
 		B67ED5472DDB5DCC009F74E6 /* NotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B67ED5462DDB5DCC009F74E6 /* NotificationHandler.swift */; };
+		B68968092EA8F0CB00AC2AE2 /* TransferHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B68968082EA8F0CB00AC2AE2 /* TransferHandler.swift */; };
 		B68BD2CA2DE04B5B00687F09 /* Components in Frameworks */ = {isa = PBXBuildFile; productRef = B68BD2C92DE04B5B00687F09 /* Components */; };
 		B68BD2D82DE05F7500687F09 /* KeystoreTestKit in Frameworks */ = {isa = PBXBuildFile; productRef = B68BD2D72DE05F7500687F09 /* KeystoreTestKit */; };
 		B68BD2DA2DE05F9100687F09 /* PrimitivesTestKit in Frameworks */ = {isa = PBXBuildFile; productRef = B68BD2D92DE05F9100687F09 /* PrimitivesTestKit */; };
@@ -200,6 +201,7 @@
 		83E041592D0AFCB80031D4BC /* RootSceneViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootSceneViewModel.swift; sourceTree = "<group>"; };
 		83FE37B22D2715BF0048D54C /* WalletConnector */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = WalletConnector; sourceTree = "<group>"; };
 		B67ED5462DDB5DCC009F74E6 /* NotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHandler.swift; sourceTree = "<group>"; };
+		B68968082EA8F0CB00AC2AE2 /* TransferHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferHandler.swift; sourceTree = "<group>"; };
 		B6B86A0F2D702E7C00D31D65 /* SwapNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwapNavigationView.swift; sourceTree = "<group>"; };
 		B6EA21D42E27E21700F1C849 /* Support */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Support; sourceTree = "<group>"; };
 		C30952B0299C39D70004C0F9 /* Gem.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Gem.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -471,6 +473,7 @@
 		83A188492D10811E00E571F0 /* Types */ = {
 			isa = PBXGroup;
 			children = (
+				B68968082EA8F0CB00AC2AE2 /* TransferHandler.swift */,
 				C36679092A0B7E5800F1D74D /* Environment.swift */,
 				830FDA472C22EEC4003DA605 /* TabItem.swift */,
 				B67ED5462DDB5DCC009F74E6 /* NotificationHandler.swift */,
@@ -1074,6 +1077,7 @@
 				D8C4A3762C8CF956006FABE8 /* StakeNavigationView.swift in Sources */,
 				D852CB012C9CC315004121D3 /* PriceAlertsNavigationView.swift in Sources */,
 				833CDFD02D10622D00DAABEE /* ServicesFactory.swift in Sources */,
+				B68968092EA8F0CB00AC2AE2 /* TransferHandler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
@@ -28,6 +28,7 @@ struct SelectAssetSceneNavigationStack: View {
     @Environment(\.swapService) private var swapService
     @Environment(\.nameService) private var nameService
     @Environment(\.addressNameService) private var addressNameService
+    @Environment(\.transferHandler) private var transferHandler
 
     @State private var isPresentingFilteringView: Bool = false
 
@@ -84,6 +85,7 @@ struct SelectAssetSceneNavigationStack: View {
                             priceService: priceService,
                             transactionService: transactionService,
                             addressNameService: addressNameService,
+                            transferHandler: transferHandler,
                             chain: input.asset.chain
                         ),
                         model: viewModelFactory.recipientScene(

--- a/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
@@ -29,6 +29,7 @@ struct SelectedAssetNavigationStack: View  {
     @Environment(\.transactionService) private var transactionService
     @Environment(\.nameService) private var nameService
     @Environment(\.addressNameService) private var addressNameService
+    @Environment(\.transferHandler) private var transferHandler
 
     @State private var navigationPath = NavigationPath()
 
@@ -61,6 +62,7 @@ struct SelectedAssetNavigationStack: View  {
                             priceService: priceService,
                             transactionService: transactionService,
                             addressNameService: addressNameService,
+                            transferHandler: transferHandler,
                             chain: input.asset.chain
                         ),
                         model: viewModelFactory.recipientScene(

--- a/Gem/Services/AppResolver+Services.swift
+++ b/Gem/Services/AppResolver+Services.swift
@@ -59,6 +59,7 @@ extension AppResolver {
         let perpetualObserverService: PerpetualObserverService
         let nameService: NameService
         let addressNameService: AddressNameService
+        let transferHandler: TransferHandler
         let viewModelFactory: ViewModelFactory
 
         init(
@@ -93,6 +94,7 @@ extension AppResolver {
             perpetualObserverService: PerpetualObserverService,
             nameService: NameService,
             addressNameService: AddressNameService,
+            transferHandler: TransferHandler,
             viewModelFactory: ViewModelFactory
         ) {
             self.assetsService = assetsService
@@ -126,6 +128,7 @@ extension AppResolver {
             self.perpetualObserverService = perpetualObserverService
             self.nameService = nameService
             self.addressNameService = addressNameService
+            self.transferHandler = transferHandler
             self.viewModelFactory = viewModelFactory
         }
     }

--- a/Gem/Services/ServicesFactory.swift
+++ b/Gem/Services/ServicesFactory.swift
@@ -181,7 +181,9 @@ struct ServicesFactory {
         let nameService = NameService()
         let scanService = ScanService(securePreferences: .standard)
         let addressNameService = AddressNameService(addressStore: storeManager.addressStore)
-        
+
+        let transferHandler = TransferHandler()
+
         let viewModelFactory = ViewModelFactory(
             keystore: storages.keystore,
             nodeService: nodeService,
@@ -195,7 +197,8 @@ struct ServicesFactory {
             priceService: priceService,
             transactionService: transactionService,
             chainServiceFactory: chainServiceFactory,
-            addressNameService: addressNameService
+            addressNameService: addressNameService,
+            transferHandler: transferHandler
         )
 
         return AppResolver.Services(
@@ -230,6 +233,7 @@ struct ServicesFactory {
             perpetualObserverService: perpetualObserverService,
             nameService: nameService,
             addressNameService: addressNameService,
+            transferHandler: transferHandler,
             viewModelFactory: viewModelFactory
         )
     }

--- a/Gem/Services/ViewModelFactory.swift
+++ b/Gem/Services/ViewModelFactory.swift
@@ -38,7 +38,8 @@ public struct ViewModelFactory: Sendable {
     let transactionService: TransactionService
     let chainServiceFactory: ChainServiceFactory
     let addressNameService: AddressNameService
-    
+    let transferHandler: TransferHandler
+
     public init(
         keystore: any Keystore,
         nodeService: NodeService,
@@ -52,7 +53,8 @@ public struct ViewModelFactory: Sendable {
         priceService: PriceService,
         transactionService: TransactionService,
         chainServiceFactory: ChainServiceFactory,
-        addressNameService: AddressNameService
+        addressNameService: AddressNameService,
+        transferHandler: TransferHandler
     ) {
         self.keystore = keystore
         self.nodeService = nodeService
@@ -67,6 +69,7 @@ public struct ViewModelFactory: Sendable {
         self.transactionService = transactionService
         self.chainServiceFactory = chainServiceFactory
         self.addressNameService = addressNameService
+        self.transferHandler = transferHandler
     }
     
     @MainActor
@@ -85,9 +88,10 @@ public struct ViewModelFactory: Sendable {
             priceService: priceService,
             transactionService: transactionService,
             addressNameService: addressNameService,
+            transferHandler: transferHandler,
             chain: data.chain
         )
-        
+
         return ConfirmTransferSceneViewModel(
             wallet: wallet,
             data: data,

--- a/Gem/Types/Environment.swift
+++ b/Gem/Types/Environment.swift
@@ -61,5 +61,6 @@ extension EnvironmentValues {
     @Entry var transactionService: TransactionService = AppResolver.main.services.transactionService
     @Entry var nameService: NameService = AppResolver.main.services.nameService
     @Entry var addressNameService: AddressNameService = AppResolver.main.services.addressNameService
+    @Entry var transferHandler: TransferHandler = AppResolver.main.services.transferHandler
     @Entry var viewModelFactory: ViewModelFactory = AppResolver.main.services.viewModelFactory
 }

--- a/Gem/Types/TransferHandler.swift
+++ b/Gem/Types/TransferHandler.swift
@@ -1,0 +1,62 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import Observation
+import Components
+import SwiftUI
+import Style
+import Localization
+import Transfer
+
+@Observable
+public final class TransferHandler: TransferHandleable {
+    @MainActor
+    public var toastMessage: ToastMessage?
+
+    public init() {}
+
+    @MainActor
+    public func handle(state: TransferState) async {
+        switch state {
+        case .executing(let type):
+            toastMessage = ToastMessage(
+                title: executingTitle(for: type),
+                image: SystemImage.paperplane,
+                duration: .infinity
+            )
+        case .completed(let type):
+            toastMessage = ToastMessage(
+                title: completedTitle(for: type),
+                image: SystemImage.checkmarkCircle
+            )
+        case .failed:
+            toastMessage = ToastMessage(
+                title: Localized.Errors.errorOccured,
+                image: SystemImage.xmarkCircle
+            )
+        }
+    }
+
+    private func executingTitle(for type: TransferDataType) -> String {
+        switch type {
+        case .perpetual(_, let perpetualType):
+            switch perpetualType {
+            case .open: "Opening position..."
+            case .close: "Closing position..."
+            }
+        default: "Transaction executing..."
+        }
+    }
+
+    private func completedTitle(for type: TransferDataType) -> String {
+        switch type {
+        case .perpetual(_, let perpetualType):
+            switch perpetualType {
+            case .open: "Position opened successfully"
+            case .close: "Position closed successfully"
+            }
+        default: "Sent successfully"
+        }
+    }
+}

--- a/Gem/Views/MainTabView.swift
+++ b/Gem/Views/MainTabView.swift
@@ -13,6 +13,8 @@ import WalletTab
 import Transactions
 import Swap
 import Assets
+import Transfer
+import Components
 
 struct MainTabView: View {
     @Environment(\.scenePhase) private var scenePhase
@@ -28,6 +30,7 @@ struct MainTabView: View {
     @Environment(\.walletService) private var walletService
     @Environment(\.assetsService) private var assetsService
     @Environment(\.perpetualObserverService) private var perpetualObserverService
+    @Environment(\.transferHandler) private var transferHandler
 
     private let model: MainTabViewModel
 
@@ -43,6 +46,7 @@ struct MainTabView: View {
 
     @State private var isPresentingSelectedAssetInput: SelectedAssetInput?
     @State private var isPresentingSupport = false
+    @State private var isPresentingToastMessage: ToastMessage?
 
     init(model: MainTabViewModel) {
         self.model = model
@@ -127,6 +131,8 @@ struct MainTabView: View {
             initial: true,
             onReceiveNotifications
         )
+        .onChange(of: transferHandler.toastMessage, onReceiveToast)
+        .toast(message: $isPresentingToastMessage)
         .taskOnce {
             Task {
                 await connectObservers()
@@ -290,6 +296,10 @@ extension MainTabView {
                 isPresentingSelectedAssetInput = nil
             }
         }
+    }
+    
+    private func onReceiveToast(_ old: ToastMessage?, new: ToastMessage?) {
+        isPresentingToastMessage = new
     }
 }
 

--- a/Packages/Components/Sources/Types/ToastMessage.swift
+++ b/Packages/Components/Sources/Types/ToastMessage.swift
@@ -3,18 +3,26 @@
 import Foundation
 import SwiftUI
 
-public struct ToastMessage: Identifiable {
+public struct ToastMessage: Identifiable, Equatable {
+    public static let toastDuration: Double = 2
+
     public var id: String { title + image }
-    
+
     public let title: String
     public let image: String
-    
+    public let duration: Double
+    public let tapToDismiss: Bool
+
     public init(
         title: String,
-        image: String
+        image: String,
+        duration: Double = Self.toastDuration,
+        tapToDismiss: Bool = true
     ) {
         self.title = title
         self.image = image
+        self.duration = duration
+        self.tapToDismiss = tapToDismiss
     }
 }
 

--- a/Packages/Components/Sources/ViewModifiers/ToastModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/ToastModifier.swift
@@ -6,26 +6,19 @@ import Style
 
 struct ToastModifier: ViewModifier {
     private var isPresenting: Binding<Bool>
-
     private let message: ToastMessage
-    private let duration: Double
-    private let tapToDismiss: Bool
 
     init(
         isPresenting: Binding<Bool>,
-        message: ToastMessage,
-        duration: Double,
-        tapToDismiss: Bool
+        message: ToastMessage
     ) {
         self.isPresenting = isPresenting
         self.message = message
-        self.duration = duration
-        self.tapToDismiss = tapToDismiss
     }
 
     func body(content: Content) -> some View {
         content
-            .toast(isPresenting: isPresenting, duration: duration, tapToDismiss: tapToDismiss) {
+            .toast(isPresenting: isPresenting, duration: message.duration, tapToDismiss: message.tapToDismiss) {
                 AlertToast(
                     displayMode: .banner(.pop),
                     type: .systemImage(message.image, Colors.black),
@@ -37,13 +30,9 @@ struct ToastModifier: ViewModifier {
 
 private struct OptionalMessageToastModifier: ViewModifier {
     @Binding var message: ToastMessage?
-    private let duration: Double
-    private let tapToDismiss: Bool
-    
-    init(message: Binding<ToastMessage?>, duration: Double, tapToDismiss: Bool) {
+
+    init(message: Binding<ToastMessage?>) {
         _message = message
-        self.duration = duration
-        self.tapToDismiss = tapToDismiss
     }
 
     func body(content: Content) -> some View {
@@ -55,9 +44,7 @@ private struct OptionalMessageToastModifier: ViewModifier {
                         if showing == false { message = nil }
                     }
                 ),
-                message: message ?? .empty(),
-                duration: duration,
-                tapToDismiss: tapToDismiss
+                message: message ?? .empty()
             )
         )
     }
@@ -66,31 +53,21 @@ private struct OptionalMessageToastModifier: ViewModifier {
 // MARK: - View Modifier
 
 public extension View {
-    static var toastDuration: Double { 2 }
-
     func toast(
         isPresenting: Binding<Bool>,
-        message: ToastMessage,
-        duration: Double = Self.toastDuration,
-        tapToDismiss: Bool = true
+        message: ToastMessage
     ) -> some View {
         modifier(ToastModifier(
             isPresenting: isPresenting,
-            message: message,
-            duration: duration,
-            tapToDismiss: tapToDismiss
+            message: message
         ))
     }
 
     func toast(
-        message: Binding<ToastMessage?>,
-        duration: Double = Self.toastDuration,
-        tapToDismiss: Bool = true
+        message: Binding<ToastMessage?>
     ) -> some View {
         modifier(OptionalMessageToastModifier(
-            message: message,
-            duration: duration,
-            tapToDismiss: tapToDismiss
+            message: message
         ))
     }
 }

--- a/Packages/Primitives/Sources/TransferState.swift
+++ b/Packages/Primitives/Sources/TransferState.swift
@@ -1,0 +1,9 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public enum TransferState: Sendable, Equatable {
+    case executing(type: TransferDataType)
+    case completed(type: TransferDataType)
+    case failed
+}


### PR DESCRIPTION
Closes #1268

## Summary
- Implement TransferHandler to show toast messages during transaction lifecycle
- Add TransferState enum to track executing, completed, and failed states
- Update ToastMessage to support custom duration and tap-to-dismiss settings
- Use async execution for perpetual transfers with toast feedback
- Close confirm screen automatically for perpetual transfers

## TODO
- [ ] Localization for toast messages


https://github.com/user-attachments/assets/73d895bb-ec73-4088-a188-92bb62f8c03a


https://github.com/user-attachments/assets/7d31b83d-20a7-4c42-84e6-ca5795a9bcfc

