### PR TITLE
Add context menu and toast to WalletSearchScene

### DIFF
--- a/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -288,18 +288,12 @@ extension AssetSceneViewModel {
 
     public func onTogglePriceAlert() {
         Task {
-            if assetData.isPriceAlertsEnabled {
-                isPresentingToastMessage = ToastMessage(
-                    title: Localized.PriceAlerts.disabledFor(assetData.asset.name),
-                    image: priceAlertsSystemImage
-                )
-                await disablePriceAlert()
-            } else {
-                isPresentingToastMessage = ToastMessage(
-                    title: Localized.PriceAlerts.enabledFor(assetData.asset.name),
-                    image: priceAlertsSystemImage
-                )
+            let enable = !assetData.isPriceAlertsEnabled
+            isPresentingToastMessage = .priceAlert(for: assetData.asset.name, enabled: enable)
+            if enable {
                 await enablePriceAlert()
+            } else {
+                await disablePriceAlert()
             }
         }
     }

--- a/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
+++ b/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
@@ -171,7 +171,7 @@ extension CollectibleViewModel {
         Task {
             do {
                 try await saveImageToGallery()
-                isPresentingToast = ToastMessage(title: Localized.Nft.saveToPhotos, image: SystemImage.checkmark)
+                isPresentingToast = .success(Localized.Nft.saveToPhotos)
             } catch let error as ImageGalleryServiceError {
                 switch error {
                 case .wrongURL, .invalidData, .invalidResponse, .unexpectedStatusCode, .urlSessionError:
@@ -202,7 +202,7 @@ extension CollectibleViewModel {
         Task {
             do {
                 try await setWalletAvatar()
-                isPresentingToast = ToastMessage(title: Localized.Nft.setAsAvatar, image: SystemImage.checkmark)
+                isPresentingToast = .success(Localized.Nft.setAsAvatar)
             } catch {
                 debugLog("Set nft avatar error: \(error)")
             }

--- a/Features/PriceAlerts/Sources/ViewModels/AssetPriceAlertsViewModel.swift
+++ b/Features/PriceAlerts/Sources/ViewModels/AssetPriceAlertsViewModel.swift
@@ -85,6 +85,6 @@ extension AssetPriceAlertsViewModel {
     
     func onSetPriceAlertComplete(message: String) {
         isPresentingSetPriceAlert = false
-        isPresentingToastMessage = ToastMessage(title: message, image: SystemImage.bellFill)
+        isPresentingToastMessage = .priceAlert(message: message)
     }
 }

--- a/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
@@ -55,6 +55,7 @@ public struct WalletSearchScene: View {
         .onAppear {
             model.onAppear()
         }
+        .toast(message: $model.isPresentingToastMessage)
     }
 
     @ViewBuilder
@@ -131,7 +132,8 @@ public struct WalletSearchScene: View {
                         formatter: .abbreviated,
                         currencyCode: model.currencyCode
                     )
-                ),
+                )
+                .contextMenu(model.contextMenuItems(for: assetData)),
                 action: { model.onSelectAsset(assetData.asset) }
             )
         }

--- a/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -207,20 +207,14 @@ extension WalletSceneViewModel {
     func onPinAsset(_ asset: Asset, value: Bool) {
         do {
             try walletsService.setPinned(value, walletId: wallet.walletId, assetId: asset.id)
-            isPresentingToastMessage = ToastMessage(
-                title: value ? "\(Localized.Common.pinned) \(asset.name)" : "\(Localized.Common.unpin) \(asset.name)",
-                image: value ? SystemImage.pin : SystemImage.unpin
-            )
+            isPresentingToastMessage = .pinned(asset.name, isPinned: value)
         } catch {
             debugLog("WalletSceneViewModel pin asset error: \(error)")
         }
     }
 
     func onCopyAddress(_ message: String) {
-        isPresentingToastMessage = ToastMessage(
-            title: message,
-            image: SystemImage.copy
-        )
+        isPresentingToastMessage = .copy(message)
     }
 
     public func onChangeWallet(_ oldWallet: Wallet?, _ newWallet: Wallet?) {
@@ -244,7 +238,7 @@ extension WalletSceneViewModel {
     
     public func onSetPriceAlertComplete(message: String) {
         isPresentingSetPriceAlert = nil
-        isPresentingToastMessage = ToastMessage(title: message, image: SystemImage.bellFill)
+        isPresentingToastMessage = .priceAlert(message: message)
     }
 }
 

--- a/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -11,12 +11,14 @@ import Preferences
 import Style
 import Localization
 import ActivityService
+import WalletsService
 
 @Observable
 @MainActor
 public final class WalletSearchSceneViewModel: Sendable {
     private let searchService: AssetSearchService
     private let activityService: ActivityService
+    private let walletsService: WalletsService
     private let preferences: Preferences
 
     private let wallet: Wallet
@@ -31,6 +33,7 @@ public final class WalletSearchSceneViewModel: Sendable {
     var request: AssetsRequest
     var recentActivityRequest: RecentActivityRequest
 
+    var isPresentingToastMessage: ToastMessage? = nil
     var isSearching: Bool = false
     var isSearchPresented: Bool = false
     var dismissSearch: Bool = false
@@ -41,6 +44,7 @@ public final class WalletSearchSceneViewModel: Sendable {
         wallet: Wallet,
         searchService: AssetSearchService,
         activityService: ActivityService,
+        walletsService: WalletsService,
         preferences: Preferences = .standard,
         onDismissSearch: VoidAction,
         onSelectAssetAction: AssetAction,
@@ -49,6 +53,7 @@ public final class WalletSearchSceneViewModel: Sendable {
         self.wallet = wallet
         self.searchService = searchService
         self.activityService = activityService
+        self.walletsService = walletsService
         self.preferences = preferences
         self.onDismissSearch = onDismissSearch
         self.onSelectAssetAction = onSelectAssetAction
@@ -168,6 +173,60 @@ extension WalletSearchSceneViewModel {
 
     func onSelectAddCustomToken() {
         onAddToken?()
+    }
+
+    func onSelectAddToWallet(_ asset: Asset) {
+        Task {
+            await walletsService.enableAssets(walletId: wallet.walletId, assetIds: [asset.id], enabled: true)
+            isPresentingToastMessage = ToastMessage(
+                title: Localized.Asset.addToWallet,
+                image: SystemImage.plusCircle
+            )
+        }
+    }
+
+    func onSelectPinAsset(_ assetData: AssetData, value: Bool) {
+        do {
+            try walletsService.setPinned(value, walletId: wallet.walletId, assetId: assetData.asset.id)
+            isPresentingToastMessage = ToastMessage(
+                title: value ? "\(Localized.Common.pinned) \(assetData.asset.name)" : "\(Localized.Common.unpin) \(assetData.asset.name)",
+                image: value ? SystemImage.pin : SystemImage.unpin
+            )
+        } catch {
+            debugLog("WalletSearchSceneViewModel pin asset error: \(error)")
+        }
+    }
+
+    func onSelectCopyAddress(_ message: String) {
+        isPresentingToastMessage = ToastMessage(
+            title: message,
+            image: SystemImage.copy
+        )
+    }
+
+    func contextMenuItems(for assetData: AssetData) -> [ContextMenuItemType] {
+        [
+            .copy(
+                title: Localized.Wallet.copyAddress,
+                value: assetData.account.address,
+                onCopy: { [weak self] in
+                    self?.onSelectCopyAddress(CopyTypeViewModel(type: .address(assetData.asset, address: $0), copyValue: $0).message)
+                }
+            ),
+            .pin(
+                isPinned: assetData.metadata.isPinned,
+                onPin: { [weak self] in
+                    self?.onSelectPinAsset(assetData, value: !assetData.metadata.isPinned)
+                }
+            ),
+            !assetData.metadata.isBalanceEnabled ? .custom(
+                title: Localized.Asset.addToWallet,
+                systemImage: SystemImage.plusCircle,
+                action: { [weak self] in
+                    self?.onSelectAddToWallet(assetData.asset)
+                }
+            ) : nil
+        ].compactMap { $0 }
     }
 }
 

--- a/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -178,30 +178,21 @@ extension WalletSearchSceneViewModel {
     func onSelectAddToWallet(_ asset: Asset) {
         Task {
             await walletsService.enableAssets(walletId: wallet.walletId, assetIds: [asset.id], enabled: true)
-            isPresentingToastMessage = ToastMessage(
-                title: Localized.Asset.addToWallet,
-                image: SystemImage.plusCircle
-            )
+            isPresentingToastMessage = .addedToWallet()
         }
     }
 
     func onSelectPinAsset(_ assetData: AssetData, value: Bool) {
         do {
             try walletsService.setPinned(value, walletId: wallet.walletId, assetId: assetData.asset.id)
-            isPresentingToastMessage = ToastMessage(
-                title: value ? "\(Localized.Common.pinned) \(assetData.asset.name)" : "\(Localized.Common.unpin) \(assetData.asset.name)",
-                image: value ? SystemImage.pin : SystemImage.unpin
-            )
+            isPresentingToastMessage = .pinned(assetData.asset.name, isPinned: value)
         } catch {
             debugLog("WalletSearchSceneViewModel pin asset error: \(error)")
         }
     }
 
     func onSelectCopyAddress(_ message: String) {
-        isPresentingToastMessage = ToastMessage(
-            title: message,
-            image: SystemImage.copy
-        )
+        isPresentingToastMessage = .copy(message)
     }
 
     func contextMenuItems(for assetData: AssetData) -> [ContextMenuItemType] {

--- a/Gem/Navigation/Price Alerts/PriceAlertsNavigationView.swift
+++ b/Gem/Navigation/Price Alerts/PriceAlertsNavigationView.swift
@@ -53,6 +53,6 @@ struct PriceAlertsNavigationView: View {
     
     private func onSelectAsset(asset: Asset) {
         isPresentingAddAsset = false
-        isPresentingToastMessage = ToastMessage(title: Localized.PriceAlerts.enabledFor(asset.name), image: SystemImage.bellFill)
+        isPresentingToastMessage = .priceAlert(for: asset.name, enabled: true)
     }
 }

--- a/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -54,6 +54,7 @@ struct WalletNavigationStack: View {
                             wallet: model.wallet,
                             searchService: AssetSearchService(assetsService: assetsService),
                             activityService: activityService,
+                            walletsService: walletsService,
                             onDismissSearch: model.onToggleSearch,
                             onSelectAssetAction: { navigationState.wallet.append(Scenes.Asset(asset: $0)) },
                             onAddToken: model.onSelectAddCustomToken

--- a/Packages/PrimitivesComponents/Sources/Extensions/ToastMessage+PrimitivesComponents.swift
+++ b/Packages/PrimitivesComponents/Sources/Extensions/ToastMessage+PrimitivesComponents.swift
@@ -8,4 +8,34 @@ public extension ToastMessage {
     static func copied(_ value: String) -> ToastMessage {
         ToastMessage(title: Localized.Common.copied(value), image: SystemImage.copy)
     }
+
+    static func copy(_ message: String) -> ToastMessage {
+        ToastMessage(title: message, image: SystemImage.copy)
+    }
+
+    static func pinned(_ name: String, isPinned: Bool) -> ToastMessage {
+        ToastMessage(
+            title: isPinned ? "\(Localized.Common.pinned) \(name)" : "\(Localized.Common.unpin) \(name)",
+            image: isPinned ? SystemImage.pin : SystemImage.unpin
+        )
+    }
+
+    static func addedToWallet() -> ToastMessage {
+        ToastMessage(title: Localized.Asset.addToWallet, image: SystemImage.plusCircle)
+    }
+
+    static func priceAlert(for assetName: String, enabled: Bool) -> ToastMessage {
+        ToastMessage(
+            title: enabled ? Localized.PriceAlerts.enabledFor(assetName) : Localized.PriceAlerts.disabledFor(assetName),
+            image: SystemImage.bellFill
+        )
+    }
+
+    static func priceAlert(message: String) -> ToastMessage {
+        ToastMessage(title: message, image: SystemImage.bellFill)
+    }
+
+    static func success(_ message: String) -> ToastMessage {
+        ToastMessage(title: message, image: SystemImage.checkmark)
+    }
 }

--- a/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ToastMessageTests.swift
+++ b/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ToastMessageTests.swift
@@ -1,0 +1,36 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Style
+import Components
+@testable import PrimitivesComponents
+
+struct ToastMessageTests {
+
+    @Test
+    func copy() {
+        #expect(ToastMessage.copy("Copied").image == SystemImage.copy)
+    }
+
+    @Test
+    func pinned() {
+        #expect(ToastMessage.pinned("BTC", isPinned: true).image == SystemImage.pin)
+        #expect(ToastMessage.pinned("BTC", isPinned: false).image == SystemImage.unpin)
+    }
+
+    @Test
+    func addedToWallet() {
+        #expect(ToastMessage.addedToWallet().image == SystemImage.plusCircle)
+    }
+
+    @Test
+    func priceAlert() {
+        #expect(ToastMessage.priceAlert(for: "ETH", enabled: true).image == SystemImage.bellFill)
+        #expect(ToastMessage.priceAlert(message: "Alert set").image == SystemImage.bellFill)
+    }
+
+    @Test
+    func success() {
+        #expect(ToastMessage.success("Saved").image == SystemImage.checkmark)
+    }
+}


### PR DESCRIPTION
Introduces context menu actions for assets in WalletSearchScene, allowing users to copy addresses, pin/unpin assets, and add assets to wallet. Displays toast messages for these actions. Updates WalletSearchSceneViewModel and WalletNavigationStack to support new functionality and dependencies.

closes  #1452

<img width="360"  alt="image" src="https://github.com/user-attachments/assets/fc6efd7f-5aee-451a-bc67-54e3fc3e0455" />
