### PR TITLE
Update ShowSecretDataScene list styling and padding

### DIFF
--- a/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
@@ -17,6 +17,7 @@ struct ShowSecretDataScene: View {
             if let calloutViewStyle = model.calloutViewStyle {
                 CalloutView(style: calloutViewStyle)
                     .cleanListRow()
+                    .padding(.horizontal, .medium)
             }
             
             Section {
@@ -44,6 +45,7 @@ struct ShowSecretDataScene: View {
                 .padding(.bottom, .scene.bottom)
             }
         }
+        .listStyle(.plain)
         .contentMargins([.top], .extraSmall, for: .scrollContent)
         .listSectionSpacing(.custom(.medium))
         .toolbarInfoButton(url: model.docsUrl)


### PR DESCRIPTION
Added horizontal padding to CalloutView and set the list style to plain for improved UI consistency in ShowSecretDataScene.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-10-28 at 22 45 18" src="https://github.com/user-attachments/assets/7c85568d-d6dc-43ce-8e75-cd7aa48e8c4c" />
