### PR TITLE
Add selectable flag to network fee item model

### DIFF
--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -121,11 +121,15 @@ extension ConfirmTransferScene {
                 with: ListItemView(model: model.listItemModel),
                 action: { self.model.onSelectPerpetualDetails(model) }
             )
-        case let .networkFee(model):
-            NavigationCustomLink(
-                with: ListItemView(model: model),
-                action: self.model.onSelectFeePicker
-            )
+        case let .networkFee(model, selectable):
+            if selectable {
+                NavigationCustomLink(
+                    with: ListItemView(model: model),
+                    action: self.model.onSelectFeePicker
+                )
+            } else {
+                ListItemView(model: model)
+            }
         case let .error(title, error, onInfoAction):
             ListItemErrorView(
                 errorTitle: title,

--- a/Features/Transfer/Sources/Types/ConfirmTransferSection.swift
+++ b/Features/Transfer/Sources/Types/ConfirmTransferSection.swift
@@ -38,7 +38,7 @@ public enum ConfirmTransferItemModel {
     case network(ListItemModel)
     case memo(ListItemModel)
     case swapDetails(SwapDetailsViewModel)
-    case networkFee(ListItemModel)
+    case networkFee(ListItemModel, selectable: Bool)
     case perpetualDetails(PerpetualDetailsViewModel)
     case error(title: String, error: Error, onInfoAction: VoidAction)
     case empty

--- a/Features/Transfer/Sources/ViewModels/ConfirmNetworkFeeViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmNetworkFeeViewModel.swift
@@ -36,7 +36,8 @@ extension ConfirmNetworkFeeViewModel {
                 subtitleExtra: networkFeeFiatValue,
                 placeholders: [.subtitle],
                 infoAction: infoAction
-            )
+            ),
+            selectable: !state.isError
         )
     }
 }

--- a/Features/Transfer/Tests/ViewModels/ConfirmNetworkFeeViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmNetworkFeeViewModelTests.swift
@@ -21,8 +21,9 @@ struct ConfirmNetworkFeeViewModelTests {
             infoAction: {}
         )
 
-        guard case .networkFee(let item) = model.itemModel else { return }
+        guard case .networkFee(let item, let selectable) = model.itemModel else { return }
         #expect(item.subtitle == fiatValue)
+        #expect(selectable == true)
     }
 
     @Test
@@ -36,8 +37,9 @@ struct ConfirmNetworkFeeViewModelTests {
             infoAction: {}
         )
 
-        guard case .networkFee(let item) = model.itemModel else { return }
+        guard case .networkFee(let item, let selectable) = model.itemModel else { return }
         #expect(item.subtitle == value)
+        #expect(selectable == true)
     }
 
     @Test
@@ -50,8 +52,9 @@ struct ConfirmNetworkFeeViewModelTests {
             infoAction: {}
         )
 
-        guard case .networkFee(let item) = model.itemModel else { return }
+        guard case .networkFee(let item, let selectable) = model.itemModel else { return }
         #expect(item.subtitle == "-")
+        #expect(selectable == false)
     }
 
     @Test
@@ -72,9 +75,10 @@ struct ConfirmNetworkFeeViewModelTests {
             infoAction: {}
         )
 
-        guard case .networkFee(let item) = model.itemModel else { return }
+        guard case .networkFee(let item, let selectable) = model.itemModel else { return }
         #expect(item.subtitle == value)
         #expect(item.subtitleExtra == fiatValue)
+        #expect(selectable == true)
     }
 }
 

--- a/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
@@ -176,7 +176,7 @@ struct ConfirmTransferSceneViewModelTests {
         model.state = .error(AnyError("test"))
         let errorFeeItem = model.itemModel(for: .networkFee) as? ConfirmNetworkFeeViewModel
 
-        if case .networkFee(let listItem) = errorFeeItem?.itemModel {
+        if case .networkFee(let listItem, _) = errorFeeItem?.itemModel {
             #expect(listItem.subtitle == "-")
             #expect(listItem.subtitleExtra == nil)
         } else {
@@ -187,7 +187,7 @@ struct ConfirmTransferSceneViewModelTests {
         model.state = .data(TransactionInputViewModel.mock())
         let feeWithFiatItem = model.itemModel(for: .networkFee) as? ConfirmNetworkFeeViewModel
 
-        if case .networkFee(let listItem) = feeWithFiatItem?.itemModel {
+        if case .networkFee(let listItem, _) = feeWithFiatItem?.itemModel {
             #expect(listItem.subtitle == "$2.50")
             #expect(listItem.subtitleExtra == nil)
         } else {
@@ -197,7 +197,7 @@ struct ConfirmTransferSceneViewModelTests {
         model.feeModel.update(value: "0.001 ETH", fiatValue: nil)
         let feeNoFiatItem = model.itemModel(for: .networkFee) as? ConfirmNetworkFeeViewModel
 
-        if case .networkFee(let listItem) = feeNoFiatItem?.itemModel {
+        if case .networkFee(let listItem, _) = feeNoFiatItem?.itemModel {
             #expect(listItem.subtitle == "0.001 ETH")
             #expect(listItem.subtitleExtra == nil)
         } else {


### PR DESCRIPTION
Updated ConfirmTransferItemModel.networkFee to include a selectable flag, allowing the UI to conditionally enable fee picker navigation. Adjusted scene rendering logic and view model to support this, and updated related unit tests to verify selectable behavior.

closes #1338 
<img width="320" height="680" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/668083d7-3b58-4049-aaac-2e31438f97b8" />
