### PR TITLE
Fix button title disappearing during loading state transition

### DIFF
--- a/Features/Onboarding/Sources/ViewsModels/ImportWalletViewModel.swift
+++ b/Features/Onboarding/Sources/ViewsModels/ImportWalletViewModel.swift
@@ -110,9 +110,8 @@ extension ImportWalletViewModel {
         buttonState = .loading(showProgress: true)
 
         Task {
-            try await Task.sleep(for: .milliseconds(50))
             do {
-                try importWallet()
+                try await importWallet()
             } catch {
                 isPresentingAlertMessage = AlertMessage(
                     title: alertTitle,
@@ -150,7 +149,7 @@ extension ImportWalletViewModel {
 // MARK: - Private
 
 extension ImportWalletViewModel {
-    private func importWallet() throws {
+    private func importWallet() async throws {
         let recipient: RecipientImport = {
             if let result = nameResolveState.result {
                 return RecipientImport(name: result.name, address: result.address)
@@ -165,12 +164,12 @@ extension ImportWalletViewModel {
             }
             switch type {
             case .multicoin:
-                try importWallet(
+                try await importWallet(
                     name: recipient.name,
                     keystoreType: .phrase(words: words, chains: AssetConfiguration.allChains)
                 )
             case .chain(let chain):
-                try importWallet(
+                try await importWallet(
                     name: recipient.name,
                     keystoreType: .single(words: words, chain: chain)
                 )
@@ -179,7 +178,7 @@ extension ImportWalletViewModel {
             guard try validateForm(type: importType, address: recipient.address, words: [input]) else {
                 return
             }
-            try importWallet(name: recipient.name, keystoreType: .privateKey(text: input, chain: chain!))
+            try await importWallet(name: recipient.name, keystoreType: .privateKey(text: input, chain: chain!))
         case .address:
             guard try validateForm(type: importType, address: recipient.address, words: []) else {
                 return
@@ -187,12 +186,12 @@ extension ImportWalletViewModel {
             let chain = chain!
             let address = chain.checksumAddress(recipient.address)
 
-            try importWallet(name: recipient.name, keystoreType: .address(chain: chain, address: address))
+            try await importWallet(name: recipient.name, keystoreType: .address(chain: chain, address: address))
         }
     }
 
-    private func importWallet(name: String, keystoreType: KeystoreImportType) throws {
-        try walletService.importWallet(name: name, type: keystoreType)
+    private func importWallet(name: String, keystoreType: KeystoreImportType) async throws {
+        try await walletService.importWallet(name: name, type: keystoreType)
         onFinish?()
     }
 

--- a/Features/Onboarding/Sources/ViewsModels/VerifyPhraseViewModel.swift
+++ b/Features/Onboarding/Sources/ViewsModels/VerifyPhraseViewModel.swift
@@ -81,9 +81,7 @@ final class VerifyPhraseViewModel {
     
     func importWallet() async throws  {
         let name = WalletNameGenerator(type: .multicoin, walletService: walletService).name
-        let wallet = try await Task.detached {
-            try self.walletService.importWallet(name: name, type: .phrase(words: self.words, chains: AssetConfiguration.allChains))
-        }.value
+        let wallet = try await walletService.importWallet(name: name, type: .phrase(words: self.words, chains: AssetConfiguration.allChains))
 
         WalletPreferences(walletId: wallet.id).completeInitialSynchronization()
         walletService.acceptTerms()

--- a/Features/Onboarding/Sources/ViewsModels/VerifyPhraseViewModel.swift
+++ b/Features/Onboarding/Sources/ViewsModels/VerifyPhraseViewModel.swift
@@ -94,7 +94,9 @@ final class VerifyPhraseViewModel {
 
 extension VerifyPhraseViewModel {
     func onImportWallet() {
-        buttonState = .loading(showProgress: true)
+        Task { @MainActor in
+            buttonState = .loading(showProgress: true)
+        }
 
         Task {
             try await Task.sleep(for: .milliseconds(50))

--- a/Packages/FeatureServices/WalletService/WalletService.swift
+++ b/Packages/FeatureServices/WalletService/WalletService.swift
@@ -65,7 +65,7 @@ public struct WalletService: Sendable {
     }
 
     @discardableResult
-    public func importWallet(name: String, type: KeystoreImportType) throws -> Wallet {
+    public func importWallet(name: String, type: KeystoreImportType) async throws -> Wallet {
         let newWallet = try keystore.importWallet(
             name: name,
             type: type,


### PR DESCRIPTION
Fixes #1285

## Summary
- Made `importWallet()` async and moved wallet import operation to background thread using `Task.detached`
- Wrapped wallet import in `Task` to create a suspension point, allowing SwiftUI to render the loading state before the import operation blocks execution
- Removed artificial delay and unnecessary `MainActor.run` wrappers since the ViewModel is already `@MainActor` isolated

https://github.com/user-attachments/assets/97b04089-8fec-4b6f-bd2a-1d07bbd7425a