### PR TITLE
Add transaction type filter to asset scene

### DIFF
--- a/Features/Assets/Package.swift
+++ b/Features/Assets/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
         .package(name: "Blockchain", path: "../../Packages/Blockchain"),
         .package(name: "InfoSheet", path: "../InfoSheet"),
         .package(name: "QRScanner", path: "../QRScanner"),
+        .package(name: "Transactions", path: "../Transactions"),
         .package(name: "ChainServices", path: "../../Packages/ChainServices"),
         .package(name: "FeatureServices", path: "../../Packages/FeatureServices")
     ],
@@ -43,6 +44,7 @@ let package = Package(
                 "Blockchain",
                 "InfoSheet",
                 "QRScanner",
+                "Transactions",
                 .product(name: "PriceAlertService", package: "FeatureServices"),
                 .product(name: "ExplorerService", package: "ChainServices"),
                 .product(name: "AssetsService", package: "FeatureServices"),

--- a/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -147,7 +147,9 @@ public struct AssetScene: View {
                 TransactionsList(
                     explorerService: model.explorerService,
                     model.transactions,
-                    currency: model.assetDataModel.currencyCode
+                    currency: model.assetDataModel.currencyCode,
+                    filterButtonAction: model.onSelectFilterButton,
+                    isFilterActive: model.filterModel.isAnyFilterSpecified
                 )
                 .listRowInsets(.assetListRowInsets)
             } else {

--- a/Features/Assets/Sources/Scenes/AssetTransactionsFilterScene.swift
+++ b/Features/Assets/Sources/Scenes/AssetTransactionsFilterScene.swift
@@ -1,0 +1,41 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Style
+import Components
+import Primitives
+import PrimitivesComponents
+import Localization
+import Transactions
+
+public struct AssetTransactionsFilterScene: View {
+    @Environment(\.dismiss) private var dismiss
+    @Binding private var model: TransactionsFilterViewModel
+
+    public init(model: Binding<TransactionsFilterViewModel>) {
+        _model = model
+    }
+
+    public var body: some View {
+        SelectableSheet(
+            model: model.typesModel,
+            onFinishSelection: onFinishSelection(value:),
+            listContent: {
+                ListItemView(title: TransactionFilterTypeViewModel(type: $0).title)
+            }
+        )
+        .presentationDetentsForCurrentDeviceSize(expandable: true)
+        .presentationDragIndicator(.visible)
+    }
+}
+
+// MARK: - Actions
+
+extension AssetTransactionsFilterScene {
+    private func onFinishSelection(value: SelectionResult<TransactionFilterType>) {
+        model.transactionTypesFilter.selectedTypes = value.items
+        if value.isConfirmed {
+            dismiss()
+        }
+    }
+}

--- a/Features/Assets/Sources/Types/AssetSceneInput.swift
+++ b/Features/Assets/Sources/Types/AssetSceneInput.swift
@@ -11,7 +11,6 @@ public struct AssetSceneInput: Sendable {
     public let asset: Asset
 
     public var assetRequest: AssetRequest
-    public var transactionsRequest: TransactionsRequest
     public var bannersRequest: BannersRequest
 
     public init(wallet: Wallet, asset: Asset) {
@@ -21,12 +20,6 @@ public struct AssetSceneInput: Sendable {
         self.assetRequest = AssetRequest(
             walletId: wallet.id,
             assetId: asset.id
-        )
-
-        self.transactionsRequest = TransactionsRequest(
-            walletId: wallet.id,
-            type: .asset(assetId: asset.id),
-            limit: Self.transactionsLimit
         )
 
         self.bannersRequest = BannersRequest(

--- a/Features/Transactions/Sources/ViewModels/TransactionFilterTypeViewModel.swift
+++ b/Features/Transactions/Sources/ViewModels/TransactionFilterTypeViewModel.swift
@@ -4,14 +4,14 @@ import Foundation
 import Primitives
 import Localization
 
-struct TransactionFilterTypeViewModel {
+public struct TransactionFilterTypeViewModel {
     private let type: TransactionFilterType
 
-    init(type: TransactionFilterType) {
+    public init(type: TransactionFilterType) {
         self.type = type
     }
 
-    var title: String {
+    public var title: String {
         switch type {
         case .transfers: Localized.Transfer.title
         case .smartContract: Localized.Transfer.SmartContract.title

--- a/Gem/Navigation/Assets/AssetNavigationView.swift
+++ b/Gem/Navigation/Assets/AssetNavigationView.swift
@@ -24,7 +24,7 @@ struct AssetNavigationView: View {
         )
         .observeQuery(request: $model.input.assetRequest, value: $model.assetData)
         .observeQuery(request: $model.input.bannersRequest, value: $model.banners)
-        .observeQuery(request: $model.input.transactionsRequest, value: $model.transactions)
+        .observeQuery(request: $model.filterModel.request, value: $model.transactions)
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button(action: model.onTogglePriceAlert) {
@@ -54,6 +54,9 @@ struct AssetNavigationView: View {
             case let .url(url):
                 SFSafariView(url: url)
             }
+        }
+        .sheet(isPresented: $model.isPresentingFilterView) {
+            AssetTransactionsFilterScene(model: $model.filterModel)
         }
     }
 }

--- a/Packages/PrimitivesComponents/Sources/Components/TransactionsList.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/TransactionsList.swift
@@ -2,6 +2,8 @@
 
 import SwiftUI
 import Primitives
+import Components
+import Style
 
 public struct TransactionsList: View {
 
@@ -9,6 +11,8 @@ public struct TransactionsList: View {
     let showSections: Bool
     let explorerService: any ExplorerLinkFetchable
     let currency: String
+    let filterButtonAction: (() -> Void)?
+    let isFilterActive: Bool
 
     var groupedByDate: [Date: [Primitives.TransactionExtended]] {
         Dictionary(grouping: transactions, by: {
@@ -24,19 +28,23 @@ public struct TransactionsList: View {
         explorerService: any ExplorerLinkFetchable,
         _ transactions: [Primitives.TransactionExtended],
         currency: String,
-        showSections: Bool = true
+        showSections: Bool = true,
+        filterButtonAction: (() -> Void)? = nil,
+        isFilterActive: Bool = false
     ) {
         self.explorerService = explorerService
         self.transactions = transactions
         self.currency =  currency
         self.showSections = showSections
+        self.filterButtonAction = filterButtonAction
+        self.isFilterActive = isFilterActive
     }
 
     public var body: some View {
         if showSections {
-            ForEach(headers, id: \.self) { header in
+            ForEach(headers.enumerated().map { $0 }, id: \.element) { index, header in
                 Section(
-                    header: Text(TransactionDateFormatter(date: header).section)
+                    header: sectionHeader(for: header, isFirst: index == 0)
                 ) {
                     TransactionsListView(
                         explorerService: explorerService,
@@ -51,6 +59,20 @@ public struct TransactionsList: View {
                 transactions: transactions,
                 currency: currency
             )
+        }
+    }
+
+    @ViewBuilder
+    private func sectionHeader(for date: Date, isFirst: Bool) -> some View {
+        if isFirst, let action = filterButtonAction {
+            HStack {
+                Text(TransactionDateFormatter(date: date).section)
+                Spacer()
+                FilterButton(isActive: isFilterActive, action: action)
+                    .foregroundStyle(Colors.gray)
+            }
+        } else {
+            Text(TransactionDateFormatter(date: date).section)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add filter button to transactions list in asset scene
- Create AssetTransactionsFilterScene for filtering by transaction types
- Update TransactionsList to support optional filter button
- Update AssetSceneViewModel to manage filter state
- Show empty state when filters are active but no results found

Fixes #1292