### PR TITLE
Refactor keystore and wallet operations to async/await

### DIFF
--- a/Features/ManageWallets/Sources/Scenes/WalletDetailScene.swift
+++ b/Features/ManageWallets/Sources/Scenes/WalletDetailScene.swift
@@ -113,8 +113,10 @@ public struct WalletDetailScene: View {
                     Localized.Common.delete,
                     role: .destructive,
                     action: {
-                        if model.onDelete() {
-                            dismiss()
+                        Task {
+                            if await model.onDelete() {
+                                dismiss()
+                            }
                         }
                     }
                 )

--- a/Features/ManageWallets/Sources/Scenes/WalletsScene.swift
+++ b/Features/ManageWallets/Sources/Scenes/WalletsScene.swift
@@ -86,7 +86,7 @@ public struct WalletsScene: View {
                 Button(
                     Localized.Common.delete,
                     role: .destructive,
-                    action: { model.onDeleteConfirmed(wallet: wallet) }
+                    action: { Task { await model.onDeleteConfirmed(wallet: wallet) } }
                 )
             }
         )

--- a/Features/ManageWallets/Sources/ViewModels/WalletIDetailViewModel.swift
+++ b/Features/ManageWallets/Sources/ViewModels/WalletIDetailViewModel.swift
@@ -90,21 +90,21 @@ extension WalletDetailViewModel {
         try walletService.rename(walletId: wallet.walletId, newName: name)
     }
     
