### PR TITLE
Fix `popd` invalid argument error

### DIFF
--- a/scripts/generate-stone.sh
+++ b/scripts/generate-stone.sh
@@ -24,7 +24,7 @@ generate() {
     rm -rf ${PACKAGES_DIR}
     cp -Rf target/spm ${PACKAGES_DIR}
 
-    popd /dev/null
+    popd > /dev/null
 }
 
 generate


### PR DESCRIPTION
It works on fish/bash/zsh