### PR TITLE
Add AssetsTestKit and improve SelectAssetViewModel logic

### DIFF
--- a/Features/Assets/Package.swift
+++ b/Features/Assets/Package.swift
@@ -12,6 +12,9 @@ let package = Package(
         .library(
             name: "Assets",
             targets: ["Assets"]),
+        .library(
+            name: "AssetsTestKit",
+            targets: ["AssetsTestKit"]),
     ],
     dependencies: [
         .package(name: "Primitives", path: "../../Packages/Primitives"),
@@ -52,7 +55,21 @@ let package = Package(
                 .product(name: "BannerService", package: "FeatureServices"),
                 .product(name: "ChainService", package: "ChainServices"),
                 .product(name: "ActivityService", package: "FeatureServices")
-            ]
+            ],
+            path: "Sources"
+        ),
+        .target(
+            name: "AssetsTestKit",
+            dependencies: [
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
+                .product(name: "WalletsServiceTestKit", package: "FeatureServices"),
+                .product(name: "AssetsServiceTestKit", package: "FeatureServices"),
+                .product(name: "PriceAlertServiceTestKit", package: "FeatureServices"),
+                .product(name: "ActivityServiceTestKit", package: "FeatureServices"),
+                "Components",
+                "Assets"
+            ],
+            path: "TestKit"
         ),
         .testTarget(
             name: "AssetsTests",
@@ -64,9 +81,7 @@ let package = Package(
                 .product(name: "PriceServiceTestKit", package: "FeatureServices"),
                 .product(name: "PriceAlertServiceTestKit", package: "FeatureServices"),
                 .product(name: "BannerServiceTestKit", package: "FeatureServices"),
-                .product(name: "BalanceServiceTestKit", package: "FeatureServices"),
-                .product(name: "TransactionServiceTestKit", package: "FeatureServices"),
-                "Assets"
+                "AssetsTestKit"
             ]
         )
     ]

--- a/Features/Assets/Sources/Scenes/SelectAssetScene.swift
+++ b/Features/Assets/Sources/Scenes/SelectAssetScene.swift
@@ -34,10 +34,10 @@ public struct SelectAssetScene: View {
             )
         }
         .overlay {
-            if model.state.isLoading, model.sections.assets.isEmpty {
+            if model.showLoading {
                 LoadingView()
-            } else if model.sections.assets.isEmpty {
-                EmptyContentView (
+            } else if model.showEmpty {
+                EmptyContentView(
                     model: EmptyContentTypeViewModel(
                         type: .search(
                             type: .assets,

--- a/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
@@ -141,6 +141,14 @@ public final class SelectAssetViewModel {
         searchModel.searchableQuery.isEmpty
     }
 
+    var showLoading: Bool {
+        state.isLoading && showEmpty
+    }
+
+    var showEmpty: Bool {
+        sections.pinned.isEmpty && sections.assets.isEmpty
+    }
+
     var showRecentActivities: Bool {
         switch selectType {
         case .send, .receive, .buy: searchModel.searchableQuery.isEmpty && recentActivities.isNotEmpty

--- a/Features/Assets/TestKit/SelectAssetViewModel+AssetsTestKit.swift
+++ b/Features/Assets/TestKit/SelectAssetViewModel+AssetsTestKit.swift
@@ -1,0 +1,34 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import PrimitivesTestKit
+import Components
+import WalletsServiceTestKit
+import AssetsServiceTestKit
+import PriceAlertServiceTestKit
+import ActivityServiceTestKit
+
+@testable import Assets
+
+extension SelectAssetViewModel {
+    @MainActor
+    public static func mock(
+        wallet: Wallet = .mock(),
+        selectType: SelectAssetType = .manage,
+        assets: [AssetData] = [],
+        state: StateViewType<[AssetBasic]> = .noData
+    ) -> SelectAssetViewModel {
+        let model = SelectAssetViewModel(
+            wallet: wallet,
+            selectType: selectType,
+            searchService: .mock(),
+            walletsService: .mock(),
+            priceAlertService: .mock(),
+            activityService: .mock()
+        )
+        model.assets = assets
+        model.state = state
+        return model
+    }
+}

--- a/Features/Assets/Tests/AssetsTests/SelectAssetViewModelTests.swift
+++ b/Features/Assets/Tests/AssetsTests/SelectAssetViewModelTests.swift
@@ -1,0 +1,26 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Primitives
+import PrimitivesTestKit
+import AssetsTestKit
+
+@testable import Assets
+
+@MainActor
+struct SelectAssetViewModelTests {
+
+    @Test
+    func showEmpty() {
+        #expect(SelectAssetViewModel.mock(assets: []).showEmpty == true)
+        #expect(SelectAssetViewModel.mock(assets: [AssetData.mock(metadata: .mock(isPinned: true))]).showEmpty == false)
+        #expect(SelectAssetViewModel.mock(assets: [AssetData.mock(metadata: .mock(isPinned: false))]).showEmpty == false)
+    }
+
+    @Test
+    func showLoading() {
+        let pinnedAsset = AssetData.mock(metadata: .mock(isPinned: true))
+        #expect(SelectAssetViewModel.mock(assets: [], state: .loading).showLoading == true)
+        #expect(SelectAssetViewModel.mock(assets: [pinnedAsset], state: .loading).showLoading == false)
+    }
+}

--- a/Packages/FeatureServices/AssetsService/TestKit/AssetSearchService+TestKit.swift
+++ b/Packages/FeatureServices/AssetsService/TestKit/AssetSearchService+TestKit.swift
@@ -1,0 +1,13 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import AssetsService
+import Primitives
+
+extension AssetSearchService {
+    public static func mock(
+        assetsService: AssetsService = .mock()
+    ) -> AssetSearchService {
+        AssetSearchService(assetsService: assetsService)
+    }
+}

--- a/Packages/PrimitivesComponents/Sources/Types/AssetsSection.swift
+++ b/Packages/PrimitivesComponents/Sources/Types/AssetsSection.swift
@@ -7,7 +7,7 @@ public struct AssetsSections: Hashable, Sendable {
     public let pinned: [AssetData]
     public let assets: [AssetData]
     public let popular: [AssetData]
-    
+
     private static let popularChains = Set<AssetId>(arrayLiteral: Chain.bitcoin.assetId, Chain.ethereum.assetId, Chain.solana.assetId)
 }
 


### PR DESCRIPTION
Introduces the AssetsTestKit target and related test utilities for SelectAssetViewModel. Refactors SelectAssetViewModel to add showLoading and showEmpty computed properties, updates SelectAssetScene to use these properties, and adds unit tests for their behavior. Also adds a mock implementation for AssetSearchService in FeatureServices.

closes  #1434

