### PR TITLE
Update swap value formatting in TransactionViewModel

### DIFF
--- a/Features/Transactions/Tests/TransactionsTests/ViewModels/TransactionViewModelTests.swift
+++ b/Features/Transactions/Tests/TransactionsTests/ViewModels/TransactionViewModelTests.swift
@@ -25,8 +25,8 @@ final class TransactionViewModelTests {
         #expect(TransactionViewModel.mock(metadata: .swap(.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "10000"))).subtitleTextValue?.text == "+0.01 USDT")
         #expect(TransactionViewModel.mock(metadata: .swap(.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1000"))).subtitleTextValue?.text == "+0.001 USDT")
         #expect(TransactionViewModel.mock(metadata: .swap(.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "100"))).subtitleTextValue?.text == "+0.0001 USDT")
-        #expect(TransactionViewModel.mock(metadata: .swap(.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "10"))).subtitleTextValue?.text == "+0.00001 USDT")
-        #expect(TransactionViewModel.mock(metadata: .swap(.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1"))).subtitleTextValue?.text == "+0.000001 USDT")
+        #expect(TransactionViewModel.mock(metadata: .swap(.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "10"))).subtitleTextValue?.text == "+0.00 USDT")
+        #expect(TransactionViewModel.mock(metadata: .swap(.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1"))).subtitleTextValue?.text == "+0.00 USDT")
     }
     
     @Test

--- a/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
@@ -16,6 +16,7 @@ public struct TransactionViewModel: Sendable {
     private let explorerService: any ExplorerLinkFetchable
     private let assetImageFormatter = AssetImageFormatter()
     private let currency: String
+    private let formatter: ValueFormatter = .short
 
     public init(
         explorerService: any ExplorerLinkFetchable,
@@ -240,7 +241,7 @@ public struct TransactionViewModel: Sendable {
             .assetActivation,
             .stakeFreeze,
             .stakeUnfreeze:
-            return infoModel.amountDisplay(formatter: .short).amount
+            return infoModel.amountDisplay(formatter: formatter).amount
         case .perpetualClosePosition:
             guard case .perpetual(let metadata) = transaction.transaction.metadata, metadata.pnl != 0 else {
                 return .none
@@ -252,7 +253,7 @@ public struct TransactionViewModel: Sendable {
                 price: Price(price: 1, priceChangePercentage24h: .zero, updatedAt: .now),
                 value: transaction.transaction.valueBigInt,
                 currency: Currency.usd.rawValue,
-                formatter: .auto,
+                formatter: formatter,
                 textStyle: TextStyle(font: .body, color: Colors.black, fontWeight: .medium)
             ).fiat
         case .tokenApproval:
@@ -263,7 +264,7 @@ public struct TransactionViewModel: Sendable {
             }
             return AmountDisplay.numeric(
                 data: AssetValuePrice(asset: asset, value: BigInt(stringLiteral: metadata.toValue), price: nil),
-                style: AmountDisplayStyle(sign: .incoming, formatter: .auto, currencyCode: currency)
+                style: AmountDisplayStyle(sign: .incoming, formatter: formatter, currencyCode: currency)
             ).amount
         case .transferNFT:
             return nil
@@ -298,7 +299,7 @@ public struct TransactionViewModel: Sendable {
                 data: AssetValuePrice(asset: asset, value: BigInt(stringLiteral: metadata.fromValue), price: nil),
                 style: AmountDisplayStyle(
                     sign: .outgoing,
-                    formatter: .auto,
+                    formatter: formatter,
                     currencyCode: currency,
                     textStyle: .footnote
                 )


### PR DESCRIPTION
Changed the value formatter in TransactionViewModel to consistently use the short format for swap transactions. Updated related unit tests to expect '+0.00 USDT' for very small swap values, reflecting the new formatting behavior.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-26 at 18 28 13" src="https://github.com/user-attachments/assets/a6b5bc12-8606-4654-9ebb-9cbacc55fc84" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-26 at 18 28 16" src="https://github.com/user-attachments/assets/ed32e4ef-9b0c-4c81-be9c-ef222ab4dfef" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-26 at 18 28 19" src="https://github.com/user-attachments/assets/fbee35e8-b022-44d6-849d-2f342464e665" />



Fix: https://github.com/gemwalletcom/gem-ios/issues/1421