### PR TITLE
Fix dark background in searchable list view

### DIFF
--- a/Packages/Components/Sources/ListViews/SearchableListView.swift
+++ b/Packages/Components/Sources/ListViews/SearchableListView.swift
@@ -24,23 +24,22 @@ public struct SearchableListView<Item: Identifiable & Hashable, Content: View, E
     }
 
     public var body: some View {
-        VStack {
-            ListView(
-                items: filteredItems,
-                content: content
-            )
-            .searchable(
-                text: $searchQuery,
-                placement: .navigationBarDrawer(displayMode: .always)
-            )
-        }
+        ListView(
+            items: filteredItems,
+            content: content
+        )
+        .searchable(
+            text: $searchQuery,
+            placement: .navigationBarDrawer(displayMode: .always)
+        )
         .autocorrectionDisabled(true)
         .scrollDismissesKeyboard(.interactively)
-        .scrollContentBackground(.hidden)
-        .background { Colors.insetGroupedListStyle.ignoresSafeArea() }
         .overlay {
             if filteredItems.isEmpty {
-                emptyContent()
+                ContentUnavailableView {
+                    emptyContent()
+                }
+                .background(UIColor.systemGroupedBackground.color)
             }
         }
     }


### PR DESCRIPTION
Remove unnecessary VStack wrapper and background customization that caused dark background issues in transaction filters. Wrap empty content in ContentUnavailableView with proper system background color.

Fixes #1205

## Screenshots
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 21 01 56" src="https://github.com/user-attachments/assets/0a70b541-34b7-4d13-b3fc-238ee31c0dd9" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 21 02 04" src="https://github.com/user-attachments/assets/6abb3de8-04f8-4685-9b7a-f23467949cba" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 21 02 16" src="https://github.com/user-attachments/assets/73511c34-ad04-4020-b4ff-a3f5b29a95aa" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 21 02 31" src="https://github.com/user-attachments/assets/47c4a23c-b7c7-470d-9aaf-93bc340de535" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 21 03 20" src="https://github.com/user-attachments/assets/66339e3e-6008-4e75-bc1b-4bbabe6c5c77" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 21 03 25" src="https://github.com/user-attachments/assets/fc51b928-7fb6-4f3a-97e1-df197164dfa7" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 21 03 30" src="https://github.com/user-attachments/assets/735bc179-b43c-41e9-a322-f97763b7f0c7" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-22 at 21 03 36" src="https://github.com/user-attachments/assets/c281dc91-a147-4a95-87c2-1828dd5908d3" />
