### PR TITLE
Autoclose improvements

### DIFF
--- a/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
+++ b/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
@@ -161,7 +161,7 @@ public struct InfoSheetModelFactory {
                 title: Localized.Perpetual.autoClose,
                 description: Localized.Info.Perpetual.AutoClose.description,
                 image: .image(Images.Logo.logo),
-                button: .url(Docs.url(.perpetualsAutoclose))
+                button: .url(Docs.url(.perpetualsAutoClose))
             )
         }
     }

--- a/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
+++ b/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
@@ -161,7 +161,7 @@ public struct InfoSheetModelFactory {
                 title: Localized.Perpetual.autoClose,
                 description: Localized.Info.Perpetual.AutoClose.description,
                 image: .image(Images.Logo.logo),
-                button: .url(Docs.url(.perpetualsFundingRate)) // TODO: - update when available
+                button: .url(Docs.url(.perpetualsAutoclose))
             )
         }
     }

--- a/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
+++ b/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
@@ -161,7 +161,7 @@ public struct InfoSheetModelFactory {
                 title: Localized.Perpetual.autoClose,
                 description: Localized.Info.Perpetual.AutoClose.description,
                 image: .image(Images.Logo.logo),
-                button: .url(Docs.url(.perpetualsAutoClose))
+                button: .url(Docs.url(.perpetualsAutoclose))
             )
         }
     }

