### PR TITLE
Fix transaction update loop

### DIFF
--- a/Features/Transactions/Sources/TransactionNavigationView.swift
+++ b/Features/Transactions/Sources/TransactionNavigationView.swift
@@ -22,12 +22,7 @@ public struct TransactionNavigationView: View {
         TransactionScene(
             model: model
         )
-        .onChangeObserveQuery(
-            request: $model.request,
-            value: $model.transactionExtended,
-            initial: true,
-            action: model.onChangeTransaction
-        )
+        .observeQuery(request: $model.request, value: $model.transactionExtended)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(action: model.onSelectShare) {

--- a/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
+++ b/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
@@ -70,12 +70,6 @@ extension TransactionSceneViewModel: ListSectionProvideable {
 // MARK: - Actions
 
 extension TransactionSceneViewModel {
-    func onChangeTransaction(_ oldValue: TransactionExtended, _ newValue: TransactionExtended) {
-        if oldValue != newValue {
-            transactionExtended = newValue
-        }
-    }
-
     func onSelectTransactionHeader() {
         if let headerLink = headerViewModel.headerLink {
             UIApplication.shared.open(headerLink)

--- a/Gem/Views/MainTabView.swift
+++ b/Gem/Views/MainTabView.swift
@@ -185,22 +185,23 @@ extension MainTabView {
         do {
             switch notification {
             case let .transaction(walletIndex, assetId, transaction):
-                if walletIndex != model.wallet.index.asInt {
-                    walletService.setCurrent(for: walletIndex)
+                let walletId: WalletId
+                if walletIndex != model.wallet.index.asInt, let currentWalletId = walletService.setCurrent(for: walletIndex) {
+                    walletId = currentWalletId
+                } else {
+                    walletId = model.walletId
                 }
 
                 let asset = try await assetsService.getOrFetchAsset(for: assetId)
                 var path = NavigationPath()
                 path.append(Scenes.Asset(asset: asset))
 
-                if let walletId = walletService.currentWalletId {
-                    try transactionsService.addTransaction(walletId: walletId, transaction: transaction)
-                    let transaction = try transactionsService.getTransaction(
-                        walletId: walletId,
-                        transactionId: transaction.id.identifier
-                    )
-                    path.append(transaction)
-                }
+                try transactionsService.addTransaction(walletId: walletId, transaction: transaction)
+                let transaction = try transactionsService.getTransaction(
+                    walletId: walletId,
+                    transactionId: transaction.id.identifier
+                )
+                path.append(transaction)
 
                 navigationState.wallet = path
             case .priceAlert(let assetId):

--- a/Gem/Views/MainTabView.swift
+++ b/Gem/Views/MainTabView.swift
@@ -190,15 +190,18 @@ extension MainTabView {
                 }
 
                 let asset = try await assetsService.getOrFetchAsset(for: assetId)
-                try transactionsService.addTransaction(walletId: model.walletId, transaction: transaction)
-                let transaction = try transactionsService.getTransaction(
-                    walletId: model.walletId,
-                    transactionId: transaction.id.identifier
-                )
-                
                 var path = NavigationPath()
                 path.append(Scenes.Asset(asset: asset))
-                path.append(transaction)
+
+                if let walletId = walletService.currentWalletId {
+                    try transactionsService.addTransaction(walletId: walletId, transaction: transaction)
+                    let transaction = try transactionsService.getTransaction(
+                        walletId: walletId,
+                        transactionId: transaction.id.identifier
+                    )
+                    path.append(transaction)
+                }
+
                 navigationState.wallet = path
             case .priceAlert(let assetId):
                 let asset = try await assetsService.getOrFetchAsset(for: assetId)

--- a/Gem/Views/MainTabView.swift
+++ b/Gem/Views/MainTabView.swift
@@ -185,11 +185,8 @@ extension MainTabView {
         do {
             switch notification {
             case let .transaction(walletIndex, assetId, transaction):
-                let walletId: WalletId
-                if walletIndex != model.wallet.index.asInt, let currentWalletId = walletService.setCurrent(for: walletIndex) {
-                    walletId = currentWalletId
-                } else {
-                    walletId = model.walletId
+                guard let walletId = walletService.setCurrent(for: walletIndex) else {
+                    return
                 }
 
                 let asset = try await assetsService.getOrFetchAsset(for: assetId)

--- a/Packages/FeatureServices/Package.swift
+++ b/Packages/FeatureServices/Package.swift
@@ -341,7 +341,7 @@ let package = Package(
                 "Preferences"
             ],
             path: "WalletSessionService",
-            exclude: ["TestKit"]
+            exclude: ["TestKit", "Tests"]
         ),
         .target(
             name: "WalletSessionServiceTestKit",
@@ -477,6 +477,17 @@ let package = Package(
                 "Primitives"
             ],
             path: "BannerService/Tests"
+        ),
+        .testTarget(
+            name: "WalletSessionServiceTests",
+            dependencies: [
+                "WalletSessionService",
+                "WalletSessionServiceTestKit",
+                .product(name: "StoreTestKit", package: "Store"),
+                .product(name: "PreferencesTestKit", package: "Preferences"),
+                .product(name: "PrimitivesTestKit", package: "Primitives")
+            ],
+            path: "WalletSessionService/Tests"
         ),
     ]
 )

--- a/Packages/FeatureServices/WalletService/WalletService.swift
+++ b/Packages/FeatureServices/WalletService/WalletService.swift
@@ -48,7 +48,7 @@ public struct WalletService: Sendable {
         try walletStore.nextWalletIndex()
     }
 
-    public func setCurrent(for index: Int) {
+    public func setCurrent(for index: Int) -> WalletId? {
         walletSessionService.setCurrent(index: index)
     }
 

--- a/Packages/FeatureServices/WalletSessionService/Protocols/WalletSessionManageable.swift
+++ b/Packages/FeatureServices/WalletSessionService/Protocols/WalletSessionManageable.swift
@@ -15,7 +15,7 @@ public protocol WalletSessionManageable: WalletSessionManageableThrowing {
     var currentWallet: Wallet? { get }
     var currentWalletId: WalletId? { get }
 
-    func setCurrent(index: Int)
+    func setCurrent(index: Int) -> WalletId?
     func setCurrent(walletId: WalletId?)
 }
 

--- a/Packages/FeatureServices/WalletSessionService/TestKit/WalletSessionService+TestKit.swift
+++ b/Packages/FeatureServices/WalletSessionService/TestKit/WalletSessionService+TestKit.swift
@@ -4,8 +4,10 @@ import Foundation
 import StoreTestKit
 import WalletSessionService
 import PreferencesTestKit
+import PrimitivesTestKit
 import Store
 import Preferences
+import Primitives
 
 public extension WalletSessionService {
     static func mock(
@@ -15,6 +17,16 @@ public extension WalletSessionService {
         WalletSessionService(
             walletStore: store,
             preferences: preferences
+        )
+    }
+
+    static func mock(wallet: Wallet) throws -> WalletSessionService {
+        let db = DB.mock()
+        let store = WalletStore.mock(db: db)
+        try store.addWallet(wallet)
+        return WalletSessionService(
+            walletStore: store,
+            preferences: .mock()
         )
     }
 }

--- a/Packages/FeatureServices/WalletSessionService/Tests/WalletSessionServiceTests.swift
+++ b/Packages/FeatureServices/WalletSessionService/Tests/WalletSessionServiceTests.swift
@@ -1,0 +1,27 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import WalletSessionServiceTestKit
+import PrimitivesTestKit
+import Primitives
+
+@testable import WalletSessionService
+
+struct WalletSessionServiceTests {
+    @Test
+    func setCurrentReturnsWalletId() throws {
+        let wallet = Wallet.mock(index: 1)
+        let service = try WalletSessionService.mock(wallet: wallet)
+
+        #expect(service.setCurrent(index: 1) == wallet.walletId)
+        #expect(service.currentWalletId == wallet.walletId)
+    }
+
+    @Test
+    func setCurrentReturnsNil() throws {
+        let service = try WalletSessionService.mock(wallet: .mock(index: 1))
+
+        #expect(service.setCurrent(index: 999) == .none)
+        #expect(service.currentWalletId == .none)
+    }
+}

--- a/Packages/FeatureServices/WalletSessionService/WalletSessionService.swift
+++ b/Packages/FeatureServices/WalletSessionService/WalletSessionService.swift
@@ -27,10 +27,12 @@ public struct WalletSessionService: WalletSessionManageable {
         return WalletId(id: id)
     }
 
-    public func setCurrent(index: Int) {
-        if let wallet = wallets.first(where: {$0.index == index }) {
+    public func setCurrent(index: Int) -> WalletId? {
+        if let wallet = wallets.first(where: { $0.index == index }) {
             preferences.currentWalletId = wallet.id
+            return wallet.walletId
         }
+        return nil
     }
 
     public func setCurrent(walletId: WalletId?) {

--- a/Packages/FeatureServices/WalletSessionService/WalletSessionService.swift
+++ b/Packages/FeatureServices/WalletSessionService/WalletSessionService.swift
@@ -28,11 +28,15 @@ public struct WalletSessionService: WalletSessionManageable {
     }
 
     public func setCurrent(index: Int) -> WalletId? {
-        if let wallet = wallets.first(where: { $0.index == index }) {
-            preferences.currentWalletId = wallet.id
-            return wallet.walletId
+        guard let wallet = wallets.first(where: { $0.index == index }) else {
+            return nil
         }
-        return nil
+        if let currentWallet, currentWallet == wallet {
+            return currentWallet.walletId
+        }
+        preferences.currentWalletId = wallet.id
+        
+        return wallet.walletId
     }
 
     public func setCurrent(walletId: WalletId?) {


### PR DESCRIPTION
## Summary

- Fix transaction detail screen update loop causing "tried to update multiple times per frame" warning
- Remove redundant onChangeTransaction callback that was duplicating updates already handled by observeQuery