### PR TITLE
Apply consistent gray background to sheet presentations

### DIFF
--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -68,12 +68,14 @@ public struct ConfirmTransferScene: View {
                     NavigationStack {
                         SwapDetailsView(model: Bindable(model))
                             .presentationDetentsForCurrentDeviceSize(expandable: true)
+                            .presentationBackground(Colors.grayBackground)
                     }
                 }
             case .perpetualDetails(let model):
                 NavigationStack {
                     PerpetualDetailsView(model: model)
                         .presentationDetentsForCurrentDeviceSize(expandable: true)
+                        .presentationBackground(Colors.grayBackground)
                 }
             }
         }

--- a/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
@@ -184,6 +184,7 @@ struct SelectAssetSceneNavigationStack: View {
             }
             .presentationDetentsForCurrentDeviceSize(expandable: true)
             .presentationDragIndicator(.visible)
+            .presentationBackground(Colors.grayBackground)
         }
     }
 }

--- a/Gem/Navigation/Swap/SwapNavigationView.swift
+++ b/Gem/Navigation/Swap/SwapNavigationView.swift
@@ -7,6 +7,7 @@ import InfoSheet
 import Swap
 import Assets
 import AssetsService
+import Style
 
 struct SwapNavigationView: View {
     @Environment(\.viewModelFactory) private var viewModelFactory
@@ -42,6 +43,7 @@ struct SwapNavigationView: View {
                         NavigationStack {
                             SwapDetailsView(model: Bindable(model))
                                 .presentationDetentsForCurrentDeviceSize(expandable: true)
+                                .presentationBackground(Colors.grayBackground)
                         }
                     }
                 }

--- a/Gem/Navigation/Transactions/TransactionsNavigationStack.swift
+++ b/Gem/Navigation/Transactions/TransactionsNavigationStack.swift
@@ -83,6 +83,7 @@ struct TransactionsNavigationStack: View {
                     }
                     .presentationDetentsForCurrentDeviceSize(expandable: true)
                     .presentationDragIndicator(.visible)
+                    .presentationBackground(Colors.grayBackground)
                 }
                 .sheet(item: $model.isPresentingSelectAssetType) {
                     SelectAssetSceneNavigationStack(

--- a/Packages/Components/Sources/ListViews/SelectableListNavigationStack.swift
+++ b/Packages/Components/Sources/ListViews/SelectableListNavigationStack.swift
@@ -41,7 +41,7 @@ public struct SelectableListNavigationStack<ViewModel: SelectableListAdoptable &
             .navigationTitle(model.title)
             .navigationBarTitleDisplayMode(.inline)
             .presentationDetentsForCurrentDeviceSize(expandable: true)
-            .background(Colors.grayBackground)
+            .presentationBackground(Colors.grayBackground)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(model.doneTitle) {

--- a/Packages/PrimitivesComponents/Sources/Scenes/NetworkFeeSheet.swift
+++ b/Packages/PrimitivesComponents/Sources/Scenes/NetworkFeeSheet.swift
@@ -3,6 +3,7 @@
 import SwiftUI
 import Components
 import Primitives
+import Style
 
 public struct NetworkFeeSheet: View {
     private let model: NetworkFeeSceneViewModel
@@ -15,6 +16,7 @@ public struct NetworkFeeSheet: View {
         NavigationStack {
             NetworkFeeScene(model: model)
                 .presentationDetents(presentationDetent)
+                .presentationBackground(Colors.grayBackground)
         }
     }
     


### PR DESCRIPTION
Replaces or adds .presentationBackground(Colors.grayBackground) to various sheet and navigation stack views for a unified appearance across ConfirmTransferScene, SelectAssetSceneNavigationStack, SwapNavigationView, TransactionsNavigationStack, SelectableListNavigationStack, and NetworkFeeSheet.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1396

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-17 at 13 01 28" src="https://github.com/user-attachments/assets/f43abc4b-8629-4a9c-bda5-1783385b3d43" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-17 at 13 01 31" src="https://github.com/user-attachments/assets/68869b94-badb-4874-b78f-3e0ebc0975c1" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-17 at 13 01 37" src="https://github.com/user-attachments/assets/faf690c2-1385-422e-a1b9-ebf169fc2a9b" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-17 at 13 01 40" src="https://github.com/user-attachments/assets/2d34adb8-352e-4de7-978b-5deb8eb1c514" />
