### PR TITLE
Update onboarding banner text

### DIFF
--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -166,10 +166,10 @@ public enum Localized {
       public static let title = Localized.tr("Localizable", "banner.enable_notifications.title", fallback: "Enable Notifications")
     }
     public enum Onboarding {
-      /// Buy or Receive crypto to your wallet to get started
-      public static let description = Localized.tr("Localizable", "banner.onboarding.description", fallback: "Buy or Receive crypto to your wallet to get started")
-      /// Welcome to the Gem Family
-      public static let title = Localized.tr("Localizable", "banner.onboarding.title", fallback: "Welcome to the Gem Family")
+      /// Buy or Receive crypto to get started
+      public static let description = Localized.tr("Localizable", "banner.onboarding.description", fallback: "Buy or Receive crypto to get started")
+      /// Your wallet is ready
+      public static let title = Localized.tr("Localizable", "banner.onboarding.title", fallback: "Your wallet is ready")
     }
     public enum Stake {
       /// Earn %@ rewards on your stake while you sleep.

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "يُعدِّل";
 "perpetual.reduce_position" = "تقليل الموضع";
 "perpetual.increase_position" = "زيادة الموقف";
-"banner.onboarding.title" = "مرحبًا بك في عائلة Gem";
-"banner.onboarding.description" = "قم بشراء أو استلام العملات المشفرة في محفظتك للبدء";
+"banner.onboarding.title" = "محفظتك جاهزة";
+"banner.onboarding.description" = "قم بشراء أو استلام العملات المشفرة للبدء";
 "info.stake.reserved.title" = "محجوز لرسوم الشبكة";
 "info.stake.reserved.description" = "يبقى مبلغ صغير في محفظتك لتغطية الرسوم الخاصة بالعمليات مثل إلغاء المراهنة أو المطالبة بالمكافآت.";
 "perpetual.open_direction" = "افتح %@";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "পরিবর্তন করুন";
 "perpetual.reduce_position" = "অবস্থান হ্রাস করুন";
 "perpetual.increase_position" = "অবস্থান বৃদ্ধি করুন";
-"banner.onboarding.title" = "Gem পরিবারে স্বাগতম";
-"banner.onboarding.description" = "শুরু করতে আপনার ওয়ালেটে ক্রিপ্টো কিনুন বা গ্রহণ করুন";
+"banner.onboarding.title" = "তোমার মানিব্যাগ প্রস্তুত।";
+"banner.onboarding.description" = "শুরু করতে ক্রিপ্টো কিনুন বা গ্রহণ করুন";
 "info.stake.reserved.title" = "নেটওয়ার্ক ফি এর জন্য সংরক্ষিত";
 "info.stake.reserved.description" = "পুরষ্কার দাবি করা বা স্টক খোলার মতো ক্রিয়াকলাপের ফি মেটাতে আপনার ওয়ালেটে অল্প পরিমাণ টাকা থেকে যায়।";
 "perpetual.open_direction" = "%@ খুলুন";
@@ -508,4 +508,4 @@
 "secret_phrase.screenshot_detected.description" = "স্ক্রিনশটগুলি অন্যান্য অ্যাপের কাছে অ্যাক্সেসযোগ্য হতে পারে, যদি এইভাবে সংরক্ষণ করা হয় তবে এগুলি আপনার গোপন বাক্যাংশকে ঝুঁকির মধ্যে ফেলতে পারে।";
 "secret_phrase.content_hidden.description" = "স্ক্রিন রেকর্ডিংয়ের সময় লুকানো কন্টেন্ট";
 "asset.verification.verified" = "যাচাইকৃত";
-"errors.connections.malicious_origin" = "This connection comes from an untrusted source.";
+"errors.connections.malicious_origin" = "এই সংযোগটি একটি অবিশ্বস্ত উৎস থেকে আসে।";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Upravit";
 "perpetual.reduce_position" = "Snížit pozici";
 "perpetual.increase_position" = "Zvýšit pozici";
-"banner.onboarding.title" = "Vítejte v rodině Gem";
-"banner.onboarding.description" = "Kupte si kryptoměny nebo je přijměte do své peněženky a začněte";
+"banner.onboarding.title" = "Vaše peněženka je připravena";
+"banner.onboarding.description" = "Kupte si nebo přijměte kryptoměny a začněte";
 "info.stake.reserved.title" = "Rezervováno pro síťový poplatek";
 "info.stake.reserved.description" = "Malá částka vám zůstane v peněžence na pokrytí poplatků za operace, jako je odstraňování sázek nebo nárokování odměn.";
 "perpetual.open_direction" = "Otevřít %@";
@@ -508,4 +508,4 @@
 "secret_phrase.screenshot_detected.description" = "Snímky obrazovky mohou být přístupné jiným aplikacím, pokud se uloží tímto způsobem, mohou ohrozit vaši tajnou frázi.";
 "secret_phrase.content_hidden.description" = "Obsah skrytý během nahrávání obrazovky";
 "asset.verification.verified" = "Ověřeno";
-"errors.connections.malicious_origin" = "This connection comes from an untrusted source.";
+"errors.connections.malicious_origin" = "Toto spojení pochází z nedůvěryhodného zdroje.";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Modificere";
 "perpetual.reduce_position" = "Reducer position";
 "perpetual.increase_position" = "Øg position";
-"banner.onboarding.title" = "Velkommen til Gem-familien";
-"banner.onboarding.description" = "Køb eller modtag krypto til din wallet for at komme i gang";
+"banner.onboarding.title" = "Din tegnebog er klar";
+"banner.onboarding.description" = "Køb eller modtag krypto for at komme i gang";
 "info.stake.reserved.title" = "Reserveret til netværksgebyr";
 "info.stake.reserved.description" = "Et lille beløb forbliver i din pung til at dække gebyrer for operationer som at fjerne indsatser eller gøre krav på belønninger.";
 "perpetual.open_direction" = "Åbn %@";
@@ -508,4 +508,4 @@
 "secret_phrase.screenshot_detected.description" = "Skærmbilleder kan være tilgængelige for andre apps, og de kan bringe din hemmelige frase i fare, hvis de gemmes på denne måde.";
 "secret_phrase.content_hidden.description" = "Indhold skjult under skærmoptagelse";
 "asset.verification.verified" = "Bekræftet";
-"errors.connections.malicious_origin" = "This connection comes from an untrusted source.";
+"errors.connections.malicious_origin" = "Denne forbindelse kommer fra en upålidelig kilde.";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Ändern";
 "perpetual.reduce_position" = "Position reduzieren";
 "perpetual.increase_position" = "Position erhöhen";
-"banner.onboarding.title" = "Willkommen in der Gem-Familie";
-"banner.onboarding.description" = "Kaufen oder erhalten Sie Kryptowährungen in Ihr Wallet, um loszulegen";
+"banner.onboarding.title" = "Ihre Brieftasche ist bereit";
+"banner.onboarding.description" = "Kaufen oder empfangen Sie Kryptowährung, um loszulegen";
 "info.stake.reserved.title" = "Reserviert für Netzwerkgebühr";
 "info.stake.reserved.description" = "Ein kleiner Betrag verbleibt in Ihrem Wallet, um Gebühren für Vorgänge wie das Aufheben der Absteckung oder das Einfordern von Prämien zu decken.";
 "perpetual.open_direction" = "Öffnen %@";

--- a/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Modify";
 "perpetual.reduce_position" = "Reduce Position";
 "perpetual.increase_position" = "Increase Position";
-"banner.onboarding.title" = "Welcome to the Gem Family";
-"banner.onboarding.description" = "Buy or Receive crypto to your wallet to get started";
+"banner.onboarding.title" = "Your wallet is ready";
+"banner.onboarding.description" = "Buy or Receive crypto to get started";
 "info.stake.reserved.title" = "Reserved for Network Fee";
 "info.stake.reserved.description" = "A small amount stays in your wallet to cover fees for operations like unstaking or claiming rewards.";
 "perpetual.open_direction" = "Open %@";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Modificar";
 "perpetual.reduce_position" = "Reducir posición";
 "perpetual.increase_position" = "Aumentar posición";
-"banner.onboarding.title" = "Bienvenido a la familia Gem";
-"banner.onboarding.description" = "Compra o recibe criptomonedas en tu billetera para comenzar";
+"banner.onboarding.title" = "Tu billetera está lista";
+"banner.onboarding.description" = "Compra o recibe criptomonedas para empezar";
 "info.stake.reserved.title" = "Reservado para comisión de red";
 "info.stake.reserved.description" = "Una pequeña cantidad permanece en tu billetera para cubrir las tarifas de operaciones como dejar de apostar o reclamar recompensas.";
 "perpetual.open_direction" = "Abrir %@";
@@ -508,4 +508,4 @@
 "secret_phrase.screenshot_detected.description" = "Las capturas de pantalla pueden ser accesibles a otras aplicaciones y, si se guardan de esta manera, pueden poner en riesgo tu frase secreta.";
 "secret_phrase.content_hidden.description" = "Contenido oculto durante la grabación de pantalla";
 "asset.verification.verified" = "Verificado";
-"errors.connections.malicious_origin" = "This connection comes from an untrusted source.";
+"errors.connections.malicious_origin" = "Esta conexión proviene de una fuente no confiable.";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "اصلاح";
 "perpetual.reduce_position" = "کاهش موقعیت";
 "perpetual.increase_position" = "افزایش موقعیت";
-"banner.onboarding.title" = "به خانواده Gem خوش آمدید";
-"banner.onboarding.description" = "برای شروع، ارز دیجیتال را در کیف پول خود خریداری یا دریافت کنید";
+"banner.onboarding.title" = "کیف پول شما آماده است";
+"banner.onboarding.description" = "برای شروع، کریپتو بخرید یا دریافت کنید";
 "info.stake.reserved.title" = "برای هزینه شبکه رزرو شده است";
 "info.stake.reserved.description" = "مقدار کمی در کیف پول شما باقی می‌ماند تا هزینه‌های عملیاتی مانند برداشت از حساب یا دریافت پاداش را پوشش دهد.";
 "perpetual.open_direction" = "باز کردن %@";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Baguhin";
 "perpetual.reduce_position" = "Bawasan ang Posisyon";
 "perpetual.increase_position" = "Taasan ang Posisyon";
-"banner.onboarding.title" = "Maligayang pagdating sa Gem Family";
-"banner.onboarding.description" = "Bumili o Tumanggap ng crypto sa iyong wallet para makapagsimula";
+"banner.onboarding.title" = "Handa na ang iyong wallet";
+"banner.onboarding.description" = "Bumili o Tumanggap ng crypto para makapagsimula";
 "info.stake.reserved.title" = "Nakalaan para sa Bayad ng Network";
 "info.stake.reserved.description" = "May maliit na halaga ang nananatili sa iyong wallet para mabayaran ang mga bayarin para sa mga operasyon tulad ng pag-unstaking o pag-claim ng mga reward.";
 "perpetual.open_direction" = "Buksan ang %@";
@@ -508,4 +508,4 @@
 "secret_phrase.screenshot_detected.description" = "Maaaring ma-access ang mga screenshot sa iba pang apps, maaari nilang ilagay sa panganib ang iyong sikretong parirala kung ise-save sa ganitong paraan.";
 "secret_phrase.content_hidden.description" = "Nakatago ang content habang nagre-record ng screen";
 "asset.verification.verified" = "Na-verify";
-"errors.connections.malicious_origin" = "This connection comes from an untrusted source.";
+"errors.connections.malicious_origin" = "Ang koneksyon na ito ay nagmula sa isang hindi pinagkakatiwalaang pinagmulan.";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Modifier";
 "perpetual.reduce_position" = "Réduire la position";
 "perpetual.increase_position" = "Augmenter la position";
-"banner.onboarding.title" = "Bienvenue dans la famille Gem";
-"banner.onboarding.description" = "Achetez ou recevez des crypto-monnaies sur votre portefeuille pour commencer";
+"banner.onboarding.title" = "Votre portefeuille est prêt";
+"banner.onboarding.description" = "Achetez ou recevez des cryptomonnaies pour commencer.";
 "info.stake.reserved.title" = "Réservé aux frais de réseau";
 "info.stake.reserved.description" = "Une petite somme reste dans votre portefeuille pour couvrir les frais d'opérations telles que le déblocage ou la réclamation de récompenses.";
 "perpetual.open_direction" = "Ouvrir %@";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "לְשַׁנוֹת";
 "perpetual.reduce_position" = "הקטן את המיקום";
 "perpetual.increase_position" = "הגדלת מיקום";
-"banner.onboarding.title" = "ברוך הבא למשפחת Gem";
-"banner.onboarding.description" = "קנה או קבל קריפטו לארנק שלך כדי להתחיל";
+"banner.onboarding.title" = "הארנק שלך מוכן";
+"banner.onboarding.description" = "קנה או קבל קריפטו כדי להתחיל";
 "info.stake.reserved.title" = "שמור עבור דמי רשת";
 "info.stake.reserved.description" = "סכום קטן נשאר בארנק שלך כדי לכסות עמלות עבור פעולות כמו ביטול הפקדה או תביעת תגמולים.";
 "perpetual.open_direction" = "פתח %@";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "संशोधित";
 "perpetual.reduce_position" = "स्थिति कम करें";
 "perpetual.increase_position" = "स्थिति बढ़ाएँ";
-"banner.onboarding.title" = "Gem परिवार में आपका स्वागत ";
-"banner.onboarding.description" = "आरंभ करने के लिए अपने वॉलेट में क्रिप्टो खरीदें या प्राप्त करें";
+"banner.onboarding.title" = "आपका बटुआ तैयार है";
+"banner.onboarding.description" = "आरंभ करने के लिए क्रिप्टो खरीदें या प्राप्त करें";
 "info.stake.reserved.title" = "नेटवर्क शुल्क के लिए आरक्षित";
 "info.stake.reserved.description" = "आपके वॉलेट में एक छोटी राशि रहती है, जो अनस्टेकिंग या पुरस्कार का दावा करने जैसे कार्यों के लिए शुल्क को कवर करती है।";
 "perpetual.open_direction" = "%@ खोलें";
@@ -508,4 +508,4 @@
 "secret_phrase.screenshot_detected.description" = "स्क्रीनशॉट अन्य ऐप्स के लिए सुलभ हो सकते हैं, यदि वे इस तरह से सहेजे गए तो वे आपके गुप्त वाक्यांश को खतरे में डाल सकते हैं।";
 "secret_phrase.content_hidden.description" = "स्क्रीन रिकॉर्डिंग के दौरान सामग्री छिपाई गई";
 "asset.verification.verified" = "सत्यापित";
-"errors.connections.malicious_origin" = "This connection comes from an untrusted source.";
+"errors.connections.malicious_origin" = "यह कनेक्शन एक अविश्वसनीय स्रोत से आता है।";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Memodifikasi";
 "perpetual.reduce_position" = "Kurangi Posisi";
 "perpetual.increase_position" = "Tingkatkan Posisi";
-"banner.onboarding.title" = "Selamat datang di keluarga Gem";
-"banner.onboarding.description" = "Beli atau Terima kripto ke dompet Anda untuk memulai";
+"banner.onboarding.title" = "Dompet Anda sudah siap";
+"banner.onboarding.description" = "Beli atau Terima kripto untuk memulai";
 "info.stake.reserved.title" = "Dicadangkan untuk Biaya Jaringan";
 "info.stake.reserved.description" = "Sejumlah kecil dana disimpan di dompet Anda untuk menutupi biaya operasi seperti unstaking atau klaim hadiah.";
 "perpetual.open_direction" = "Buka %@";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Modificare";
 "perpetual.reduce_position" = "Ridurre la posizione";
 "perpetual.increase_position" = "Aumenta la posizione";
-"banner.onboarding.title" = "Benvenuto nella famiglia Gem";
-"banner.onboarding.description" = "Acquista o ricevi criptovalute sul tuo portafoglio per iniziare";
+"banner.onboarding.title" = "Il tuo portafoglio è pronto";
+"banner.onboarding.description" = "Acquista o ricevi criptovalute per iniziare";
 "info.stake.reserved.title" = "Riservato per la commissione di rete";
 "info.stake.reserved.description" = "Una piccola somma rimane nel tuo portafoglio per coprire le commissioni per operazioni come l'annullamento dello staking o la richiesta di premi.";
 "perpetual.open_direction" = "Apri %@";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "修正する";
 "perpetual.reduce_position" = "位置を減らす";
 "perpetual.increase_position" = "ポジションを上げる";
-"banner.onboarding.title" = "Gemファミリーへようこそ";
-"banner.onboarding.description" = "始めるにはウォレットで暗号通貨を購入または受け取りましょう";
+"banner.onboarding.title" = "ウォレットの準備ができました";
+"banner.onboarding.description" = "始めるには暗号通貨を購入または受け取りましょう";
 "info.stake.reserved.title" = "ネットワーク料金用に予約";
 "info.stake.reserved.description" = "ステーキング解除や報酬の請求などの操作にかかる手数料をカバーするために、少額がウォレットに残ります。";
 "perpetual.open_direction" = "%@を開く";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "수정하다";
 "perpetual.reduce_position" = "위치 줄이기";
 "perpetual.increase_position" = "위치 증가";
-"banner.onboarding.title" = "Gem 패밀리에 오신 것을 환영합니다";
-"banner.onboarding.description" = "시작하려면 암호화폐를 구매하거나 지갑으로 받으세요";
+"banner.onboarding.title" = "지갑이 준비되었습니다";
+"banner.onboarding.description" = "시작하려면 암호화폐를 구매하거나 받으세요";
 "info.stake.reserved.title" = "네트워크 수수료로 예약됨";
 "info.stake.reserved.description" = "스테이킹 해제나 보상 청구 등의 수수료를 충당하기 위해 소액이 지갑에 남아 있습니다.";
 "perpetual.open_direction" = "%@ 열기";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Ubah suai";
 "perpetual.reduce_position" = "Kurangkan Kedudukan";
 "perpetual.increase_position" = "Tingkatkan Kedudukan";
-"banner.onboarding.title" = "Selamat datang ke keluarga Gem";
-"banner.onboarding.description" = "Beli atau Terima kripto ke dompet anda untuk bermula";
+"banner.onboarding.title" = "Dompet anda sudah sedia";
+"banner.onboarding.description" = "Beli atau Terima crypto untuk bermula";
 "info.stake.reserved.title" = "Dikhaskan untuk Yuran Rangkaian";
 "info.stake.reserved.description" = "Sejumlah kecil kekal dalam dompet anda untuk menampung yuran untuk operasi seperti menanggalkan atau menuntut ganjaran.";
 "perpetual.open_direction" = "Buka %@";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Bewerken";
 "perpetual.reduce_position" = "Positie verkleinen";
 "perpetual.increase_position" = "Positie verhogen";
-"banner.onboarding.title" = "Welkom bij de Gem-familie";
-"banner.onboarding.description" = "Koop of ontvang crypto in uw portemonnee om te beginnen";
+"banner.onboarding.title" = "Je portemonnee is klaar";
+"banner.onboarding.description" = "Koop of ontvang crypto om te beginnen";
 "info.stake.reserved.title" = "Gereserveerd voor netwerkkosten";
 "info.stake.reserved.description" = "Een klein bedrag blijft in uw portemonnee staan om de kosten voor handelingen zoals unstaking of het claimen van beloningen te dekken.";
 "perpetual.open_direction" = "Open %@";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Modyfikować";
 "perpetual.reduce_position" = "Zmniejsz pozycję";
 "perpetual.increase_position" = "Zwiększ pozycję";
-"banner.onboarding.title" = "Witamy w rodzinie Gem";
-"banner.onboarding.description" = "Kup lub odbierz kryptowalutę do swojego portfela, aby zacząć";
+"banner.onboarding.title" = "Twój portfel jest gotowy";
+"banner.onboarding.description" = "Kup lub odbierz kryptowalutę, aby zacząć";
 "info.stake.reserved.title" = "Zarezerwowane na opłatę sieciową";
 "info.stake.reserved.description" = "Niewielka kwota pozostaje w Twoim portfelu i służy pokryciu opłat za operacje, takie jak anulowanie transakcji lub odbieranie nagród.";
 "perpetual.open_direction" = "Otwórz %@";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Modificar";
 "perpetual.reduce_position" = "Reduzir posição";
 "perpetual.increase_position" = "Aumentar a posição";
-"banner.onboarding.title" = "Bem-vindo à família Gem";
-"banner.onboarding.description" = "Compre ou receba criptomoedas em sua carteira para começar";
+"banner.onboarding.title" = "Sua carteira está pronta.";
+"banner.onboarding.description" = "Compre ou receba criptomoedas para começar.";
 "info.stake.reserved.title" = "Reservado para taxa de rede";
 "info.stake.reserved.description" = "Uma pequena quantia fica na sua carteira para cobrir taxas de operações como retirada de stake ou reivindicação de recompensas.";
 "perpetual.open_direction" = "Abrir %@";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Modifica";
 "perpetual.reduce_position" = "Reduceți poziția";
 "perpetual.increase_position" = "Creșteți poziția";
-"banner.onboarding.title" = "Bine ai venit în familia Gem";
-"banner.onboarding.description" = "Cumpără sau primește criptomonede în portofelul tău pentru a începe";
+"banner.onboarding.title" = "Portofelul tău este gata";
+"banner.onboarding.description" = "Cumpără sau primește criptomonede pentru a începe";
 "info.stake.reserved.title" = "Rezervat pentru comision de rețea";
 "info.stake.reserved.description" = "O sumă mică rămâne în portofelul tău pentru a acoperi comisioanele aferente operațiunilor precum unstaking-ul sau revendicarea recompenselor.";
 "perpetual.open_direction" = "Deschis %@";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Изменить";
 "perpetual.reduce_position" = "Уменьшить позицию";
 "perpetual.increase_position" = "Увеличить позицию";
-"banner.onboarding.title" = "Добро пожаловать в семью Gem";
-"banner.onboarding.description" = "Чтобы начать, купите или получите криптовалюту на свой кошелек.";
+"banner.onboarding.title" = "Ваш кошелек готов";
+"banner.onboarding.description" = "Купите или получите криптовалюту, чтобы начать";
 "info.stake.reserved.title" = "Зарезервировано для комиссии сети";
 "info.stake.reserved.description" = "Небольшая сумма остается в вашем кошельке для покрытия комиссий за такие операции, как отмена стейкинга или получение вознаграждений.";
 "perpetual.open_direction" = "Открыть %@";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Rekebisha";
 "perpetual.reduce_position" = "Punguza Nafasi";
 "perpetual.increase_position" = "Ongeza Nafasi";
-"banner.onboarding.title" = "Karibu kwenye familia ya Gem";
-"banner.onboarding.description" = "Nunua au Pokea crypto kwenye pochi yako ili uanze";
+"banner.onboarding.title" = "Pochi yako iko tayari";
+"banner.onboarding.description" = "Nunua au Upokee crypto ili kuanza";
 "info.stake.reserved.title" = "Imehifadhiwa kwa Ada ya Mtandao";
 "info.stake.reserved.description" = "Kiasi kidogo husalia kwenye mkoba wako ili kulipia ada za shughuli kama vile kutoweka au kudai zawadi.";
 "perpetual.open_direction" = "Fungua %@";
@@ -508,4 +508,4 @@
 "secret_phrase.screenshot_detected.description" = "Picha za skrini zinaweza kupatikana kwa programu zingine, zinaweza kuweka maneno yako ya siri hatarini ikiwa yamehifadhiwa kwa njia hii.";
 "secret_phrase.content_hidden.description" = "Maudhui yaliyofichwa wakati wa kurekodi skrini";
 "asset.verification.verified" = "Imethibitishwa";
-"errors.connections.malicious_origin" = "This connection comes from an untrusted source.";
+"errors.connections.malicious_origin" = "Muunganisho huu unatoka kwa chanzo kisichoaminika.";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "แก้ไข";
 "perpetual.reduce_position" = "ลดตำแหน่ง";
 "perpetual.increase_position" = "เพิ่มตำแหน่ง";
-"banner.onboarding.title" = "ยินดีต้อนรับสู่ครอบครัว Gem";
-"banner.onboarding.description" = "ซื้อหรือรับ crypto ลงในกระเป๋าเงินของคุณเพื่อเริ่มต้น";
+"banner.onboarding.title" = "กระเป๋าเงินของคุณพร้อมแล้ว";
+"banner.onboarding.description" = "ซื้อหรือรับ crypto เพื่อเริ่มต้น";
 "info.stake.reserved.title" = "สงวนไว้สำหรับค่าธรรมเนียมเครือข่าย";
 "info.stake.reserved.description" = "เงินจำนวนเล็กน้อยจะอยู่ในกระเป๋าเงินของคุณเพื่อชำระค่าธรรมเนียมการดำเนินการ เช่น การยกเลิกการเดิมพันหรือการรับรางวัล";
 "perpetual.open_direction" = "เปิด %@";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Değiştir";
 "perpetual.reduce_position" = "Pozisyonu Azalt";
 "perpetual.increase_position" = "Pozisyonu Artır";
-"banner.onboarding.title" = "Gem ailesine hoş geldiniz";
-"banner.onboarding.description" = "Başlamak için kripto paranızı cüzdanınıza satın alın veya alın";
+"banner.onboarding.title" = "Cüzdanınız hazır";
+"banner.onboarding.description" = "Başlamak için kripto satın alın veya alın";
 "info.stake.reserved.title" = "Ağ ücreti için ayrıldı";
 "info.stake.reserved.description" = "Cüzdanınızda, stake'lerinizi iptal etme veya ödül talep etme gibi işlemlerin ücretlerini karşılamak için küçük bir miktar kalır.";
 "perpetual.open_direction" = "%@ yi aç";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Змінити";
 "perpetual.reduce_position" = "Зменшити позицію";
 "perpetual.increase_position" = "Збільшити позицію";
-"banner.onboarding.title" = "Ласкаво просимо до родини Gem";
-"banner.onboarding.description" = "Купуйте або отримуйте криптовалюту на свій гаманець, щоб розпочати";
+"banner.onboarding.title" = "Ваш гаманець готовий";
+"banner.onboarding.description" = "Купуйте або отримуйте криптовалюту, щоб розпочати";
 "info.stake.reserved.title" = "Зарезервовано для комісії мережі";
 "info.stake.reserved.description" = "Невелика сума залишається у вашому гаманці для покриття комісій за такі операції, як зняття коштів зі стейкінгу або отримання винагород.";
 "perpetual.open_direction" = "Відкрити %@";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "ترمیم کریں۔";
 "perpetual.reduce_position" = "پوزیشن کو کم کریں۔";
 "perpetual.increase_position" = "پوزیشن میں اضافہ کریں۔";
-"banner.onboarding.title" = "Gem خاندان میں خوش آمدید";
-"banner.onboarding.description" = "شروع کرنے کے لیے اپنے بٹوے میں کریپٹو خریدیں یا وصول کریں۔";
+"banner.onboarding.title" = "آپ کا پرس تیار ہے۔";
+"banner.onboarding.description" = "شروع کرنے کے لیے کریپٹو خریدیں یا وصول کریں۔";
 "info.stake.reserved.title" = "نیٹ ورک فیس کے لیے محفوظ ہے";
 "info.stake.reserved.description" = "ایک چھوٹی سی رقم آپ کے بٹوے میں رہ جاتی ہے تاکہ ان کارروائیوں کے لیے فیس کو پورا کیا جا سکے جیسے کہ انعامات کا دعوی کرنا یا دعوی کرنا۔";
 "perpetual.open_direction" = "کھولیں %@";
@@ -508,4 +508,4 @@
 "secret_phrase.screenshot_detected.description" = "اسکرین شاٹس دیگر ایپس کے لیے قابل رسائی ہو سکتے ہیں، اگر اس طرح محفوظ کیا جائے تو وہ آپ کے خفیہ جملے کو خطرے میں ڈال سکتے ہیں۔";
 "secret_phrase.content_hidden.description" = "اسکرین ریکارڈنگ کے دوران چھپا ہوا مواد";
 "asset.verification.verified" = "تصدیق شدہ";
-"errors.connections.malicious_origin" = "This connection comes from an untrusted source.";
+"errors.connections.malicious_origin" = "یہ کنکشن ایک ناقابل اعتماد ذریعہ سے آتا ہے۔";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "Biến đổi";
 "perpetual.reduce_position" = "Giảm vị trí";
 "perpetual.increase_position" = "Tăng vị trí";
-"banner.onboarding.title" = "Chào mừng đến với gia đình Gem";
-"banner.onboarding.description" = "Mua hoặc nhận tiền điện tử vào ví của bạn để bắt đầu";
+"banner.onboarding.title" = "Ví của bạn đã sẵn sàng";
+"banner.onboarding.description" = "Mua hoặc nhận tiền điện tử để bắt đầu";
 "info.stake.reserved.title" = "Dành riêng cho Phí mạng";
 "info.stake.reserved.description" = "Một số tiền nhỏ sẽ được giữ lại trong ví của bạn để trang trải phí cho các hoạt động như hủy đặt cọc hoặc nhận phần thưởng.";
 "perpetual.open_direction" = "Mở %@";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "调整";
 "perpetual.reduce_position" = "减仓";
 "perpetual.increase_position" = "增加职位";
-"banner.onboarding.title" = "欢迎加入 Gem 家庭";
-"banner.onboarding.description" = "购买或接收加密货币到您的钱包即可开始使用";
+"banner.onboarding.title" = "您的钱包已准备就绪";
+"banner.onboarding.description" = "购买或接收加密货币即可开始";
 "info.stake.reserved.title" = "预留网络费";
 "info.stake.reserved.description" = "您的钱包中会留有少量资金，用于支付取消质押或领取奖励等操作的费用。";
 "perpetual.open_direction" = "打开%@";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -476,8 +476,8 @@
 "perpetual.modify" = "調整";
 "perpetual.reduce_position" = "減倉";
 "perpetual.increase_position" = "增加職位";
-"banner.onboarding.title" = "歡迎加入 Gem 家庭";
-"banner.onboarding.description" = "購買或接收加密貨幣到您的錢包即可開始使用";
+"banner.onboarding.title" = "您的錢包已準備就緒";
+"banner.onboarding.description" = "購買或接收加密貨幣即可開始";
 "info.stake.reserved.title" = "預留網路費用";
 "info.stake.reserved.description" = "您的錢包中會留有少量資金，用於支付取消質押或領取獎勵等操作的費用。";
 "perpetual.open_direction" = "打開%@";


### PR DESCRIPTION
Replaces the onboarding banner title and description across all supported languages to use a more generic and welcoming message ('Your wallet is ready' and 'Buy or Receive crypto to get started'). Updates both the Swift fallback strings and all Localizable.strings files to ensure consistency in onboarding messaging.

<img width="320" alt="Simulator Screenshot - iPhone 17 - 2025-11-19 at 15 04 02" src="https://github.com/user-attachments/assets/7954f3c3-7e4c-4b7a-ae6c-9d37bb8aa83f" />