-    func getMnemonicWords() throws -> [String] {
-        try walletService.getMnemonic(wallet: wallet)
+    func getMnemonicWords() async throws -> [String] {
+        try await walletService.getMnemonic(wallet: wallet)
     }
-    
-    func getPrivateKey() throws -> String {
+
+    func getPrivateKey() async throws -> String {
         let chain = wallet.accounts[0].chain
-        return try walletService.getPrivateKey(
+        return try await walletService.getPrivateKey(
             wallet: wallet,
             chain: chain,
             encoding: chain.defaultKeyEncodingType
         )
     }
 
-    func delete() throws {
-        try walletService.delete(wallet)
+    func delete() async throws {
+        try await walletService.delete(wallet)
     }
 
     func onSelectImage() {
@@ -124,18 +124,22 @@ extension WalletDetailViewModel {
     }
 
     func onShowSecretPhrase() {
-        do {
-            isPresentingExportWallet = .words(try getMnemonicWords())
-        } catch {
-            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
+        Task {
+            do {
+                isPresentingExportWallet = .words(try await getMnemonicWords())
+            } catch {
+                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
+            }
         }
     }
 
     func onShowPrivateKey() {
-        do {
-            isPresentingExportWallet = .privateKey(try getPrivateKey())
-        } catch {
-            isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
+        Task {
+            do {
+                isPresentingExportWallet = .privateKey(try await getPrivateKey())
+            } catch {
+                isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)
+            }
         }
     }
 
@@ -143,9 +147,9 @@ extension WalletDetailViewModel {
         isPresentingDeleteConfirmation = true
     }
 
-    func onDelete() -> Bool {
+    func onDelete() async -> Bool {
         do {
-            try delete()
+            try await delete()
             return true
         } catch {
             isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)

--- a/Features/ManageWallets/Sources/ViewModels/WalletsSceneViewModel.swift
+++ b/Features/ManageWallets/Sources/ViewModels/WalletsSceneViewModel.swift
@@ -65,8 +65,8 @@ extension WalletsSceneViewModel {
         navigationPath.wrappedValue.append(Scenes.WalletDetail(wallet: wallet))
     }
 
-    private func delete(_ wallet: Wallet) throws {
-        try service.delete(wallet)
+    private func delete(_ wallet: Wallet) async throws {
+        try await service.delete(wallet)
     }
 
     private func pin(_ wallet: Wallet) throws {
@@ -134,9 +134,9 @@ extension WalletsSceneViewModel {
         }
     }
     
-    func onDeleteConfirmed(wallet: Wallet) {
+    func onDeleteConfirmed(wallet: Wallet) async {
         do {
-            try delete(wallet)
+            try await delete(wallet)
             currentWalletId = service.currentWalletId
         } catch {
             isPresentingAlertMessage = AlertMessage(message: error.localizedDescription)

--- a/Features/ManageWallets/Tests/WalletsSceneViewModelTests.swift
+++ b/Features/ManageWallets/Tests/WalletsSceneViewModelTests.swift
@@ -15,20 +15,23 @@ import WalletServiceTestKit
 struct WalletsSceneViewModelTests {
     
     @Test
-    func onDeleteConfirmed() throws {
+    func onDeleteConfirmed() async throws {
         let service: WalletService = try .mockWallets()
         let model = WalletsSceneViewModel.mock(walletService: service)
         model.wallets = service.wallets
 
         #expect(model.currentWalletId == .mock(id: "1"))
 
-        model.onDeleteConfirmed(wallet: .mock(id: "1"))
+        await model.onDeleteConfirmed(wallet: .mock(id: "1"))
+        
         #expect(model.currentWalletId == .mock(id: "2"))
 
-        model.onDeleteConfirmed(wallet: .mock(id: "2"))
+        await model.onDeleteConfirmed(wallet: .mock(id: "2"))
+        
         #expect(model.currentWalletId == .mock(id: "3"))
 
-        model.onDeleteConfirmed(wallet: .mock(id: "3"))
+        await model.onDeleteConfirmed(wallet: .mock(id: "3"))
+        
         #expect(model.currentWalletId == .none)
     }
 

--- a/Features/Onboarding/Sources/ViewsModels/ImportWalletViewModel.swift
+++ b/Features/Onboarding/Sources/ViewsModels/ImportWalletViewModel.swift
@@ -110,9 +110,8 @@ extension ImportWalletViewModel {
         buttonState = .loading(showProgress: true)
 
         Task {
-            try await Task.sleep(for: .milliseconds(50))
             do {
-                try importWallet()
+                try await importWallet()
             } catch {
                 isPresentingAlertMessage = AlertMessage(
                     title: alertTitle,
@@ -150,7 +149,7 @@ extension ImportWalletViewModel {
 // MARK: - Private
 
 extension ImportWalletViewModel {
-    private func importWallet() throws {
+    private func importWallet() async throws {
         let recipient: RecipientImport = {
             if let result = nameResolveState.result {
                 return RecipientImport(name: result.name, address: result.address)
@@ -165,12 +164,12 @@ extension ImportWalletViewModel {
             }
             switch type {
             case .multicoin:
-                try importWallet(
+                try await importWallet(
                     name: recipient.name,
                     keystoreType: .phrase(words: words, chains: AssetConfiguration.allChains)
                 )
             case .chain(let chain):
-                try importWallet(
+                try await importWallet(
                     name: recipient.name,
                     keystoreType: .single(words: words, chain: chain)
                 )
@@ -179,7 +178,7 @@ extension ImportWalletViewModel {
             guard try validateForm(type: importType, address: recipient.address, words: [input]) else {
                 return
             }
-            try importWallet(name: recipient.name, keystoreType: .privateKey(text: input, chain: chain!))
+            try await importWallet(name: recipient.name, keystoreType: .privateKey(text: input, chain: chain!))
         case .address:
             guard try validateForm(type: importType, address: recipient.address, words: []) else {
                 return
@@ -187,12 +186,12 @@ extension ImportWalletViewModel {
             let chain = chain!
             let address = chain.checksumAddress(recipient.address)
 
-            try importWallet(name: recipient.name, keystoreType: .address(chain: chain, address: address))
+            try await importWallet(name: recipient.name, keystoreType: .address(chain: chain, address: address))
         }
     }
 
-    private func importWallet(name: String, keystoreType: KeystoreImportType) throws {
-        try walletService.importWallet(name: name, type: keystoreType)
+    private func importWallet(name: String, keystoreType: KeystoreImportType) async throws {
+        try await walletService.importWallet(name: name, type: keystoreType)
         onFinish?()
     }
 

--- a/Features/Onboarding/Sources/ViewsModels/VerifyPhraseViewModel.swift
+++ b/Features/Onboarding/Sources/ViewsModels/VerifyPhraseViewModel.swift
@@ -79,9 +79,9 @@ final class VerifyPhraseViewModel {
         selectedIndexes.contains(index)
     }
     
-    func importWallet() throws  {
+    func importWallet() async throws  {
         let name = WalletNameGenerator(type: .multicoin, walletService: walletService).name
-        let wallet = try walletService.importWallet(name: name, type: .phrase(words: words, chains: AssetConfiguration.allChains))
+        let wallet = try await walletService.importWallet(name: name, type: .phrase(words: words, chains: AssetConfiguration.allChains))
 
         WalletPreferences(walletId: wallet.id).completeInitialSynchronization()
         walletService.acceptTerms()
@@ -97,19 +97,14 @@ extension VerifyPhraseViewModel {
         buttonState = .loading(showProgress: true)
 
         Task {
-            try await Task.sleep(for: .milliseconds(50))
             do {
-                try await MainActor.run {
-                    try importWallet()
-                }
+                try await importWallet()
             } catch {
-                await MainActor.run {
-                    isPresentingAlertMessage = AlertMessage(
-                        title: Localized.Errors.createWallet(""),
-                        message: error.localizedDescription
-                    )
-                    buttonState = .normal
-                }
+                isPresentingAlertMessage = AlertMessage(
+                    title: Localized.Errors.createWallet(""),
+                    message: error.localizedDescription
+                )
+                buttonState = .normal
             }
         }
     }

--- a/Features/Transfer/Sources/Services/TransferExecutor.swift
+++ b/Features/Transfer/Sources/Services/TransferExecutor.swift
@@ -30,7 +30,7 @@ public struct TransferExecutor: TransferExecutable {
     }
 
     public func execute(input: TransferConfirmationInput) async throws {
-        let signedData = try sign(input: input)
+        let signedData = try await sign(input: input)
         let options = broadcastOptions(data: input.data)
 
         for (index, transactionData) in signedData.enumerated() {
@@ -81,8 +81,8 @@ public struct TransferExecutor: TransferExecutable {
 // MARK: - Private
 
 extension TransferExecutor {
-    private func sign(input: TransferConfirmationInput) throws -> [String] {
-        try signer.sign(
+    private func sign(input: TransferConfirmationInput) async throws -> [String] {
+        try await signer.sign(
             transfer: input.data,
             transactionData: input.transactionData,
             amount: input.amount,

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
@@ -74,11 +74,13 @@ public struct SignMessageScene: View {
     }
     
     func sign() {
-        do {
-            try model.signMessage()
-            dismiss()
-        } catch {
-            NSLog("sign message error \(error)")
+        Task {
+            do {
+                try await model.signMessage()
+                dismiss()
+            } catch {
+                NSLog("sign message error \(error)")
+            }
         }
     }
 }

--- a/Packages/FeatureServices/SwapService/Permit2DataProvider.swift
+++ b/Packages/FeatureServices/SwapService/Permit2DataProvider.swift
@@ -17,7 +17,7 @@ protocol Permit2DataProvidable: Sendable {
         wallet: Wallet,
         chain: Chain,
         approval: Permit2ApprovalData
-    ) throws -> Permit2Data
+    ) async throws -> Permit2Data
 }
 
 struct Permit2DataProvider: Permit2DataProvidable {
@@ -31,7 +31,7 @@ struct Permit2DataProvider: Permit2DataProvidable {
         wallet: Wallet,
         chain: Chain,
         approval: Permit2ApprovalData
-    ) throws -> Permit2Data {
+    ) async throws -> Permit2Data {
 
         let permitSingle = permitSingle(approval: approval)
         let json = try Gemstone.permit2DataToEip712Json(
@@ -41,7 +41,7 @@ struct Permit2DataProvider: Permit2DataProvidable {
         )
 
         let signer = Signer(wallet: wallet, keystore: keystore)
-        let hexSignature = try signer.signMessage(chain: chain, message: .typed(json))
+        let hexSignature = try await signer.signMessage(chain: chain, message: .typed(json))
         let signature = try Data.from(hex: hexSignature)
 
         return Permit2Data(permitSingle: permitSingle, signature: signature)

--- a/Packages/FeatureServices/SwapService/SwapQuoteDataProvider.swift
+++ b/Packages/FeatureServices/SwapService/SwapQuoteDataProvider.swift
@@ -25,7 +25,7 @@ public struct SwapQuoteDataProvider: SwapQuoteDataProvidable {
         case .none:
             return try await swapService.getQuoteData(quote, data: .none)
         case .some(let approval):
-            let permit2Data = try permit2DataProvider.getPermit2Data(
+            let permit2Data = try await permit2DataProvider.getPermit2Data(
                 wallet: wallet,
                 chain: AssetId(id: quote.request.fromAsset.id).chain,
                 approval: approval

--- a/Packages/Keystore/Sources/Extensions/DispatchQueue+Keystore.swift
+++ b/Packages/Keystore/Sources/Extensions/DispatchQueue+Keystore.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension DispatchQueue {
+    func asyncTask<T: Sendable>(
+        execute work: @escaping @Sendable () throws -> T
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            self.async {
+                do {
+                    continuation.resume(returning: try work())
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/Packages/Keystore/Sources/LocalKeystore.swift
+++ b/Packages/Keystore/Sources/LocalKeystore.swift
@@ -2,9 +2,10 @@ import Foundation
 import Primitives
 import WalletCore
 
-public struct LocalKeystore: Keystore {
+public final class LocalKeystore: Keystore, @unchecked Sendable {
     private let walletKeyStore: WalletKeyStore
     private let keystorePassword: KeystorePassword
+    private let queue = DispatchQueue(label: "com.gemwallet.keystore", qos: .userInitiated)
 
     public init(
         directory: String = "keystore",
@@ -36,47 +37,35 @@ public struct LocalKeystore: Keystore {
         name: String,
         type: KeystoreImportType,
         isWalletsEmpty: Bool
-    ) throws -> Primitives.Wallet {
-        return switch type {
-        case .phrase(let words, let chains):
-            try walletKeyStore.importWallet(
-                name: name,
-                words: words,
-                chains: chains,
-                password: getOrCreatePassword(createPasswordIfNone: isWalletsEmpty)
-            )
-        case .single(let words, let chain):
-            try walletKeyStore.importWallet(
-                name: name,
-                words: words,
-                chains: [chain],
-                password: getOrCreatePassword(createPasswordIfNone: isWalletsEmpty)
-            )
-        case .privateKey(let text, let chain):
-            try walletKeyStore.importPrivateKey(
-                name: name,
-                key: text,
-                chain: chain,
-                password: getOrCreatePassword(createPasswordIfNone: isWalletsEmpty)
-            )
-        case .address(let chain, let address):
-            Wallet.makeView(name: name, chain: chain, address: address)
+    ) async throws -> Primitives.Wallet {
+        let password = try await getOrCreatePassword(createPasswordIfNone: isWalletsEmpty)
+
+        return try await queue.asyncTask { [walletKeyStore] in
+            switch type {
+            case .phrase(let words, let chains):
+                try walletKeyStore.importWallet(name: name, words: words, chains: chains, password: password)
+            case .single(let words, let chain):
+                try walletKeyStore.importWallet(name: name, words: words, chains: [chain], password: password)
+            case .privateKey(let text, let chain):
+                try walletKeyStore.importPrivateKey(name: name, key: text, chain: chain, password: password)
+            case .address(let chain, let address):
+                Wallet.makeView(name: name, chain: chain, address: address)
+            }
         }
     }
 
     public func setupChains(chains: [Chain], for wallets: [Primitives.Wallet]) throws -> [Primitives.Wallet] {
-        let wallets = wallets.filter {
+        let filteredWallets = wallets.filter {
             let enabled = Set($0.accounts.map(\.chain)).intersection(chains).map { $0 }
             let missing = Set(chains).subtracting(enabled)
             return missing.isNotEmpty
         }
-        guard wallets.isNotEmpty else {
+        guard filteredWallets.isNotEmpty else {
             return []
         }
         let password = try keystorePassword.getPassword()
-        
-        // Some users might expirience long launch time due to large number of wallets to process, each one takes 100-300ms to process.
-        return try wallets
+
+        return try filteredWallets
             .prefix(25)
             .map {
                 let existingChains = $0.accounts.map(\.chain)
@@ -89,73 +78,87 @@ public struct LocalKeystore: Keystore {
             }
     }
 
-    public func deleteKey(for wallet: Primitives.Wallet) throws {
+    public func deleteKey(for wallet: Primitives.Wallet) async throws {
         switch wallet.type {
         case .view: break
         case .multicoin, .single, .privateKey:
-            let password = try keystorePassword.getPassword()
-            do {
-                try walletKeyStore.deleteWallet(id: wallet.id, password: password)
-            } catch let error as KeystoreError {
-                // in some cases wallet already deleted, just ignore
-                switch error {
-                case .unknownWalletInWalletCore, .unknownWalletIdInWalletCore, .unknownWalletInWalletCoreList, .invalidPrivateKey, .invalidPrivateKeyEncoding:
-                    break
+            let password = try await getPassword()
+            try await queue.asyncTask { [walletKeyStore] in
+                do {
+                    try walletKeyStore.deleteWallet(id: wallet.id, password: password)
+                } catch let error as KeystoreError {
+                    switch error {
+                    case .unknownWalletInWalletCore, .unknownWalletIdInWalletCore, .unknownWalletInWalletCoreList:
+                        break
+                    case .invalidPrivateKey, .invalidPrivateKeyEncoding:
+                        throw error
+                    @unknown default:
+                        throw error
+                    }
                 }
             }
         }
     }
 
-    public func getPrivateKey(wallet: Primitives.Wallet, chain: Chain) throws -> Data {
-        let password = try keystorePassword.getPassword()
-        return try walletKeyStore.getPrivateKey(id: wallet.id, type: wallet.type, chain: chain, password: password)
+    public func getPrivateKey(wallet: Primitives.Wallet, chain: Chain) async throws -> Data {
+        let password = try await getPassword()
+        return try await queue.asyncTask { [walletKeyStore] in
+            try walletKeyStore.getPrivateKey(id: wallet.id, type: wallet.type, chain: chain, password: password)
+        }
     }
 
-    public func getPrivateKey(wallet: Primitives.Wallet, chain: Chain, encoding: EncodingType) throws -> String {
-        let data = try getPrivateKey(wallet: wallet, chain: chain)
+    public func getPrivateKey(wallet: Primitives.Wallet, chain: Chain, encoding: EncodingType) async throws -> String {
+        let data = try await getPrivateKey(wallet: wallet, chain: chain)
         switch encoding {
         case .base58:
             return Base58.encodeNoCheck(data: data)
         case .hex:
             return data.hexString.append0x
         case .base32:
-            // not allow exporting to Base32
             throw KeystoreError.invalidPrivateKeyEncoding
         }
     }
 
-    public func getMnemonic(wallet: Primitives.Wallet) throws -> [String] {
-        try walletKeyStore.getMnemonic(
-            wallet: wallet,
-            password: keystorePassword.getPassword()
-        )
+    public func getMnemonic(wallet: Primitives.Wallet) async throws -> [String] {
+        let password = try await getPassword()
+        return try await queue.asyncTask { [walletKeyStore] in
+            try walletKeyStore.getMnemonic(wallet: wallet, password: password)
+        }
     }
 
     public func getPasswordAuthentication() throws -> KeystoreAuthentication {
         try keystorePassword.getAuthentication()
     }
 
-    public func sign(hash: Data, wallet: Primitives.Wallet, chain: Chain) throws -> Data {
-        try walletKeyStore.sign(
-            hash: hash,
-            walletId: wallet.id,
-            type: wallet.type,
-            password: keystorePassword.getPassword(),
-            chain: chain
-        )
+    public func sign(hash: Data, wallet: Primitives.Wallet, chain: Chain) async throws -> Data {
+        let password = try await getPassword()
+        return try await queue.asyncTask { [walletKeyStore] in
+            try walletKeyStore.sign(
+                hash: hash,
+                walletId: wallet.id,
+                type: wallet.type,
+                password: password,
+                chain: chain
+            )
+        }
     }
 
     public func destroy() throws {
         try walletKeyStore.destroy()
     }
 
+    @MainActor
+    private func getPassword() throws -> String {
+        try keystorePassword.getPassword()
+    }
+
+    @MainActor
     private func getOrCreatePassword(createPasswordIfNone: Bool) throws -> String {
         let password = try keystorePassword.getPassword()
 
         guard password.isEmpty, createPasswordIfNone else {
             return password
         }
-        // setup once
         let newPassword = UUID().uuidString
         try keystorePassword.setPassword(newPassword, authentication: .none)
         return newPassword

--- a/Packages/Keystore/Sources/LocalKeystore.swift
+++ b/Packages/Keystore/Sources/LocalKeystore.swift
@@ -87,11 +87,14 @@ public final class LocalKeystore: Keystore, @unchecked Sendable {
                 do {
                     try walletKeyStore.deleteWallet(id: wallet.id, password: password)
                 } catch let error as KeystoreError {
+                    // in some cases wallet already deleted, just ignore
                     switch error {
-                    case .unknownWalletInWalletCore, .unknownWalletIdInWalletCore, .unknownWalletInWalletCoreList:
+                    case .unknownWalletInWalletCore,
+                        .unknownWalletIdInWalletCore,
+                        .unknownWalletInWalletCoreList,
+                        .invalidPrivateKey,
+                        .invalidPrivateKeyEncoding:
                         break
-                    case .invalidPrivateKey, .invalidPrivateKeyEncoding:
-                        throw error
                     @unknown default:
                         throw error
                     }

--- a/Packages/Keystore/Sources/Protocols/Keystore.swift
+++ b/Packages/Keystore/Sources/Protocols/Keystore.swift
@@ -7,13 +7,13 @@ import SwiftUI
 public protocol Keystore: Sendable {
     func createWallet() -> [String]
     @discardableResult
-    func importWallet(name: String, type: KeystoreImportType, isWalletsEmpty: Bool) throws -> Wallet
+    func importWallet(name: String, type: KeystoreImportType, isWalletsEmpty: Bool) async throws -> Wallet
     func setupChains(chains: [Chain], for wallets: [Wallet]) throws -> [Wallet]
-    func deleteKey(for wallet: Wallet) throws
-    func getPrivateKey(wallet: Wallet, chain: Chain) throws -> Data
-    func getPrivateKey(wallet: Wallet, chain: Chain, encoding: EncodingType) throws -> String
-    func getMnemonic(wallet: Wallet) throws -> [String]
+    func deleteKey(for wallet: Wallet) async throws
+    func getPrivateKey(wallet: Wallet, chain: Chain) async throws -> Data
+    func getPrivateKey(wallet: Wallet, chain: Chain, encoding: EncodingType) async throws -> String
+    func getMnemonic(wallet: Wallet) async throws -> [String]
     func getPasswordAuthentication() throws -> KeystoreAuthentication
-    func sign(hash: Data, wallet: Wallet, chain: Chain) throws -> Data
+    func sign(hash: Data, wallet: Wallet, chain: Chain) async throws -> Data
     func destroy() throws
 }

--- a/Packages/Keystore/Tests/LocalKeystoreTests.swift
+++ b/Packages/Keystore/Tests/LocalKeystoreTests.swift
@@ -16,11 +16,11 @@ struct LocalKeystoreTests {
     }
 
     @Test
-    func testImportWallet() {
-        #expect(throws: Never.self) {
+    func testImportWallet() async {
+        await #expect(throws: Never.self) {
             let keystore = LocalKeystore.mock()
             let words = keystore.createWallet()
-            let wallet = try keystore.importWallet(
+            let wallet = try await keystore.importWallet(
                 name: "test",
                 type: .phrase(words: words, chains: [.ethereum]),
                 isWalletsEmpty: true
@@ -32,10 +32,10 @@ struct LocalKeystoreTests {
     }
 
     @Test
-    func testImportSolanaWallet() {
-        #expect(throws: Never.self) {
+    func testImportSolanaWallet() async {
+        await #expect(throws: Never.self) {
             let keystore = LocalKeystore.mock()
-            let wallet = try keystore.importWallet(
+            let wallet = try await keystore.importWallet(
                 name: "Solana Wallet",
                 type: .phrase(words: LocalKeystore.words, chains: [.solana]),
                 isWalletsEmpty: true
@@ -48,12 +48,12 @@ struct LocalKeystoreTests {
     }
 
     @Test
-    func testImportEthereumWallet() {
-        #expect(throws: Never.self) {
+    func testImportEthereumWallet() async {
+        await #expect(throws: Never.self) {
             let keystore = LocalKeystore.mock()
             let chains: [Chain] = [.ethereum, .smartChain, .blast]
 
-            let wallet = try keystore.importWallet(
+            let wallet = try await keystore.importWallet(
                 name: "test",
                 type: .phrase(words: LocalKeystore.words, chains: chains),
                 isWalletsEmpty: true
@@ -69,38 +69,38 @@ struct LocalKeystoreTests {
     }
 
     @Test
-    func testExportSolanaPrivateKey() {
-        #expect(throws: Never.self) {
+    func testExportSolanaPrivateKey() async {
+        await #expect(throws: Never.self) {
             let keystore = LocalKeystore.mock()
             let hex = "0xb9095df5360714a69bc86ca92f6191e60355f206909982a8409f7b8358cf41b0"
-            let wallet = try keystore.importWallet(
+            let wallet = try await keystore.importWallet(
                 name: "Test Solana",
                 type: .privateKey(text: hex, chain: .solana),
                 isWalletsEmpty: true
             )
 
-            let exportedHex = try keystore.getPrivateKey(wallet: wallet, chain: .solana, encoding: .hex)
-            let exportedBase58 = try keystore.getPrivateKey(wallet: wallet, chain: .solana, encoding: .base58)
+            let exportedHex = try await keystore.getPrivateKey(wallet: wallet, chain: .solana, encoding: .hex)
+            let exportedBase58 = try await keystore.getPrivateKey(wallet: wallet, chain: .solana, encoding: .base58)
 
             #expect(exportedHex == hex)
             #expect(exportedBase58 == "DTJi5pMtSKZHdkLX4wxwvjGjf2xwXx1LSuuUZhugYWDV")
 
             let keystore2 = LocalKeystore.mock()
-            let wallet2 = try keystore2.importWallet(
+            let wallet2 = try await keystore2.importWallet(
                 name: "Test Solana 2",
                 type: .privateKey(text: exportedBase58, chain: .solana),
                 isWalletsEmpty: true
             )
-            let exportedKey = try keystore2.getPrivateKey(wallet: wallet2, chain: .solana)
+            let exportedKey = try await keystore2.getPrivateKey(wallet: wallet2, chain: .solana)
 
             #expect(Base58.encodeNoCheck(data: exportedKey) == exportedBase58)
         }
     }
 
     @Test
-    func testSignSolanaMessage() throws {
+    func testSignSolanaMessage() async throws {
         let keystore = LocalKeystore.mock()
-        let wallet = try keystore.importWallet(
+        let wallet = try await keystore.importWallet(
             name: "Test Solana",
             type: .phrase(words: LocalKeystore.words, chains: [.solana]),
             isWalletsEmpty: true
@@ -108,7 +108,7 @@ struct LocalKeystoreTests {
 
         let text = "5A2EYggC6hiAAuRArnkAANGySDyqQUGrbBHXfKQD9DQ5XcSkReDswnRqb7x3KRrnie9qSL"
         let hash = Base58.decodeNoCheck(string: text)!
-        let signature = try keystore.sign(hash: hash, wallet: wallet, chain: .solana)
+        let signature = try await keystore.sign(hash: hash, wallet: wallet, chain: .solana)
         let encoded = Base58.encodeNoCheck(data: signature)
 
         #expect(encoded == "5ZRaXVuDePowJjZmKaMjfcuqBVZet6e8QiCjTkGXBn7xhCvoEswUKXiGs2wmPxcqTfJUH28eCC91J1vLSjANNM9v")
@@ -127,11 +127,11 @@ struct LocalKeystoreTests {
     }
 
     @Test
-    func testDeriveAddress() {
-        #expect(throws: Never.self) {
+    func testDeriveAddress() async {
+        await #expect(throws: Never.self) {
             let keystore = LocalKeystore.mock()
             let chains = Chain.allCases
-            let wallet = try keystore.importWallet(
+            let wallet = try await keystore.importWallet(
                 name: "test",
                 type: .phrase(words: LocalKeystore.words, chains: chains),
                 isWalletsEmpty: true
@@ -225,15 +225,15 @@ struct LocalKeystoreTests {
     }
 
     @Test
-    func testSetupChainsAddsMissingChains() {
-        #expect(throws: Never.self) {
+    func testSetupChainsAddsMissingChains() async {
+        await #expect(throws: Never.self) {
             let keystore = LocalKeystore.mock()
-            let ethWallet = try keystore.importWallet(
+            let ethWallet = try await keystore.importWallet(
                 name: "ETH only",
                 type: .phrase(words: LocalKeystore.words, chains: [.ethereum]),
                 isWalletsEmpty: true
             )
-            let solWallet = try keystore.importWallet(
+            let solWallet = try await keystore.importWallet(
                 name: "SOL only",
                 type: .phrase(words: LocalKeystore.words, chains: [.solana]),
                 isWalletsEmpty: false
@@ -252,10 +252,10 @@ struct LocalKeystoreTests {
     }
 
     @Test
-    func testSetupChainsAddNoMissingChains() {
-        #expect(throws: Never.self) {
+    func testSetupChainsAddNoMissingChains() async {
+        await #expect(throws: Never.self) {
             let keystore = LocalKeystore.mock()
-            let wallet = try keystore.importWallet(
+            let wallet = try await keystore.importWallet(
                 name: "Complete wallet",
                 type: .phrase(words: LocalKeystore.words, chains: chains),
                 isWalletsEmpty: true
@@ -267,6 +267,41 @@ struct LocalKeystoreTests {
             )
 
             #expect(result.isEmpty)
+        }
+    }
+
+    @Test
+    func testConcurrentImportAndDelete() async throws {
+        let keystore = LocalKeystore.mock()
+
+        let wallets = try await withThrowingTaskGroup(of: Primitives.Wallet.self) { group in
+            for index in 0..<5 {
+                group.addTask {
+                    try await keystore.importWallet(
+                        name: "Wallet \(index)",
+                        type: .phrase(words: LocalKeystore.words, chains: [.ethereum]),
+                        isWalletsEmpty: index == 0 ? true : false
+                    )
+                }
+            }
+
+            var wallets: [Primitives.Wallet] = []
+            for try await wallet in group {
+                wallets.append(wallet)
+            }
+            return wallets
+        }
+
+        let importedWallets = wallets
+        #expect(importedWallets.count == 5)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for wallet in importedWallets {
+                group.addTask {
+                    try await keystore.deleteKey(for: wallet)
+                }
+            }
+            try await group.waitForAll()
         }
     }
 }

--- a/Packages/Signer/Sources/Signer.swift
+++ b/Packages/Signer/Sources/Signer.swift
@@ -56,14 +56,14 @@ public struct Signer: Sendable {
         }
     }
 
-    public func sign(input: SignerInput) throws -> [String] {
+    public func sign(input: SignerInput) async throws -> [String] {
         let chain = input.asset.chain
-        let privateKey = try keystore.getPrivateKey(wallet: wallet, chain: chain)
+        let privateKey = try await keystore.getPrivateKey(wallet: wallet, chain: chain)
         return try sign(input: input, chain: chain, privateKey: privateKey)
     }
 
-    public func signMessage(chain: Chain, message: SignMessage) throws -> String {
-        let privateKey = try keystore.getPrivateKey(wallet: wallet, chain: chain)
+    public func signMessage(chain: Chain, message: SignMessage) async throws -> String {
+        let privateKey = try await keystore.getPrivateKey(wallet: wallet, chain: chain)
         return try signMessage(chain: chain, message: message, privateKey: privateKey)
     }
 

--- a/Packages/Signer/Sources/TransactionSigneable.swift
+++ b/Packages/Signer/Sources/TransactionSigneable.swift
@@ -9,5 +9,5 @@ public protocol TransactionSigneable: Sendable {
         transactionData: TransactionData,
         amount: TransferAmount,
         wallet: Wallet
-    ) throws -> [String]
+    ) async throws -> [String]
 }

--- a/Packages/Signer/Sources/TransactionSigner.swift
+++ b/Packages/Signer/Sources/TransactionSigner.swift
@@ -16,7 +16,7 @@ public struct TransactionSigner: TransactionSigneable {
         transactionData: TransactionData,
         amount: TransferAmount,
         wallet: Wallet
-    ) throws -> [String] {
+    ) async throws -> [String] {
 
         let signer = Signer(wallet: wallet, keystore: keystore)
         let fee = Fee(
@@ -38,6 +38,6 @@ public struct TransactionSigner: TransactionSigneable {
             metadata: transactionData.metadata
         )
 
-        return try signer.sign(input: input)
+        return try await signer.sign(input: input)
     }
 }

--- a/Packages/Store/Sources/Models/WalletRecord.swift
+++ b/Packages/Store/Sources/Models/WalletRecord.swift
@@ -20,7 +20,7 @@ public struct WalletRecord: Codable, TableRecord, FetchableRecord, PersistableRe
 
     public var id: String
     public var name: String
-    public var type: String
+    public var type: WalletType
     public var index: Int
     public var order: Int
     public var isPinned: Bool

--- a/Packages/Store/Sources/Stores/WalletStore.swift
+++ b/Packages/Store/Sources/Stores/WalletStore.swift
@@ -132,7 +132,7 @@ extension WalletRecord {
             id: id,
             name: name,
             index: index.asInt32,
-            type: WalletType(rawValue: type)!,
+            type: type,
             accounts: [],
             order: order.asInt32,
             isPinned: isPinned,
@@ -146,7 +146,7 @@ extension Wallet {
         return WalletRecord(
             id: id,
             name: name,
-            type: type.rawValue, 
+            type: type, 
             index: index.asInt,
             order: 0,
             isPinned: false,

--- a/Packages/Store/Sources/Types/WalletRecordInfo.swift
+++ b/Packages/Store/Sources/Types/WalletRecordInfo.swift
@@ -11,14 +11,11 @@ struct WalletRecordInfo: FetchableRecord, Codable {
 
 extension WalletRecordInfo {
     func mapToWallet() -> Wallet? {
-        guard let type = WalletType(rawValue: wallet.type) else {
-            return .none
-        }
         return Wallet(
             id: wallet.id,
             name: wallet.name,
             index: wallet.index.asInt32,
-            type: type,
+            type: wallet.type,
             accounts: accounts.map { $0.mapToAccount() },
             order: wallet.order.asInt32,
             isPinned: wallet.isPinned,


### PR DESCRIPTION
Converted keystore, wallet service, and related view models to use async/await for all key management, signing, and wallet import/delete operations. Updated protocol definitions, implementations, and tests to support concurrency and improve thread safety. Added a DispatchQueue extension for async task execution in LocalKeystore. This change enables safer concurrent wallet operations and modernizes the codebase for Swift concurrency.