### PR TITLE
Make PercentageAccessoryView percents configurable

### DIFF
--- a/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
@@ -71,6 +71,7 @@ public struct AutocloseScene: View {
 
                 if focusedField != nil {
                     PercentageAccessoryView(
+                        percents: model.takeProfitModel.percents,
                         onSelectPercent: model.onSelectPercent,
                         onDone: model.onDone
                     )

--- a/Features/Perpetuals/Sources/ViewModels/AutocloseViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/AutocloseViewModel.swift
@@ -60,4 +60,12 @@ public struct AutocloseViewModel {
         let pnl = estimator.calculatePnL(price: price)
         return PriceChangeColor.color(for: pnl)
     }
+
+    public var percents: [Int] {
+        switch estimator.leverage {
+        case 0...3: [5, 10, 15]
+        case 4...10: [10, 15, 25]
+        case _: [25, 50, 100]
+        }
+    }
 }

--- a/Features/Perpetuals/TestKit/AutocloseViewModel+TestKit.swift
+++ b/Features/Perpetuals/TestKit/AutocloseViewModel+TestKit.swift
@@ -9,14 +9,14 @@ public extension AutocloseViewModel {
     static func mock(
         type: TpslType = .takeProfit,
         price: Double? = nil,
-        estimator: AutocloseEstimator = .mock(),
+        leverage: UInt8 = 5,
         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencyCode: "USD"),
         percentFormatter: CurrencyFormatter = .percent
     ) -> AutocloseViewModel {
         AutocloseViewModel(
             type: type,
             price: price,
-            estimator: estimator,
+            estimator: .mock(leverage: leverage),
             currencyFormatter: currencyFormatter,
             percentFormatter: percentFormatter
         )

--- a/Features/Perpetuals/Tests/AutocloseViewModelTests.swift
+++ b/Features/Perpetuals/Tests/AutocloseViewModelTests.swift
@@ -44,4 +44,14 @@ struct AutocloseViewModelTests {
         let model = AutocloseViewModel.mock(price: 90.0)
         #expect(model.expectedPnL == "-$100.00 (-50.00%)")
     }
+
+    @Test
+    func percentages() {
+        #expect(AutocloseViewModel.mock(leverage: 1).percents == [5, 10, 15])
+        #expect(AutocloseViewModel.mock(leverage: 3).percents == [5, 10, 15])
+        #expect(AutocloseViewModel.mock(leverage: 4).percents == [10, 15, 25])
+        #expect(AutocloseViewModel.mock(leverage: 10).percents == [10, 15, 25])
+        #expect(AutocloseViewModel.mock(leverage: 11).percents == [25, 50, 100])
+        #expect(AutocloseViewModel.mock(leverage: 50).percents == [25, 50, 100])
+    }
 }

--- a/Features/Swap/Sources/Scenes/SwapScene.swift
+++ b/Features/Swap/Sources/Scenes/SwapScene.swift
@@ -167,6 +167,7 @@ extension SwapScene {
                     buttonView
                 } else if focusedField == .from {
                     PercentageAccessoryView(
+                        percents: SwapSceneViewModel.inputPercents,
                         onSelectPercent: model.onSelectPercent,
                         onDone: { focusedField = nil }
                     )

--- a/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
+++ b/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
@@ -20,6 +20,7 @@ import Validators
 @MainActor
 @Observable
 public final class SwapSceneViewModel {
+    static let inputPercents = [25, 50, 100]
     static let quoteTaskDebounceTimeout = Duration.milliseconds(150)
 
     public let wallet: Wallet

--- a/Packages/PrimitivesComponents/Sources/Components/PercentageAccessoryView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/PercentageAccessoryView.swift
@@ -6,19 +6,20 @@ import Style
 import Localization
 
 public struct PercentageAccessoryView: View {
-    
-    let percents = [25, 50, 100]
-    
+
+    public let percents: [Int]
     public let onSelectPercent: (Int) -> Void
-        public let onDone: () -> Void
-        
-        public init(
-            onSelectPercent: @escaping (Int) -> Void,
-            onDone: @escaping () -> Void
-        ) {
-            self.onSelectPercent = onSelectPercent
-            self.onDone = onDone
-        }
+    public let onDone: () -> Void
+
+    public init(
+        percents: [Int],
+        onSelectPercent: @escaping (Int) -> Void,
+        onDone: @escaping () -> Void
+    ) {
+        self.percents = percents
+        self.onSelectPercent = onSelectPercent
+        self.onDone = onDone
+    }
     
     public var body: some View {
         HStack {


### PR DESCRIPTION
Refactored PercentageAccessoryView to accept percents as a parameter instead of using a fixed set. Updated AutocloseScene and SwapScene to provide context-specific percents, with logic for AutocloseViewModel based on leverage and a static set for SwapSceneViewModel. Added tests for AutocloseViewModel percents logic.

images:
<img width="320" height="680" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-11-24 at 19 03 43" src="https://github.com/user-attachments/assets/3971367a-d95f-426e-ab83-83a5dd2edaf4" />
<img width="320" height="680" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-11-24 at 19 04 34" src="https://github.com/user-attachments/assets/423a8e43-b620-465c-a562-7c204dfb3d0d" />

closes #1414 