--- a/Features/Perpetuals/Package.swift
+++ b/Features/Perpetuals/Package.swift
@@ -50,7 +50,9 @@ let package = Package(
         .target(
             name: "PerpetualsTestKit",
             dependencies: [
+                "Perpetuals",
                 "Primitives",
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
             ],
             path: "TestKit"
         ),

--- a/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
@@ -38,14 +38,14 @@ public struct AutocloseScene: View {
             }
 
             AutocloseInputSection(
-                inputModel: $model.takeProfitInput,
+                inputModel: $model.input.takeProfit,
                 sectionModel: model.takeProfitModel,
                 field: Field.takeProfit,
                 focusedField: $focusedField
             )
 
             AutocloseInputSection(
-                inputModel: $model.stopLossInput,
+                inputModel: $model.input.stopLoss,
                 sectionModel: model.stopLossModel,
                 field: Field.stopLoss,
                 focusedField: $focusedField
@@ -54,7 +54,7 @@ public struct AutocloseScene: View {
             Section {
                 StateButton(
                     text: Localized.Transfer.confirm,
-                    type: .primary(),
+                    type: model.confirmButtonType,
                     action: model.onSelectConfirm
                 )
                 .frame(maxWidth: .infinity)
@@ -80,9 +80,8 @@ public struct AutocloseScene: View {
             .background(Colors.grayBackground)
         }
         .navigationTitle(model.title)
-        .onAppear(perform: model.onAppear)
         .onChange(of: focusedField, model.onChangeFocusField)
-        .onChange(of: model.focusField, onChangeFocus)
+        .onChange(of: model.input.focusField, onChangeFocus)
     }
 }
 

--- a/Features/Perpetuals/Sources/Types/AutocloseEstimator.swift
+++ b/Features/Perpetuals/Sources/Types/AutocloseEstimator.swift
@@ -3,13 +3,20 @@
 import Foundation
 import Primitives
 
-struct AutocloseEstimator {
-    let entryPrice: Double
-    let positionSize: Double
-    let direction: PerpetualDirection
-    let leverage: UInt8
+public struct AutocloseEstimator {
+    public let entryPrice: Double
+    public let positionSize: Double
+    public let direction: PerpetualDirection
+    public let leverage: UInt8
 
-    func calculateTargetPriceFromROE(roePercent: Int, type: TpslType) -> Double {
+    public init(entryPrice: Double, positionSize: Double, direction: PerpetualDirection, leverage: UInt8) {
+        self.entryPrice = entryPrice
+        self.positionSize = positionSize
+        self.direction = direction
+        self.leverage = leverage
+    }
+
+    public func calculateTargetPriceFromROE(roePercent: Int, type: TpslType) -> Double {
         let priceChangePercent = Double(roePercent) / Double(leverage) / 100.0
 
         return switch (direction, type) {
@@ -18,17 +25,17 @@ struct AutocloseEstimator {
         }
     }
 
-    func calculatePnL(price: Double) -> Double {
+    public func calculatePnL(price: Double) -> Double {
         let side: Double = direction == .long ? 1 : -1
         return side * (price - entryPrice) * abs(positionSize)
     }
 
-    func calculatePriceChangePercent(price: Double) -> Double {
+    public func calculatePriceChangePercent(price: Double) -> Double {
         let rawChange = ((price - entryPrice) / entryPrice) * 100
         return direction == .short ? -rawChange : rawChange
     }
 
-    func calculateROE(price: Double) -> Double {
+    public func calculateROE(price: Double) -> Double {
         let priceChangePercent = calculatePriceChangePercent(price: price)
         return priceChangePercent * Double(leverage)
     }

--- a/Features/Perpetuals/Sources/Types/AutocloseField.swift
+++ b/Features/Perpetuals/Sources/Types/AutocloseField.swift
@@ -2,7 +2,7 @@
 
 import Primitives
 
-struct AutocloseField {
+public struct AutocloseField {
     let price: Double?
     let originalPrice: Double?
     let formattedPrice: String?
@@ -16,4 +16,12 @@ struct AutocloseField {
     var shouldSet: Bool { isValid && hasChanged }
     var shouldUpdate: Bool { shouldSet || isCleared }
     var shouldCancel: Bool { isCleared || (shouldSet && hasExisting) }
+
+    public init(price: Double?, originalPrice: Double?, formattedPrice: String?, isValid: Bool, orderId: UInt64?) {
+        self.price = price
+        self.originalPrice = originalPrice
+        self.formattedPrice = formattedPrice
+        self.isValid = isValid
+        self.orderId = orderId
+    }
 }

--- a/Features/Perpetuals/Sources/Types/AutocloseInput.swift
+++ b/Features/Perpetuals/Sources/Types/AutocloseInput.swift
@@ -1,0 +1,50 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import PrimitivesComponents
+
+@MainActor
+struct AutocloseInput {
+    var takeProfit: InputValidationViewModel
+    var stopLoss: InputValidationViewModel
+    var focusField: AutocloseScene.Field?
+
+    var focused: InputValidationViewModel? {
+        switch focusField {
+        case .takeProfit: takeProfit
+        case .stopLoss: stopLoss
+        case nil: nil
+        }
+    }
+
+    var focusedType: TpslType? {
+        switch focusField {
+        case .takeProfit: .takeProfit
+        case .stopLoss: .stopLoss
+        case nil: nil
+        }
+    }
+
+    func field(
+        type: TpslType,
+        price: Double?,
+        originalPrice: Double?,
+        formattedPrice: String?,
+        orderId: UInt64?
+    ) -> AutocloseField {
+        let input = type == .takeProfit ? takeProfit : stopLoss
+        return AutocloseField(
+            price: price,
+            originalPrice: originalPrice,
+            formattedPrice: formattedPrice,
+            isValid: price != nil && input.isValid,
+            orderId: orderId
+        )
+    }
+
+    func update() {
+        takeProfit.update()
+        stopLoss.update()
+    }
+}

--- a/Features/Perpetuals/Sources/Types/AutocloseModifyBuilder.swift
+++ b/Features/Perpetuals/Sources/Types/AutocloseModifyBuilder.swift
@@ -3,14 +3,14 @@
 import Foundation
 import Primitives
 
-struct AutocloseModifyBuilder {
+public struct AutocloseModifyBuilder {
     private let position: PerpetualPositionData
 
-    init(position: PerpetualPositionData) {
+    public init(position: PerpetualPositionData) {
         self.position = position
     }
 
-    func canBuild(takeProfit: AutocloseField, stopLoss: AutocloseField) -> Bool {
+    public func canBuild(takeProfit: AutocloseField, stopLoss: AutocloseField) -> Bool {
         let hasChanges = takeProfit.shouldUpdate || stopLoss.shouldUpdate
         let takeProfitValid = takeProfit.price == nil || takeProfit.isValid
         let stopLossValid = stopLoss.price == nil || stopLoss.isValid
@@ -18,7 +18,7 @@ struct AutocloseModifyBuilder {
         return hasChanges && takeProfitValid && stopLossValid
     }
 
-    func build(
+    public func build(
         assetIndex: Int32,
         takeProfit: AutocloseField,
         stopLoss: AutocloseField

--- a/Features/Perpetuals/Sources/ViewModels/AutocloseSceneViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/AutocloseSceneViewModel.swift
@@ -84,7 +84,6 @@ public final class AutocloseSceneViewModel {
     var marketPriceText: String { currencyFormatter.string(position.perpetual.price) }
 
     var takeProfitModel: AutocloseViewModel { autocloseModel(type: .takeProfit, price: takeProfitPrice) }
-
     var stopLossModel: AutocloseViewModel { autocloseModel(type: .stopLoss, price: stopLossPrice) }
 
     var positionViewModel: PerpetualPositionViewModel { PerpetualPositionViewModel(position) }

--- a/Features/Perpetuals/Sources/ViewModels/AutocloseViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/AutocloseViewModel.swift
@@ -8,14 +8,14 @@ import Primitives
 import Formatters
 import Components
 
-struct AutocloseViewModel {
+public struct AutocloseViewModel {
     private let type: TpslType
     private let price: Double?
     private let estimator: AutocloseEstimator
     private let currencyFormatter: CurrencyFormatter
     private let percentFormatter: CurrencyFormatter
 
-    init(
+    public init(
         type: TpslType,
         price: Double?,
         estimator: AutocloseEstimator,
@@ -29,21 +29,21 @@ struct AutocloseViewModel {
         self.percentFormatter = percentFormatter
     }
 
-    var priceTitle: String { Localized.Asset.price }
+    public var priceTitle: String { Localized.Asset.price }
 
-    var title: String {
+    public var title: String {
         switch type {
         case .takeProfit: Localized.Perpetual.AutoClose.takeProfit
         case .stopLoss: Localized.Perpetual.AutoClose.stopLoss
         }
     }
 
-    var profitTitle: String {
+    public var profitTitle: String {
         let isProfit = price.map { estimator.calculatePnL(price: $0) >= 0 } ?? (type == .takeProfit)
         return isProfit ? Localized.Perpetual.AutoClose.expectedProfit : Localized.Perpetual.AutoClose.expectedLoss
     }
 
-    var expectedPnL: String {
+    public var expectedPnL: String {
         guard let price else { return "-" }
         let pnl = estimator.calculatePnL(price: price)
         let roe = estimator.calculateROE(price: price)
@@ -55,7 +55,7 @@ struct AutocloseViewModel {
         return "\(sign)\(amount) (\(percentText))"
     }
 
-    var pnlColor: Color {
+    public var pnlColor: Color {
         guard let price else { return Colors.secondaryText }
         let pnl = estimator.calculatePnL(price: price)
         return PriceChangeColor.color(for: pnl)

--- a/Features/Perpetuals/TestKit/AutocloseEstimator+TestKit.swift
+++ b/Features/Perpetuals/TestKit/AutocloseEstimator+TestKit.swift
@@ -1,0 +1,21 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import Perpetuals
+
+public extension AutocloseEstimator {
+    static func mock(
+        entryPrice: Double = 100.0,
+        positionSize: Double = 10.0,
+        direction: PerpetualDirection = .long,
+        leverage: UInt8 = 5
+    ) -> AutocloseEstimator {
+        AutocloseEstimator(
+            entryPrice: entryPrice,
+            positionSize: positionSize,
+            direction: direction,
+            leverage: leverage
+        )
+    }
+}

--- a/Features/Perpetuals/TestKit/AutocloseField+TestKit.swift
+++ b/Features/Perpetuals/TestKit/AutocloseField+TestKit.swift
@@ -1,0 +1,22 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Perpetuals
+
+public extension AutocloseField {
+    static func mock(
+        price: Double? = nil,
+        originalPrice: Double? = nil,
+        formattedPrice: String? = nil,
+        isValid: Bool = false,
+        orderId: UInt64? = nil
+    ) -> AutocloseField {
+        AutocloseField(
+            price: price,
+            originalPrice: originalPrice,
+            formattedPrice: formattedPrice,
+            isValid: isValid,
+            orderId: orderId
+        )
+    }
+}

--- a/Features/Perpetuals/TestKit/AutocloseModifyBuilder+TestKit.swift
+++ b/Features/Perpetuals/TestKit/AutocloseModifyBuilder+TestKit.swift
@@ -1,0 +1,13 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import Perpetuals
+
+public extension AutocloseModifyBuilder {
+    static func mock(
+        position: PerpetualPositionData = .mock()
+    ) -> AutocloseModifyBuilder {
+        AutocloseModifyBuilder(position: position)
+    }
+}

--- a/Features/Perpetuals/TestKit/AutocloseViewModel+TestKit.swift
+++ b/Features/Perpetuals/TestKit/AutocloseViewModel+TestKit.swift
@@ -1,0 +1,24 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import Formatters
+import Perpetuals
+
+public extension AutocloseViewModel {
+    static func mock(
+        type: TpslType = .takeProfit,
+        price: Double? = nil,
+        estimator: AutocloseEstimator = .mock(),
+        currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencyCode: "USD"),
+        percentFormatter: CurrencyFormatter = .percent
+    ) -> AutocloseViewModel {
+        AutocloseViewModel(
+            type: type,
+            price: price,
+            estimator: estimator,
+            currencyFormatter: currencyFormatter,
+            percentFormatter: percentFormatter
+        )
+    }
+}

--- a/Features/Perpetuals/TestKit/PerpetualPositionData+TestKit.swift
+++ b/Features/Perpetuals/TestKit/PerpetualPositionData+TestKit.swift
@@ -1,0 +1,19 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import PrimitivesTestKit
+
+public extension PerpetualPositionData {
+    static func mock(
+        perpetual: Perpetual = .mock(),
+        asset: Asset = .mock(),
+        position: PerpetualPosition = .mock()
+    ) -> PerpetualPositionData {
+        PerpetualPositionData(
+            perpetual: perpetual,
+            asset: asset,
+            position: position
+        )
+    }
+}

--- a/Features/Perpetuals/Tests/AutocloseEstimatorTests.swift
+++ b/Features/Perpetuals/Tests/AutocloseEstimatorTests.swift
@@ -1,0 +1,56 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Primitives
+@testable import Perpetuals
+
+struct AutocloseEstimatorTests {
+
+    @Test
+    func calculatePnLLong() {
+        let estimator = AutocloseEstimator(entryPrice: 100.0, positionSize: 10.0, direction: .long, leverage: 5)
+
+        #expect(estimator.calculatePnL(price: 110.0) == 100.0)
+        #expect(estimator.calculatePnL(price: 90.0) == -100.0)
+    }
+
+    @Test
+    func calculatePnLShort() {
+        let estimator = AutocloseEstimator(entryPrice: 100.0, positionSize: -10.0, direction: .short, leverage: 5)
+
+        #expect(estimator.calculatePnL(price: 90.0) == 100.0)
+        #expect(estimator.calculatePnL(price: 110.0) == -100.0)
+    }
+
+    @Test
+    func calculateROELong() {
+        let estimator = AutocloseEstimator(entryPrice: 100.0, positionSize: 10.0, direction: .long, leverage: 5)
+
+        #expect(estimator.calculateROE(price: 110.0) == 50.0)
+        #expect(estimator.calculateROE(price: 90.0) == -50.0)
+    }
+
+    @Test
+    func calculateROEShort() {
+        let estimator = AutocloseEstimator(entryPrice: 100.0, positionSize: -10.0, direction: .short, leverage: 5)
+
+        #expect(estimator.calculateROE(price: 90.0) == 50.0)
+        #expect(estimator.calculateROE(price: 110.0) == -50.0)
+    }
+
+    @Test
+    func calculateTargetPriceFromROELong() {
+        let estimator = AutocloseEstimator(entryPrice: 100.0, positionSize: 10.0, direction: .long, leverage: 5)
+
+        #expect(abs(estimator.calculateTargetPriceFromROE(roePercent: 50, type: .takeProfit) - 110.0) < 0.0001)
+        #expect(abs(estimator.calculateTargetPriceFromROE(roePercent: 50, type: .stopLoss) - 90.0) < 0.0001)
+    }
+
+    @Test
+    func calculateTargetPriceFromROEShort() {
+        let estimator = AutocloseEstimator(entryPrice: 100.0, positionSize: -10.0, direction: .short, leverage: 5)
+
+        #expect(abs(estimator.calculateTargetPriceFromROE(roePercent: 50, type: .takeProfit) - 90.0) < 0.0001)
+        #expect(abs(estimator.calculateTargetPriceFromROE(roePercent: 50, type: .stopLoss) - 110.0) < 0.0001)
+    }
+}

--- a/Features/Perpetuals/Tests/AutocloseFieldTests.swift
+++ b/Features/Perpetuals/Tests/AutocloseFieldTests.swift
@@ -1,0 +1,87 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import PerpetualsTestKit
+
+@testable import Perpetuals
+
+struct AutocloseFieldTests {
+
+    @Test
+    func hasChanged() {
+        #expect(AutocloseField.mock(price: 100.0, originalPrice: 100.0).hasChanged == false)
+        #expect(AutocloseField.mock(price: 100.0, originalPrice: 90.0).hasChanged == true)
+        #expect(AutocloseField.mock(price: nil, originalPrice: 100.0).hasChanged == true)
+        #expect(AutocloseField.mock(price: nil, originalPrice: nil).hasChanged == false)
+    }
+
+    @Test
+    func isCleared() {
+        #expect(AutocloseField.mock(price: nil, originalPrice: 100.0).isCleared == true)
+        #expect(AutocloseField.mock(price: 100.0, originalPrice: 100.0).isCleared == false)
+        #expect(AutocloseField.mock(price: nil, originalPrice: nil).isCleared == false)
+    }
+
+    @Test
+    func hasExisting() {
+        #expect(AutocloseField.mock(originalPrice: 100.0).hasExisting == true)
+        #expect(AutocloseField.mock(originalPrice: nil).hasExisting == false)
+    }
+
+    @Test
+    func shouldSet() {
+        #expect(AutocloseField.mock(price: 110.0, originalPrice: 100.0, isValid: true).shouldSet == true)
+        #expect(AutocloseField.mock(price: 100.0, originalPrice: 100.0, isValid: true).shouldSet == false)
+        #expect(AutocloseField.mock(price: 110.0, originalPrice: 100.0, isValid: false).shouldSet == false)
+        #expect(AutocloseField.mock(price: nil, originalPrice: 100.0, isValid: false).shouldSet == false)
+    }
+
+    @Test
+    func shouldUpdate() {
+        #expect(AutocloseField.mock(price: 110.0, originalPrice: 100.0, isValid: true).shouldUpdate == true)
+        #expect(AutocloseField.mock(price: nil, originalPrice: 100.0, isValid: true).shouldUpdate == true)
+        #expect(AutocloseField.mock(price: 100.0, originalPrice: 100.0, isValid: true).shouldUpdate == false)
+    }
+
+    @Test
+    func shouldCancel() {
+        #expect(AutocloseField.mock(price: nil, originalPrice: 100.0, isValid: true).shouldCancel == true)
+        #expect(AutocloseField.mock(price: 110.0, originalPrice: 100.0, isValid: true).shouldCancel == true)
+        #expect(AutocloseField.mock(price: 110.0, originalPrice: nil, isValid: true).shouldCancel == false)
+        #expect(AutocloseField.mock(price: 100.0, originalPrice: 100.0, isValid: true).shouldCancel == false)
+    }
+
+    @Test
+    func newOrderNoExisting() {
+        let field = AutocloseField.mock(price: 100.0, originalPrice: nil, isValid: true)
+        #expect(field.shouldSet == true)
+        #expect(field.shouldCancel == false)
+        #expect(field.shouldUpdate == true)
+    }
+
+    @Test
+    func updateExistingOrder() {
+        let field = AutocloseField.mock(price: 110.0, originalPrice: 100.0, isValid: true)
+        #expect(field.shouldSet == true)
+        #expect(field.shouldCancel == true)
+        #expect(field.shouldUpdate == true)
+    }
+
+    @Test
+    func clearExistingOrder() {
+        let field = AutocloseField.mock(price: nil, originalPrice: 100.0, isValid: false)
+        #expect(field.shouldSet == false)
+        #expect(field.shouldCancel == true)
+        #expect(field.shouldUpdate == true)
+        #expect(field.isCleared == true)
+    }
+
+    @Test
+    func noChanges() {
+        let field = AutocloseField.mock(price: 100.0, originalPrice: 100.0, isValid: true)
+        #expect(field.shouldSet == false)
+        #expect(field.shouldCancel == false)
+        #expect(field.shouldUpdate == false)
+        #expect(field.hasChanged == false)
+    }
+}

--- a/Features/Perpetuals/Tests/AutocloseModifyBuilderTests.swift
+++ b/Features/Perpetuals/Tests/AutocloseModifyBuilderTests.swift
@@ -1,0 +1,160 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Primitives
+import PerpetualsTestKit
+
+@testable import Perpetuals
+
+struct AutocloseModifyBuilderTests {
+
+    @Test
+    func canBuildWithValidChanges() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(price: 110.0, originalPrice: 100.0, isValid: true)
+        let stopLoss = AutocloseField.mock(price: nil, originalPrice: nil, isValid: false)
+
+        #expect(builder.canBuild(takeProfit: takeProfit, stopLoss: stopLoss) == true)
+    }
+
+    @Test
+    func cannotBuildWithoutChanges() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(price: 100.0, originalPrice: 100.0, isValid: true)
+        let stopLoss = AutocloseField.mock(price: 90.0, originalPrice: 90.0, isValid: true)
+
+        #expect(builder.canBuild(takeProfit: takeProfit, stopLoss: stopLoss) == false)
+    }
+
+    @Test
+    func cannotBuildWithInvalidPrice() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(price: 110.0, originalPrice: 100.0, isValid: false)
+        let stopLoss = AutocloseField.mock(price: nil, originalPrice: nil, isValid: false)
+
+        #expect(builder.canBuild(takeProfit: takeProfit, stopLoss: stopLoss) == false)
+    }
+
+    @Test
+    func canBuildWithClearedField() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(price: nil, originalPrice: 100.0, isValid: false)
+        let stopLoss = AutocloseField.mock(price: nil, originalPrice: nil, isValid: false)
+
+        #expect(builder.canBuild(takeProfit: takeProfit, stopLoss: stopLoss) == true)
+    }
+
+    @Test
+    func buildWithNewTakeProfitOnly() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(price: 110.0, originalPrice: nil, formattedPrice: "110.0", isValid: true)
+        let stopLoss = AutocloseField.mock(price: nil, originalPrice: nil, isValid: false)
+
+        let result = builder.build(assetIndex: 5, takeProfit: takeProfit, stopLoss: stopLoss)
+
+        #expect(result.count == 1)
+        if case .tpsl(let order) = result[0] {
+            #expect(order.takeProfit == "110.0")
+            #expect(order.stopLoss == nil)
+        }
+    }
+
+    @Test
+    func buildWithNewStopLossOnly() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(price: nil, originalPrice: nil, isValid: false)
+        let stopLoss = AutocloseField.mock(price: 90.0, originalPrice: nil, formattedPrice: "90.0", isValid: true)
+
+        let result = builder.build(assetIndex: 5, takeProfit: takeProfit, stopLoss: stopLoss)
+
+        #expect(result.count == 1)
+        if case .tpsl(let order) = result[0] {
+            #expect(order.takeProfit == nil)
+            #expect(order.stopLoss == "90.0")
+        }
+    }
+
+    @Test
+    func buildWithBothOrders() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(price: 110.0, originalPrice: nil, formattedPrice: "110.0", isValid: true)
+        let stopLoss = AutocloseField.mock(price: 90.0, originalPrice: nil, formattedPrice: "90.0", isValid: true)
+
+        let result = builder.build(assetIndex: 5, takeProfit: takeProfit, stopLoss: stopLoss)
+
+        #expect(result.count == 1)
+        if case .tpsl(let order) = result[0] {
+            #expect(order.takeProfit == "110.0")
+            #expect(order.stopLoss == "90.0")
+        }
+    }
+
+    @Test
+    func buildWithCancelOnly() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(price: nil, originalPrice: 100.0, isValid: false, orderId: 12345)
+        let stopLoss = AutocloseField.mock(price: nil, originalPrice: nil, isValid: false)
+
+        let result = builder.build(assetIndex: 5, takeProfit: takeProfit, stopLoss: stopLoss)
+
+        #expect(result.count == 1)
+        if case .cancel(let cancels) = result[0] {
+            #expect(cancels.count == 1)
+            #expect(cancels[0].orderId == 12345)
+        }
+    }
+
+    @Test
+    func buildWithCancelAndSet() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(
+            price: 120.0,
+            originalPrice: 100.0,
+            formattedPrice: "120.0",
+            isValid: true,
+            orderId: 12345
+        )
+        let stopLoss = AutocloseField.mock(price: nil, originalPrice: nil, isValid: false)
+
+        let result = builder.build(assetIndex: 5, takeProfit: takeProfit, stopLoss: stopLoss)
+
+        #expect(result.count == 2)
+        if case .cancel(let cancels) = result[0] {
+            #expect(cancels.count == 1)
+            #expect(cancels[0].orderId == 12345)
+        }
+        if case .tpsl(let order) = result[1] {
+            #expect(order.takeProfit == "120.0")
+        }
+    }
+
+    @Test
+    func buildWithCancelBothAndSetBoth() {
+        let builder = AutocloseModifyBuilder.mock()
+        let takeProfit = AutocloseField.mock(
+            price: 120.0,
+            originalPrice: 100.0,
+            formattedPrice: "120.0",
+            isValid: true,
+            orderId: 12345
+        )
+        let stopLoss = AutocloseField.mock(
+            price: 80.0,
+            originalPrice: 90.0,
+            formattedPrice: "80.0",
+            isValid: true,
+            orderId: 67890
+        )
+
+        let result = builder.build(assetIndex: 5, takeProfit: takeProfit, stopLoss: stopLoss)
+
+        #expect(result.count == 2)
+        if case .cancel(let cancels) = result[0] {
+            #expect(cancels.count == 2)
+        }
+        if case .tpsl(let order) = result[1] {
+            #expect(order.takeProfit == "120.0")
+            #expect(order.stopLoss == "80.0")
+        }
+    }
+}

--- a/Features/Perpetuals/Tests/AutocloseViewModelTests.swift
+++ b/Features/Perpetuals/Tests/AutocloseViewModelTests.swift
@@ -1,0 +1,47 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Primitives
+import PerpetualsTestKit
+
+@testable import Perpetuals
+
+struct AutocloseViewModelTests {
+
+    @Test
+    func title() {
+        #expect(AutocloseViewModel.mock(type: .takeProfit).title == "Take profit")
+        #expect(AutocloseViewModel.mock(type: .stopLoss).title == "Stop loss")
+    }
+
+    @Test
+    func profitTitleTakeProfit() {
+        #expect(AutocloseViewModel.mock(type: .takeProfit, price: nil).profitTitle == "Expected profit")
+        #expect(AutocloseViewModel.mock(type: .takeProfit, price: 110.0).profitTitle == "Expected profit")
+        #expect(AutocloseViewModel.mock(type: .takeProfit, price: 90.0).profitTitle == "Expected loss")
+    }
+
+    @Test
+    func profitTitleStopLoss() {
+        #expect(AutocloseViewModel.mock(type: .stopLoss, price: nil).profitTitle == "Expected loss")
+        #expect(AutocloseViewModel.mock(type: .stopLoss, price: 90.0).profitTitle == "Expected loss")
+        #expect(AutocloseViewModel.mock(type: .stopLoss, price: 110.0).profitTitle == "Expected profit")
+    }
+
+    @Test
+    func expectedPnLNil() {
+        #expect(AutocloseViewModel.mock(price: nil).expectedPnL == "-")
+    }
+
+    @Test
+    func expectedPnLProfit() {
+        let model = AutocloseViewModel.mock(price: 110.0)
+        #expect(model.expectedPnL == "+$100.00 (+50.00%)")
+    }
+
+    @Test
+    func expectedPnLLoss() {
+        let model = AutocloseViewModel.mock(price: 90.0)
+        #expect(model.expectedPnL == "-$100.00 (-50.00%)")
+    }
+}

--- a/Features/Transfer/Sources/ViewModels/TransferDataViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/TransferDataViewModel.swift
@@ -55,7 +55,7 @@ struct TransferDataViewModel {
             case .close: Localized.Perpetual.closePosition
             case .increase(let data): PerpetualDirectionViewModel(direction: data.direction).increaseTitle
             case .reduce(let data): PerpetualDirectionViewModel(direction: data.positionDirection).reduceTitle
-            case .modify: "Modify Position" // TODO: - Add localization
+            case .modify: Localized.Perpetual.modifyPosition
             }
         }
     }

--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -813,6 +813,8 @@ public enum Localized {
     public static let marketPrice = Localized.tr("Localizable", "perpetual.market_price", fallback: "Market Price")
     /// Modify
     public static let modify = Localized.tr("Localizable", "perpetual.modify", fallback: "Modify")
+    /// Modify Position
+    public static let modifyPosition = Localized.tr("Localizable", "perpetual.modify_position", fallback: "Modify Position")
     /// Open %@
     public static func openDirection(_ p1: Any) -> String {
       return Localized.tr("Localizable", "perpetual.open_direction", String(describing: p1), fallback: "Open %@")
@@ -838,8 +840,8 @@ public enum Localized {
       public static let expectedLoss = Localized.tr("Localizable", "perpetual.auto_close.expected_loss", fallback: "Expected loss")
       /// Expected profit
       public static let expectedProfit = Localized.tr("Localizable", "perpetual.auto_close.expected_profit", fallback: "Expected profit")
-      /// Stop Loss
-      public static let stopLoss = Localized.tr("Localizable", "perpetual.auto_close.stop_loss", fallback: "Stop Loss")
+      /// Stop loss
+      public static let stopLoss = Localized.tr("Localizable", "perpetual.auto_close.stop_loss", fallback: "Stop loss")
       /// Take profit
       public static let takeProfit = Localized.tr("Localizable", "perpetual.auto_close.take_profit", fallback: "Take profit")
     }

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "الربح المتوقع";
 "perpetual.auto_close.expected_loss" = "الخسارة المتوقعة";
 "perpetual.modify_position" = "تعديل الموضع";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "وقف الخسارة";

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "إغلاق تلقائي";
 "info.perpetual.auto_close.description" = "أغلق مركزك تلقائيًا عند مستويات الأسعار المحددة. جني الأرباح يُثبّت الأرباح، ووقف الخسارة يحدّ من الخسائر.";
 "perpetual.auto_close.take_profit" = "جني الأرباح";
-"perpetual.auto_close.stop_loss" = "وقف الخسارة";
 "perpetual.market_price" = "سعر السوق";
 "perpetual.increase_direction" = "زيادة %@";
 "perpetual.reduce_direction" = "تقليل %@";
 "perpetual.auto_close.expected_profit" = "الربح المتوقع";
 "perpetual.auto_close.expected_loss" = "الخسارة المتوقعة";
+"perpetual.modify_position" = "تعديل الموضع";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "স্বয়ংক্রিয়ভাবে বন্ধ করুন";
 "info.perpetual.auto_close.description" = "নির্ধারিত মূল্য স্তরে আপনার পজিশন স্বয়ংক্রিয়ভাবে বন্ধ করুন। টেক প্রফিট লাভকে আটকে রাখে, স্টপ লস লোকসানকে সীমাবদ্ধ করে।";
 "perpetual.auto_close.take_profit" = "লাভ নিন";
-"perpetual.auto_close.stop_loss" = "স্টপ লস";
 "perpetual.market_price" = "বাজার মূল্য";
 "perpetual.increase_direction" = "%@ বৃদ্ধি করুন";
 "perpetual.reduce_direction" = "%@ কমাও";
 "perpetual.auto_close.expected_profit" = "প্রত্যাশিত লাভ";
 "perpetual.auto_close.expected_loss" = "প্রত্যাশিত ক্ষতি";
+"perpetual.modify_position" = "অবস্থান পরিবর্তন করুন";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "প্রত্যাশিত লাভ";
 "perpetual.auto_close.expected_loss" = "প্রত্যাশিত ক্ষতি";
 "perpetual.modify_position" = "অবস্থান পরিবর্তন করুন";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "স্টপ লস";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Očekávaný zisk";
 "perpetual.auto_close.expected_loss" = "Očekávaná ztráta";
 "perpetual.modify_position" = "Upravit pozici";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Zastavit ztrátu";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Automatické zavření";
 "info.perpetual.auto_close.description" = "Automaticky uzavřete svou pozici na stanovených cenových úrovních. Funkce Take Profit blokuje zisky, Stop Loss omezuje ztráty.";
 "perpetual.auto_close.take_profit" = "Zisk z prodeje";
-"perpetual.auto_close.stop_loss" = "Zastavit ztrátu";
 "perpetual.market_price" = "Tržní cena";
 "perpetual.increase_direction" = "Zvýšení %@";
 "perpetual.reduce_direction" = "Snížit %@";
 "perpetual.auto_close.expected_profit" = "Očekávaný zisk";
 "perpetual.auto_close.expected_loss" = "Očekávaná ztráta";
+"perpetual.modify_position" = "Upravit pozici";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Forventet fortjeneste";
 "perpetual.auto_close.expected_loss" = "Forventet tab";
 "perpetual.modify_position" = "Rediger position";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Stop-loss";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Automatisk lukning";
 "info.perpetual.auto_close.description" = "Luk automatisk din position ved fastsatte prisniveauer. Take Profit låser gevinster, Stop Loss begrænser tab.";
 "perpetual.auto_close.take_profit" = "Tag profit";
-"perpetual.auto_close.stop_loss" = "Stop-loss";
 "perpetual.market_price" = "Markedspris";
 "perpetual.increase_direction" = "Forøgelse %@";
 "perpetual.reduce_direction" = "Reducer %@";
 "perpetual.auto_close.expected_profit" = "Forventet fortjeneste";
 "perpetual.auto_close.expected_loss" = "Forventet tab";
+"perpetual.modify_position" = "Rediger position";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Automatisches Schließen";
 "info.perpetual.auto_close.description" = "Schließen Sie Ihre Position automatisch bei festgelegten Preisniveaus. Take Profit sichert Gewinne, Stop Loss begrenzt Verluste.";
 "perpetual.auto_close.take_profit" = "Gewinn mitnehmen";
-"perpetual.auto_close.stop_loss" = "Stop-Loss";
 "perpetual.market_price" = "Marktpreis";
 "perpetual.increase_direction" = "Erhöhung %@";
 "perpetual.reduce_direction" = "Reduzieren %@";
 "perpetual.auto_close.expected_profit" = "Erwarteter Gewinn";
 "perpetual.auto_close.expected_loss" = "Erwarteter Verlust";
+"perpetual.modify_position" = "Position ändern";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Erwarteter Gewinn";
 "perpetual.auto_close.expected_loss" = "Erwarteter Verlust";
 "perpetual.modify_position" = "Position ändern";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Stop-Loss";

--- a/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Auto Close";
 "info.perpetual.auto_close.description" = "Automatically close your position at set price levels. Take Profit locks in gains, Stop Loss limits losses.";
 "perpetual.auto_close.take_profit" = "Take profit";
-"perpetual.auto_close.stop_loss" = "Stop Loss";
 "perpetual.market_price" = "Market Price";
 "perpetual.increase_direction" = "Increase %@";
 "perpetual.reduce_direction" = "Reduce %@";
 "perpetual.auto_close.expected_profit" = "Expected profit";
 "perpetual.auto_close.expected_loss" = "Expected loss";
+"perpetual.modify_position" = "Modify Position";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Cierre automático";
 "info.perpetual.auto_close.description" = "Cierra tu posición automáticamente a precios establecidos. El Take Profit fija las ganancias y el Stop Loss limita las pérdidas.";
 "perpetual.auto_close.take_profit" = "Tomar ganancias";
-"perpetual.auto_close.stop_loss" = "Stop Loss";
 "perpetual.market_price" = "Precio de mercado";
 "perpetual.increase_direction" = "Incremento %@";
 "perpetual.reduce_direction" = "Reducir %@";
 "perpetual.auto_close.expected_profit" = "Beneficio esperado";
 "perpetual.auto_close.expected_loss" = "Pérdida esperada";
+"perpetual.modify_position" = "Modificar posición";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "بستن خودکار";
 "info.perpetual.auto_close.description" = "موقعیت خود را به طور خودکار در سطوح قیمت تعیین شده ببندید. برداشت سود، سود را قفل می‌کند، و توقف ضرر، ضرر را محدود می‌کند.";
 "perpetual.auto_close.take_profit" = "سود ببرید";
-"perpetual.auto_close.stop_loss" = "حد ضرر";
 "perpetual.market_price" = "قیمت بازار";
 "perpetual.increase_direction" = "افزایش %@";
 "perpetual.reduce_direction" = "کاهش %@";
 "perpetual.auto_close.expected_profit" = "سود مورد انتظار";
 "perpetual.auto_close.expected_loss" = "ضرر مورد انتظار";
+"perpetual.modify_position" = "تغییر موقعیت";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "سود مورد انتظار";
 "perpetual.auto_close.expected_loss" = "ضرر مورد انتظار";
 "perpetual.modify_position" = "تغییر موقعیت";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "حد ضرر";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Auto Close";
 "info.perpetual.auto_close.description" = "Awtomatikong isara ang iyong posisyon sa nakatakdang antas ng presyo. Kumuha ng Profit lock sa mga nadagdag, Stop Loss limitahan pagkalugi.";
 "perpetual.auto_close.take_profit" = "Kumuha ng tubo";
-"perpetual.auto_close.stop_loss" = "Stop Loss";
 "perpetual.market_price" = "Presyo ng Market";
 "perpetual.increase_direction" = "Dagdagan %@";
 "perpetual.reduce_direction" = "Bawasan ang %@";
 "perpetual.auto_close.expected_profit" = "Inaasahang tubo";
 "perpetual.auto_close.expected_loss" = "Inaasahang pagkawala";
+"perpetual.modify_position" = "Baguhin ang Posisyon";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Inaasahang tubo";
 "perpetual.auto_close.expected_loss" = "Inaasahang pagkawala";
 "perpetual.modify_position" = "Baguhin ang Posisyon";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Itigil ang pagkawala";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Fermeture automatique";
 "info.perpetual.auto_close.description" = "Clôturez automatiquement votre position à des niveaux de prix définis. Le Take Profit verrouille vos gains, tandis que le Stop Loss limite vos pertes.";
 "perpetual.auto_close.take_profit" = "Prendre des bénéfices";
-"perpetual.auto_close.stop_loss" = "Stop Loss";
 "perpetual.market_price" = "Prix du marché";
 "perpetual.increase_direction" = "Augmentation %@";
 "perpetual.reduce_direction" = "Réduire %@";
 "perpetual.auto_close.expected_profit" = "Bénéfice attendu";
 "perpetual.auto_close.expected_loss" = "Perte attendue";
+"perpetual.modify_position" = "Modifier la position";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "סגירה אוטומטית";
 "info.perpetual.auto_close.description" = "סגור אוטומטית את הפוזיציה שלך ברמות מחיר קבועות. Take Profit נועל רווחים, Stop Loss מגביל הפסדים.";
 "perpetual.auto_close.take_profit" = "קח רווח";
-"perpetual.auto_close.stop_loss" = "סטופ לוס";
 "perpetual.market_price" = "מחיר שוק";
 "perpetual.increase_direction" = "הגדלה %@";
 "perpetual.reduce_direction" = "צמצום %@";
 "perpetual.auto_close.expected_profit" = "רווח צפוי";
 "perpetual.auto_close.expected_loss" = "הפסד צפוי";
+"perpetual.modify_position" = "שינוי מיקום";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "רווח צפוי";
 "perpetual.auto_close.expected_loss" = "הפסד צפוי";
 "perpetual.modify_position" = "שינוי מיקום";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "עצירת הפסד";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "अपेक्षित लाभ";
 "perpetual.auto_close.expected_loss" = "अपेक्षित हानि";
 "perpetual.modify_position" = "स्थिति संशोधित करें";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "झड़ने बंद";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "स्वतः बंद";
 "info.perpetual.auto_close.description" = "निर्धारित मूल्य स्तरों पर अपनी पोजीशन स्वचालित रूप से बंद करें। टेक प्रॉफिट लाभ को लॉक करता है, स्टॉप लॉस नुकसान को सीमित करता है।";
 "perpetual.auto_close.take_profit" = "लाभ लेने के";
-"perpetual.auto_close.stop_loss" = "झड़ने बंद";
 "perpetual.market_price" = "बाजार कीमत";
 "perpetual.increase_direction" = "%@ बढ़ाएँ";
 "perpetual.reduce_direction" = "%@ कम करें";
 "perpetual.auto_close.expected_profit" = "अपेक्षित लाभ";
 "perpetual.auto_close.expected_loss" = "अपेक्षित हानि";
+"perpetual.modify_position" = "स्थिति संशोधित करें";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Tutup Otomatis";
 "info.perpetual.auto_close.description" = "Tutup posisi Anda secara otomatis pada level harga yang ditentukan. Take Profit mengunci keuntungan, Stop Loss membatasi kerugian.";
 "perpetual.auto_close.take_profit" = "Ambil untung";
-"perpetual.auto_close.stop_loss" = "Hentikan Kerugian";
 "perpetual.market_price" = "Harga Pasar";
 "perpetual.increase_direction" = "Peningkatan %@";
 "perpetual.reduce_direction" = "Kurangi %@";
 "perpetual.auto_close.expected_profit" = "Keuntungan yang diharapkan";
 "perpetual.auto_close.expected_loss" = "Kerugian yang diharapkan";
+"perpetual.modify_position" = "Ubah Posisi";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Keuntungan yang diharapkan";
 "perpetual.auto_close.expected_loss" = "Kerugian yang diharapkan";
 "perpetual.modify_position" = "Ubah Posisi";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Hentikan kerugian";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Chiusura automatica";
 "info.perpetual.auto_close.description" = "Chiudi automaticamente la tua posizione a livelli di prezzo prestabiliti. Il Take Profit blocca i guadagni, mentre lo Stop Loss limita le perdite.";
 "perpetual.auto_close.take_profit" = "Prendi profitto";
-"perpetual.auto_close.stop_loss" = "Stop Loss";
 "perpetual.market_price" = "Prezzo di mercato";
 "perpetual.increase_direction" = "Aumenta %@";
 "perpetual.reduce_direction" = "Riduci %@";
 "perpetual.auto_close.expected_profit" = "Profitto previsto";
 "perpetual.auto_close.expected_loss" = "Perdita prevista";
+"perpetual.modify_position" = "Modifica posizione";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "自動閉じる";
 "info.perpetual.auto_close.description" = "設定した価格レベルでポジションを自動的に決済します。テイクプロフィットで利益を確定し、ストップロスで損失を制限します。";
 "perpetual.auto_close.take_profit" = "利益確定";
-"perpetual.auto_close.stop_loss" = "ストップロス";
 "perpetual.market_price" = "市場価格";
 "perpetual.increase_direction" = "%@を増やす";
 "perpetual.reduce_direction" = "%@を減らす";
 "perpetual.auto_close.expected_profit" = "予想利益";
 "perpetual.auto_close.expected_loss" = "予想損失";
+"perpetual.modify_position" = "位置の変更";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "予想利益";
 "perpetual.auto_close.expected_loss" = "予想損失";
 "perpetual.modify_position" = "位置の変更";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "ストップロス";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "예상 이익";
 "perpetual.auto_close.expected_loss" = "예상 손실";
 "perpetual.modify_position" = "위치 수정";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "손절매";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "자동 닫기";
 "info.perpetual.auto_close.description" = "설정된 가격 수준에서 자동으로 포지션을 청산합니다. 이익실현(Take Profit)은 수익을 확정하고, 손절매(Stop Loss)는 손실을 제한합니다.";
 "perpetual.auto_close.take_profit" = "이익 실현";
-"perpetual.auto_close.stop_loss" = "손절매";
 "perpetual.market_price" = "시장 가격";
 "perpetual.increase_direction" = "%@ 증가";
 "perpetual.reduce_direction" = "%@ 줄이기";
 "perpetual.auto_close.expected_profit" = "예상 이익";
 "perpetual.auto_close.expected_loss" = "예상 손실";
+"perpetual.modify_position" = "위치 수정";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Auto Tutup";
 "info.perpetual.auto_close.description" = "Tutup kedudukan anda secara automatik pada tahap harga yang ditetapkan. Ambil Untung mengunci keuntungan, Henti Kerugian menghadkan kerugian.";
 "perpetual.auto_close.take_profit" = "Ambil untung";
-"perpetual.auto_close.stop_loss" = "Hentikan Kehilangan";
 "perpetual.market_price" = "Harga Pasaran";
 "perpetual.increase_direction" = "Tingkatkan %@";
 "perpetual.reduce_direction" = "Kurangkan %@";
 "perpetual.auto_close.expected_profit" = "Keuntungan yang dijangkakan";
 "perpetual.auto_close.expected_loss" = "Kerugian yang dijangkakan";
+"perpetual.modify_position" = "Ubahsuai Kedudukan";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Keuntungan yang dijangkakan";
 "perpetual.auto_close.expected_loss" = "Kerugian yang dijangkakan";
 "perpetual.modify_position" = "Ubahsuai Kedudukan";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Hentikan kerugian";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Automatisch sluiten";
 "info.perpetual.auto_close.description" = "Sluit uw positie automatisch op ingestelde prijsniveaus. Take Profit vergrendelt winsten, Stop Loss beperkt verliezen.";
 "perpetual.auto_close.take_profit" = "Winst nemen";
-"perpetual.auto_close.stop_loss" = "Stop-loss";
 "perpetual.market_price" = "Marktprijs";
 "perpetual.increase_direction" = "Verhogen %@";
 "perpetual.reduce_direction" = "Verminder %@";
 "perpetual.auto_close.expected_profit" = "Verwachte winst";
 "perpetual.auto_close.expected_loss" = "Verwacht verlies";
+"perpetual.modify_position" = "Positie wijzigen";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Verwachte winst";
 "perpetual.auto_close.expected_loss" = "Verwacht verlies";
 "perpetual.modify_position" = "Positie wijzigen";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Stop-loss";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Oczekiwany zysk";
 "perpetual.auto_close.expected_loss" = "Oczekiwana strata";
 "perpetual.modify_position" = "Modyfikuj pozycję";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Stop-loss";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Automatyczne zamykanie";
 "info.perpetual.auto_close.description" = "Automatycznie zamykaj pozycje po ustalonych cenach. Take Profit zabezpiecza zyski, Stop Loss ogranicza straty.";
 "perpetual.auto_close.take_profit" = "Weź zysk";
-"perpetual.auto_close.stop_loss" = "Stop Loss";
 "perpetual.market_price" = "Cena rynkowa";
 "perpetual.increase_direction" = "Zwiększ %@";
 "perpetual.reduce_direction" = "Zmniejsz %@";
 "perpetual.auto_close.expected_profit" = "Oczekiwany zysk";
 "perpetual.auto_close.expected_loss" = "Oczekiwana strata";
+"perpetual.modify_position" = "Modyfikuj pozycję";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Fechamento automático";
 "info.perpetual.auto_close.description" = "Feche sua posição automaticamente em níveis de preço definidos. O Take Profit garante os ganhos, o Stop Loss limita as perdas.";
 "perpetual.auto_close.take_profit" = "Obter lucro";
-"perpetual.auto_close.stop_loss" = "Stop Loss";
 "perpetual.market_price" = "Preço de mercado";
 "perpetual.increase_direction" = "Aumentar %@";
 "perpetual.reduce_direction" = "Reduzir %@";
 "perpetual.auto_close.expected_profit" = "Lucro esperado";
 "perpetual.auto_close.expected_loss" = "Perda esperada";
+"perpetual.modify_position" = "Modificar posição";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Închidere automată";
 "info.perpetual.auto_close.description" = "Închide automat poziția la nivelurile de preț stabilite. Funcția Take Profit blochează câștigurile, iar funcția Stop Loss limitează pierderile.";
 "perpetual.auto_close.take_profit" = "Ia profit";
-"perpetual.auto_close.stop_loss" = "Stop Loss";
 "perpetual.market_price" = "Prețul de piață";
 "perpetual.increase_direction" = "Creștere %@";
 "perpetual.reduce_direction" = "Reduceți %@";
 "perpetual.auto_close.expected_profit" = "Profit așteptat";
 "perpetual.auto_close.expected_loss" = "Pierderea așteptată";
+"perpetual.modify_position" = "Modificare poziție";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Автоматическое закрытие";
 "info.perpetual.auto_close.description" = "Автоматически закрывает позицию по достижении заданного уровня цены. Тейк-профит фиксирует прибыль, стоп-лосс ограничивает убытки.";
 "perpetual.auto_close.take_profit" = "Тейк-профит";
-"perpetual.auto_close.stop_loss" = "Стоп-лосс";
 "perpetual.market_price" = "Рыночная цена";
 "perpetual.increase_direction" = "Увеличение %@";
 "perpetual.reduce_direction" = "Уменьшить %@";
 "perpetual.auto_close.expected_profit" = "Ожидаемая прибыль";
 "perpetual.auto_close.expected_loss" = "Ожидаемые потери";
+"perpetual.modify_position" = "Изменить позицию";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Ожидаемая прибыль";
 "perpetual.auto_close.expected_loss" = "Ожидаемые потери";
 "perpetual.modify_position" = "Изменить позицию";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Стоп-лосс";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Faida inayotarajiwa";
 "perpetual.auto_close.expected_loss" = "Hasara inayotarajiwa";
 "perpetual.modify_position" = "Rekebisha Nafasi";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Acha hasara";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Funga Kiotomatiki";
 "info.perpetual.auto_close.description" = "Funga msimamo wako kiotomatiki katika viwango vya bei vilivyowekwa. Chukua kufuli za Faida katika faida, Stop Loss mipaka hasara.";
 "perpetual.auto_close.take_profit" = "Chukua faida";
-"perpetual.auto_close.stop_loss" = "Acha Hasara";
 "perpetual.market_price" = "Bei ya Soko";
 "perpetual.increase_direction" = "Ongeza %@";
 "perpetual.reduce_direction" = "Punguza %@";
 "perpetual.auto_close.expected_profit" = "Faida inayotarajiwa";
 "perpetual.auto_close.expected_loss" = "Hasara inayotarajiwa";
+"perpetual.modify_position" = "Rekebisha Nafasi";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "กำไรที่คาดหวัง";
 "perpetual.auto_close.expected_loss" = "การสูญเสียที่คาดว่าจะเกิดขึ้น";
 "perpetual.modify_position" = "ปรับเปลี่ยนตำแหน่ง";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "สต็อปลอส";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "ปิดอัตโนมัติ";
 "info.perpetual.auto_close.description" = "ปิดสถานะของคุณโดยอัตโนมัติเมื่อถึงระดับราคาที่กำหนด Take Profit ล็อกกำไร Stop Loss จำกัดการขาดทุน";
 "perpetual.auto_close.take_profit" = "รับผลกำไร";
-"perpetual.auto_close.stop_loss" = "สต็อปลอส";
 "perpetual.market_price" = "ราคาตลาด";
 "perpetual.increase_direction" = "เพิ่ม %@";
 "perpetual.reduce_direction" = "ลด %@";
 "perpetual.auto_close.expected_profit" = "กำไรที่คาดหวัง";
 "perpetual.auto_close.expected_loss" = "การสูญเสียที่คาดว่าจะเกิดขึ้น";
+"perpetual.modify_position" = "ปรับเปลี่ยนตำแหน่ง";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Otomatik Kapatma";
 "info.perpetual.auto_close.description" = "Pozisyonunuzu belirlenen fiyat seviyelerinde otomatik olarak kapatın. Kâr Al özelliği kazançlarınızı sabitler, Zarar Durdur özelliği ise kayıplarınızı sınırlar.";
 "perpetual.auto_close.take_profit" = "Kar al";
-"perpetual.auto_close.stop_loss" = "Zarar Durdurma";
 "perpetual.market_price" = "Piyasa Fiyatı";
 "perpetual.increase_direction" = "%@ yi artırın";
 "perpetual.reduce_direction" = "%@ azalt";
 "perpetual.auto_close.expected_profit" = "Beklenen kar";
 "perpetual.auto_close.expected_loss" = "Beklenen kayıp";
+"perpetual.modify_position" = "Pozisyonu Değiştir";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Beklenen kar";
 "perpetual.auto_close.expected_loss" = "Beklenen kayıp";
 "perpetual.modify_position" = "Pozisyonu Değiştir";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Zarar durdurma";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Очікуваний прибуток";
 "perpetual.auto_close.expected_loss" = "Очікувані втрати";
 "perpetual.modify_position" = "Змінити позицію";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Стоп-лосс";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Автоматичне закриття";
 "info.perpetual.auto_close.description" = "Автоматично закривайте свою позицію за встановленими ціновими рівнями. Тейк-профіт фіксує прибутки, а стоп-лос обмежує збитки.";
 "perpetual.auto_close.take_profit" = "Зафіксуйте прибуток";
-"perpetual.auto_close.stop_loss" = "Стоп-лосс";
 "perpetual.market_price" = "Ринкова ціна";
 "perpetual.increase_direction" = "Збільшити %@";
 "perpetual.reduce_direction" = "Зменшити %@";
 "perpetual.auto_close.expected_profit" = "Очікуваний прибуток";
 "perpetual.auto_close.expected_loss" = "Очікувані втрати";
+"perpetual.modify_position" = "Змінити позицію";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "متوقع منافع";
 "perpetual.auto_close.expected_loss" = "متوقع نقصان";
 "perpetual.modify_position" = "پوزیشن میں ترمیم کریں۔";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "نقصان کو روکیں۔";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "آٹو بند";
 "info.perpetual.auto_close.description" = "اپنی پوزیشن کو سیٹ قیمت کی سطحوں پر خودکار طور پر بند کریں۔ منافع میں منافع کے تالے لیں، نقصان کو روکیں نقصانات کو محدود کریں۔";
 "perpetual.auto_close.take_profit" = "منافع لے لو";
-"perpetual.auto_close.stop_loss" = "نقصان کو روکیں۔";
 "perpetual.market_price" = "بازاری قیمت";
 "perpetual.increase_direction" = "اضافہ کریں %@";
 "perpetual.reduce_direction" = "کم کریں %@";
 "perpetual.auto_close.expected_profit" = "متوقع منافع";
 "perpetual.auto_close.expected_loss" = "متوقع نقصان";
+"perpetual.modify_position" = "پوزیشن میں ترمیم کریں۔";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "Tự động đóng";
 "info.perpetual.auto_close.description" = "Tự động đóng vị thế của bạn ở mức giá đã đặt. Chốt lời khóa lợi nhuận, Cắt lỗ hạn chế thua lỗ.";
 "perpetual.auto_close.take_profit" = "Kiếm lợi nhuận";
-"perpetual.auto_close.stop_loss" = "Dừng lỗ";
 "perpetual.market_price" = "Giá thị trường";
 "perpetual.increase_direction" = "Tăng %@";
 "perpetual.reduce_direction" = "Giảm %@";
 "perpetual.auto_close.expected_profit" = "Lợi nhuận dự kiến";
 "perpetual.auto_close.expected_loss" = "Dự kiến mất mát";
+"perpetual.modify_position" = "Sửa đổi vị trí";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "Lợi nhuận dự kiến";
 "perpetual.auto_close.expected_loss" = "Dự kiến mất mát";
 "perpetual.modify_position" = "Sửa đổi vị trí";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "Dừng lỗ";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "自动关闭";
 "info.perpetual.auto_close.description" = "以设定的价格自动平仓。止盈锁定收益，止损限制损失。";
 "perpetual.auto_close.take_profit" = "获利";
-"perpetual.auto_close.stop_loss" = "止损";
 "perpetual.market_price" = "市价";
 "perpetual.increase_direction" = "增加%@";
 "perpetual.reduce_direction" = "减少%@";
 "perpetual.auto_close.expected_profit" = "预期利润";
 "perpetual.auto_close.expected_loss" = "预期损失";
+"perpetual.modify_position" = "修改位置";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "预期利润";
 "perpetual.auto_close.expected_loss" = "预期损失";
 "perpetual.modify_position" = "修改位置";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "止损";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -496,9 +496,10 @@
 "perpetual.auto_close" = "自動關閉";
 "info.perpetual.auto_close.description" = "以設定的價格自動平倉。停盈鎖定收益，停損限制損失。";
 "perpetual.auto_close.take_profit" = "獲利";
-"perpetual.auto_close.stop_loss" = "停損";
 "perpetual.market_price" = "市價";
 "perpetual.increase_direction" = "增加%@";
 "perpetual.reduce_direction" = "減少%@";
 "perpetual.auto_close.expected_profit" = "預期利潤";
 "perpetual.auto_close.expected_loss" = "預期損失";
+"perpetual.modify_position" = "修改位置";
+"perpetual.auto_close.stop_loss" = "Stop loss";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -502,4 +502,4 @@
 "perpetual.auto_close.expected_profit" = "預期利潤";
 "perpetual.auto_close.expected_loss" = "預期損失";
 "perpetual.modify_position" = "修改位置";
-"perpetual.auto_close.stop_loss" = "Stop loss";
+"perpetual.auto_close.stop_loss" = "停損";


### PR DESCRIPTION
Refactored autoclose-related types to be public, introduced AutocloseInput for improved input handling, and updated AutocloseSceneViewModel to use the new structure.
Added comprehensive unit tests and test kit mocks for AutocloseEstimator, AutocloseField, AutocloseModifyBuilder, and AutocloseViewModel.
Updated localization for 'Modify Position' and standardized 'Stop loss' capitalization across languages.
Changed the InfoSheetModelFactory to use the correct documentation URL for perpetuals autoclose. Also removed an unnecessary blank line in AutocloseSceneViewModel for code cleanliness.
