### PR TITLE
Add support for swap activity in recent updates

### DIFF
--- a/Features/Transfer/Sources/Services/ConfirmService.swift
+++ b/Features/Transfer/Sources/Services/ConfirmService.swift
@@ -72,8 +72,14 @@ public struct ConfirmService: Sendable {
     }
 
     public func updateRecent(input: TransferConfirmationInput) {
-        guard input.data.type.transactionType == .transfer else { return }
-        try? activityService.updateRecent(type: .transfer, assetId: input.data.type.asset.id, walletId: input.wallet.walletId)
+        switch input.data.type {
+        case .transfer(let asset):
+            try? activityService.updateRecent(type: .transfer, assetId: asset.id, walletId: input.wallet.walletId)
+        case .swap(let fromAsset, let toAsset, _):
+            try? activityService.updateRecent(type: .swap, assetId: fromAsset.id, toAssetId: toAsset.id, walletId: input.wallet.walletId)
+        default:
+            break
+        }
     }
 
     public func getPasswordAuthentication() throws -> KeystoreAuthentication {

--- a/Features/Transfer/Sources/Services/ConfirmService.swift
+++ b/Features/Transfer/Sources/Services/ConfirmService.swift
@@ -77,7 +77,14 @@ public struct ConfirmService: Sendable {
             try? activityService.updateRecent(type: .transfer, assetId: asset.id, walletId: input.wallet.walletId)
         case .swap(let fromAsset, let toAsset, _):
             try? activityService.updateRecent(type: .swap, assetId: fromAsset.id, toAssetId: toAsset.id, walletId: input.wallet.walletId)
-        default:
+        case .deposit,
+                .withdrawal,
+                .transferNft,
+                .tokenApprove,
+                .stake,
+                .account,
+                .perpetual,
+                .generic:
             break
         }
     }

--- a/Features/Transfer/Sources/Services/ConfirmService.swift
+++ b/Features/Transfer/Sources/Services/ConfirmService.swift
@@ -71,22 +71,8 @@ public struct ConfirmService: Sendable {
         try await transferExecutor.execute(input: input)
     }
 
-    public func updateRecent(input: TransferConfirmationInput) {
-        switch input.data.type {
-        case .transfer(let asset):
-            try? activityService.updateRecent(type: .transfer, assetId: asset.id, walletId: input.wallet.walletId)
-        case .swap(let fromAsset, let toAsset, _):
-            try? activityService.updateRecent(type: .swap, assetId: fromAsset.id, toAssetId: toAsset.id, walletId: input.wallet.walletId)
-        case .deposit,
-                .withdrawal,
-                .transferNft,
-                .tokenApprove,
-                .stake,
-                .account,
-                .perpetual,
-                .generic:
-            break
-        }
+    public func updateRecent(data: RecentActivityData, walletId: WalletId) {
+        try? activityService.updateRecent(type: data.type, assetId: data.assetId, toAssetId: data.toAssetId, walletId: walletId)
     }
 
     public func getPasswordAuthentication() throws -> KeystoreAuthentication {

--- a/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -315,7 +315,9 @@ extension ConfirmTransferSceneViewModel {
                 delegate: confirmTransferDelegate
             )
             try await confirmService.executeTransfer(input: input)
-            confirmService.updateRecent(input: input)
+            if let data = input.data.type.recentActivityData {
+                confirmService.updateRecent(data: data, walletId: wallet.walletId)
+            }
             confirmingState = .data(true)
         } catch {
             confirmingState = .error(error)

--- a/Packages/FeatureServices/ActivityService/ActivityService.swift
+++ b/Packages/FeatureServices/ActivityService/ActivityService.swift
@@ -11,7 +11,7 @@ public struct ActivityService: Sendable {
         self.store = store
     }
 
-    public func updateRecent(type: RecentActivityType, assetId: AssetId, walletId: WalletId) throws {
-        try store.add(assetId: assetId, toAssetId: .none, walletId: walletId, type: type)
+    public func updateRecent(type: RecentActivityType, assetId: AssetId, toAssetId: AssetId? = nil, walletId: WalletId) throws {
+        try store.add(assetId: assetId, toAssetId: toAssetId, walletId: walletId, type: type)
     }
 }

--- a/Packages/Primitives/Sources/RecentActivityData.swift
+++ b/Packages/Primitives/Sources/RecentActivityData.swift
@@ -1,0 +1,15 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public struct RecentActivityData: Sendable {
+    public let type: RecentActivityType
+    public let assetId: AssetId
+    public let toAssetId: AssetId?
+
+    public init(type: RecentActivityType, assetId: AssetId, toAssetId: AssetId?) {
+        self.type = type
+        self.assetId = assetId
+        self.toAssetId = toAssetId
+    }
+}

--- a/Packages/Primitives/Sources/RecentActivityType.swift
+++ b/Packages/Primitives/Sources/RecentActivityType.swift
@@ -10,4 +10,5 @@ public enum RecentActivityType: String, Codable, CaseIterable, Equatable, Sendab
 	case receive
 	case fiatBuy
 	case fiatSell
+	case swap
 }

--- a/Packages/Primitives/Sources/RecentActivityType.swift
+++ b/Packages/Primitives/Sources/RecentActivityType.swift
@@ -11,4 +11,5 @@ public enum RecentActivityType: String, Codable, CaseIterable, Equatable, Sendab
 	case fiatBuy
 	case fiatSell
 	case swap
+	case perpetual
 }

--- a/Packages/Primitives/Sources/TransferDataType.swift
+++ b/Packages/Primitives/Sources/TransferDataType.swift
@@ -135,4 +135,12 @@ public enum TransferDataType: Hashable, Equatable, Sendable {
         case .transfer, .deposit, .withdrawal, .swap, .generic: false
         }
     }
+
+    public var recentActivityData: RecentActivityData? {
+        switch self {
+        case .transfer(let asset): RecentActivityData(type: .transfer, assetId: asset.id, toAssetId: nil)
+        case .swap(let from, let to, _): RecentActivityData(type: .swap, assetId: from.id, toAssetId: to.id)
+        default: nil
+        }
+    }
 }


### PR DESCRIPTION
Extended ConfirmService and ActivityService to handle swap activities in addition to transfers. Added 'swap' case to RecentActivityType to track swap operations in recent activity.

closes #1451