### PR TITLE
Add stake validation for non-zero reserved fees

### DIFF
--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -713,7 +713,7 @@ extension AmountSceneViewModel {
         case .stake:
             switch asset.chain {
             case .tron: false
-            default: availableBalanceForMaxStaking > minimumValue
+            default: availableBalanceForMaxStaking > minimumValue && reserveForFee.isZero == false
             }
         case .freeze(let data):
             switch data.freezeType {

--- a/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
@@ -142,6 +142,16 @@ struct AmountSceneViewModelTests {
         model.amountInputModel.update(text: "2.0")
         #expect(model.amountInputModel.isValid == false)
     }
+
+    @Test
+    func stakeWithZeroReservedFees() {
+        let assetData = AssetData.mock(asset: .mockHyperliquid(), balance: .mock(available: 5_000_000))
+        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
+
+        model.onSelectMaxButton()
+
+        #expect(model.infoText == nil)
+    }
 }
 
 extension AmountSceneViewModel {

--- a/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
@@ -145,7 +145,7 @@ struct AmountSceneViewModelTests {
 
     @Test
     func stakeWithZeroReservedFees() {
-        let assetData = AssetData.mock(asset: .mockHyperliquid(), balance: .mock(available: 5_000_000))
+        let assetData = AssetData.mock(asset: .mockHypercore(), balance: .mock(available: 5_000_000))
         let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
 
         model.onSelectMaxButton()

--- a/Packages/Primitives/TestKit/Asset+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/Asset+PrimitivesTestKit.swift
@@ -100,7 +100,7 @@ public extension Asset {
         )
     }
 
-    static func mockHyperliquid() -> Asset {
+    static func mockHypercore() -> Asset {
         Asset(
             id: AssetId(chain: .hyperCore, tokenId: nil),
             name: "Hyperliquid",

--- a/Packages/Primitives/TestKit/Asset+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/Asset+PrimitivesTestKit.swift
@@ -99,4 +99,14 @@ public extension Asset {
             type: .native
         )
     }
+
+    static func mockHyperliquid() -> Asset {
+        Asset(
+            id: AssetId(chain: .hyperCore, tokenId: nil),
+            name: "Hyperliquid",
+            symbol: "HYPE",
+            decimals: 8,
+            type: .native
+        )
+    }
 }


### PR DESCRIPTION
Updated stake validation logic to require non-zero reserved fees for non-Tron chains. Added a test case for staking with zero reserved fees and a mock asset for Hyperliquid in test kit.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-11-27 at 13 54 34" src="https://github.com/user-attachments/assets/cffd37ce-756f-4eff-ba8a-3dd470d573e7" />


Close: https://github.com/gemwalletcom/gem-ios/issues/1429