### PR TITLE
Improve layout and consistency for secret data views

### DIFF
--- a/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ShowSecretDataScene.swift
@@ -15,15 +15,14 @@ struct ShowSecretDataScene: View {
     var body: some View {
         List {
             if let calloutViewStyle = model.calloutViewStyle {
-                CalloutView(style: calloutViewStyle)
-                    .cleanListRow()
-                    .padding(.horizontal, .medium)
+                Section {
+                    CalloutView(style: calloutViewStyle)
+                }
+                .cleanListRow()
             }
-            
+
             Section {
-                SecretDataTypeView(
-                    type: model.type
-                )
+                SecretDataTypeView(type: model.type)
             }
             .cleanListRow()
             

--- a/Packages/Components/Sources/CalloutView.swift
+++ b/Packages/Components/Sources/CalloutView.swift
@@ -44,5 +44,7 @@ public struct CalloutView: View {
         .padding()
         .background(style.backgroundColor)
         .cornerRadius(.small)
+        .padding(.horizontal, .medium)
+        .frame(maxWidth: .scene.content.maxWidth)
     }
 }

--- a/Packages/PrimitivesComponents/Sources/Components/SecretDataTypeView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/SecretDataTypeView.swift
@@ -16,6 +16,9 @@ public struct SecretDataTypeView: View {
             SecretPhraseGridView(rows: rows)
         case .privateKey(let key):
             Text(key)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, .medium)
+                .frame(maxWidth: .scene.content.maxWidth)
         }
     }
 }

--- a/Packages/PrimitivesComponents/Sources/Components/SecretPhraseGridView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/SecretPhraseGridView.swift
@@ -34,7 +34,6 @@ public struct SecretPhraseGridView: View {
                             Spacer()
                         }
                         .padding(.small)
-                        .frame(maxWidth: (.scene.content.maxWidth / 2) - (.small * 2))
                         .background(Colors.listStyleColor)
                         .cornerRadius(10)
                         .overlay {
@@ -47,5 +46,7 @@ public struct SecretPhraseGridView: View {
                 }.padding(2)
             }
         }
+        .padding(.horizontal, .medium)
+        .frame(maxWidth: .scene.content.maxWidth)
     }
 }


### PR DESCRIPTION
Refactored ShowSecretDataScene to wrap CalloutView in a Section and adjusted padding. Updated CalloutView, SecretDataTypeView, and SecretPhraseGridView to use consistent horizontal padding and maxWidth constraints for better alignment and visual consistency.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-26 at 16 22 01" src="https://github.com/user-attachments/assets/43070a05-3b42-4936-8510-b9d75065d37f" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-26 at 16 22 14" src="https://github.com/user-attachments/assets/f8b20415-aa89-4642-8e96-eb9219bf2692" />
<img width="640" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-26 at 16 25 15" src="https://github.com/user-attachments/assets/8be97c02-b0ac-4763-938b-2d440847a8a3" />
<img width="640" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-26 at 16 25 32" src="https://github.com/user-attachments/assets/12caf707-3ef8-4fe0-bad8-0cccdf8d953a" />


Fix: https://github.com/gemwalletcom/gem-ios/issues/1422