### PR TITLE
Add and apply listEmpty button style

### DIFF
--- a/Features/FiatConnect/Sources/Scenes/FiatScene.swift
+++ b/Features/FiatConnect/Sources/Scenes/FiatScene.swift
@@ -82,7 +82,7 @@ extension FiatScene {
                             model.onSelectTypeAmount()
                         }
                         .font(.subheadline.weight(.semibold))
-                        .buttonStyle(model.typeAmountButtonStyle)
+                        .buttonStyle(.listEmpty())
                         .if(model.input.type == .buy) {
                             $0.overlay {
                                 RandomOverlayView()

--- a/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
+++ b/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
@@ -107,13 +107,6 @@ public final class FiatSceneViewModel {
         }
     }
 
-    var typeAmountButtonStyle: ColorButtonStyle {
-        switch input.type {
-        case .buy: .amount()
-        case .sell: .lightGray(paddingHorizontal: .small, paddingVertical: .small)
-        }
-    }
-
     var asset: Asset { assetAddress.asset }
     var assetImage: AssetImage { AssetIdViewModel(assetId: asset.id).assetImage }
 

--- a/Features/Transfer/Sources/Scenes/AmountScene.swift
+++ b/Features/Transfer/Sources/Scenes/AmountScene.swift
@@ -41,7 +41,7 @@ struct AmountScene: View {
                                 model.maxTitle,
                                 action: model.onSelectMaxButton
                             )
-                            .buttonStyle(.lightGray(paddingHorizontal: .medium, paddingVertical: .small))
+                            .buttonStyle(.listEmpty(paddingHorizontal: .medium, paddingVertical: .small))
                             .fixedSize()
                         }
                     )

--- a/Packages/Style/Sources/Button/ColorButtonStyle.swift
+++ b/Packages/Style/Sources/Button/ColorButtonStyle.swift
@@ -204,6 +204,21 @@ extension ButtonStyle where Self == ColorButtonStyle {
             glassEffect: glassEffect
         )
     }
+
+    public static func listEmpty(
+        paddingHorizontal: CGFloat = .small,
+        paddingVertical: CGFloat = .small,
+        cornerRadius: CGFloat = .small,
+        glassEffect: GlassEffectSettings = .isInteractive
+    ) -> ColorButtonStyle {
+        ColorButtonStyle(
+            palette: .listEmpty,
+            paddingHorizontal: paddingHorizontal,
+            paddingVertical: paddingVertical,
+            cornerRadius: cornerRadius,
+            glassEffect: glassEffect
+        )
+    }
 }
 
 // MARK: – Previews

--- a/Packages/Style/Sources/Button/Types/ButtonStylePallete.swift
+++ b/Packages/Style/Sources/Button/Types/ButtonStylePallete.swift
@@ -86,7 +86,7 @@ extension ButtonStylePalette {
     static let amount = ButtonStylePalette(
         foreground: Colors.black,
         foregroundPressed: Colors.blackFaded,
-        background: Colors.grayVeryLight,
+        background: Colors.Empty.listEmpty,
         backgroundPressed: Colors.grayVeryLightFaded,
         backgroundDisabled: Colors.grayVeryLightFaded
     )
@@ -115,6 +115,13 @@ extension ButtonStylePalette {
         backgroundDisabled: Colors.greenFadedLight
     )
 
+    static let listEmpty = ButtonStylePalette(
+        foreground: Colors.gray,
+        foregroundPressed: Colors.black,
+        background: Colors.Empty.listEmpty,
+        backgroundPressed: Colors.Empty.listEmpty,
+        backgroundDisabled: Colors.Empty.listEmpty
+    )
 }
 // MARK: – Preview
 private struct PaletteSwatch: View {

--- a/Packages/Style/Sources/Colors.swift
+++ b/Packages/Style/Sources/Colors.swift
@@ -28,6 +28,7 @@ extension Colors {
         public static let imageBackground = Color(.quaternaryLabel)
         public static let image = Color.dynamicColor("#767A81")
         public static let buttonsBackground = Color(.quaternaryLabel)
+        public static let listEmpty = Color(.secondarySystemFill)
     }
 }
 


### PR DESCRIPTION
Introduces a new ColorButtonStyle 'listEmpty' with a corresponding palette and color in the style package. Updates FiatScene and AmountScene to use the new style, and removes the now-unnecessary typeAmountButtonStyle from FiatSceneViewModel.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1382

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-17 at 17 31 23" src="https://github.com/user-attachments/assets/b7522753-151f-44a7-8cd4-630fc300f210" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-17 at 17 31 27" src="https://github.com/user-attachments/assets/3b4198bb-1960-492e-a928-7013fef0c458" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-17 at 17 31 35" src="https://github.com/user-attachments/assets/3dbc4148-1114-4930-a6df-21086e6d2214" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-17 at 17 31 40" src="https://github.com/user-attachments/assets/14b46a50-f431-4185-9c87-7059d5661bde" />
