### PR TITLE
Fix widget icons by using local assets instead of AsyncImage

### DIFF
--- a/Gem.xcodeproj/project.pbxproj
+++ b/Gem.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		B68BD2E62DE0760E00687F09 /* Primitives in Frameworks */ = {isa = PBXBuildFile; productRef = B68BD2E52DE0760E00687F09 /* Primitives */; };
 		B69C52F32DE72B1000BBD95D /* ManageWallets in Frameworks */ = {isa = PBXBuildFile; productRef = B69C52F22DE72B1000BBD95D /* ManageWallets */; };
 		B69D9C872ED85EA000A04F7F /* ImportWalletReceiveBitcoinUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69D9C852ED85EA000A04F7F /* ImportWalletReceiveBitcoinUITests.swift */; };
+		B6A5DE7C2EE6EE6E00E70673 /* PrimitivesComponents in Frameworks */ = {isa = PBXBuildFile; productRef = B6A5DE7B2EE6EE6E00E70673 /* PrimitivesComponents */; };
 		B6B86A102D702E7C00D31D65 /* SwapNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B86A0F2D702E7C00D31D65 /* SwapNavigationView.swift */; };
 		B6C8F2AF2EDE2691005915E4 /* UITestKitConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C8F2AD2EDE2691005915E4 /* UITestKitConstants.swift */; };
 		B6CBBC552ED9A80B0043443B /* CreateWalletUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CBBC542ED9A80B0043443B /* CreateWalletUITests.swift */; };
@@ -393,6 +394,7 @@
 				D8CFDEB02E37FCB000D27283 /* Components in Frameworks */,
 				D8CFDEA82E37FC8800D27283 /* Preferences in Frameworks */,
 				D838194B2E256A5A0076CDB3 /* SwiftUI.framework in Frameworks */,
+				B6A5DE7C2EE6EE6E00E70673 /* PrimitivesComponents in Frameworks */,
 				D8CFDEAA2E37FC8C00D27283 /* GemAPI in Frameworks */,
 				D8CFDEA02E37FC3B00D27283 /* Primitives in Frameworks */,
 				D838194A2E256A5A0076CDB3 /* WidgetKit.framework in Frameworks */,
@@ -929,6 +931,7 @@
 			name = GemPriceWidget;
 			packageProductDependencies = (
 				D8WIDGET12345678901234 /* WidgetLocalization */,
+				B6A5DE7B2EE6EE6E00E70673 /* PrimitivesComponents */,
 			);
 			productName = GemPriceWidgetExtension;
 			productReference = D83819492E256A5A0076CDB3 /* GemPriceWidget.appex */;
@@ -1949,6 +1952,10 @@
 		B69C52F22DE72B1000BBD95D /* ManageWallets */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ManageWallets;
+		};
+		B6A5DE7B2EE6EE6E00E70673 /* PrimitivesComponents */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PrimitivesComponents;
 		};
 		C35DA07B2A9C3B4B008CCEFA /* Settings */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Gem.xcodeproj/project.pbxproj
+++ b/Gem.xcodeproj/project.pbxproj
@@ -62,7 +62,6 @@
 		B68BD2E62DE0760E00687F09 /* Primitives in Frameworks */ = {isa = PBXBuildFile; productRef = B68BD2E52DE0760E00687F09 /* Primitives */; };
 		B69C52F32DE72B1000BBD95D /* ManageWallets in Frameworks */ = {isa = PBXBuildFile; productRef = B69C52F22DE72B1000BBD95D /* ManageWallets */; };
 		B69D9C872ED85EA000A04F7F /* ImportWalletReceiveBitcoinUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69D9C852ED85EA000A04F7F /* ImportWalletReceiveBitcoinUITests.swift */; };
-		B6A5DE7C2EE6EE6E00E70673 /* PrimitivesComponents in Frameworks */ = {isa = PBXBuildFile; productRef = B6A5DE7B2EE6EE6E00E70673 /* PrimitivesComponents */; };
 		B6B86A102D702E7C00D31D65 /* SwapNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B86A0F2D702E7C00D31D65 /* SwapNavigationView.swift */; };
 		B6C8F2AF2EDE2691005915E4 /* UITestKitConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C8F2AD2EDE2691005915E4 /* UITestKitConstants.swift */; };
 		B6CBBC552ED9A80B0043443B /* CreateWalletUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CBBC542ED9A80B0043443B /* CreateWalletUITests.swift */; };
@@ -394,7 +393,6 @@
 				D8CFDEB02E37FCB000D27283 /* Components in Frameworks */,
 				D8CFDEA82E37FC8800D27283 /* Preferences in Frameworks */,
 				D838194B2E256A5A0076CDB3 /* SwiftUI.framework in Frameworks */,
-				B6A5DE7C2EE6EE6E00E70673 /* PrimitivesComponents in Frameworks */,
 				D8CFDEAA2E37FC8C00D27283 /* GemAPI in Frameworks */,
 				D8CFDEA02E37FC3B00D27283 /* Primitives in Frameworks */,
 				D838194A2E256A5A0076CDB3 /* WidgetKit.framework in Frameworks */,
@@ -931,7 +929,6 @@
 			name = GemPriceWidget;
 			packageProductDependencies = (
 				D8WIDGET12345678901234 /* WidgetLocalization */,
-				B6A5DE7B2EE6EE6E00E70673 /* PrimitivesComponents */,
 			);
 			productName = GemPriceWidgetExtension;
 			productReference = D83819492E256A5A0076CDB3 /* GemPriceWidget.appex */;
@@ -1952,10 +1949,6 @@
 		B69C52F22DE72B1000BBD95D /* ManageWallets */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = ManageWallets;
-		};
-		B6A5DE7B2EE6EE6E00E70673 /* PrimitivesComponents */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = PrimitivesComponents;
 		};
 		C35DA07B2A9C3B4B008CCEFA /* Settings */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/GemPriceWidget/Services/WidgetPriceService.swift
+++ b/GemPriceWidget/Services/WidgetPriceService.swift
@@ -1,21 +1,23 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import SwiftUI
 import Primitives
 import GemAPI
 import WidgetKit
 import Preferences
+import Style
 
 internal struct WidgetPriceService {
     private let pricesService: any GemAPIPricesService
     private let assetsService: any GemAPIAssetsService
     private let preferences = SharedPreferences()
-    
+
     init() {
         self.pricesService = GemAPIService()
         self.assetsService = GemAPIService()
     }
-    
+
     internal func coins(_ widgetFamily: WidgetFamily) -> [AssetId] {
         switch widgetFamily {
         case .systemSmall:
@@ -30,35 +32,68 @@ internal struct WidgetPriceService {
             ]
         }
     }
-    
+
     internal func fetchTopCoinPrices(widgetFamily: WidgetFamily = .systemMedium) async -> PriceWidgetEntry {
         let coins = coins(widgetFamily)
         let currency = preferences.currency
-        
+
         do {
             let (assets, prices) = try await (
                 assetsService.getAssets(assetIds: coins),
                 pricesService.getPrices(currency: currency, assetIds: coins)
             )
-            
-            let coinPrices = assets.compactMap { asset -> CoinPrice? in
-                guard let price = prices.first(where: { $0.assetId == asset.asset.id }) else { return nil }
-                return CoinPrice(
-                    assetId: asset.asset.id,
-                    name: asset.asset.name,
-                    symbol: asset.asset.symbol,
-                    price: price.price,
-                    priceChangePercentage24h: price.priceChangePercentage24h
-                )
-            }
+
             return PriceWidgetEntry(
                 date: Date(),
-                coinPrices: coinPrices,
+                coinPrices: await coinPrices(assets: assets, prices: prices),
                 currency: currency,
                 widgetFamily: widgetFamily
             )
         } catch {
             return PriceWidgetEntry.error(error: error.localizedDescription, widgetFamily: widgetFamily)
+        }
+    }
+}
+
+// MARK: - Private
+
+extension WidgetPriceService {
+    private func coinPrices(assets: [AssetBasic], prices: [AssetPrice]) async -> [CoinPrice] {
+        await withTaskGroup(of: CoinPrice?.self) { group in
+            for asset in assets {
+                guard let assetPrice = prices.first(where: { $0.assetId == asset.asset.id }) else { continue }
+                group.addTask {
+                    CoinPrice(
+                        assetId: asset.asset.id,
+                        name: asset.asset.name,
+                        symbol: asset.asset.symbol,
+                        price: assetPrice.price,
+                        priceChangePercentage24h: assetPrice.priceChangePercentage24h,
+                        image: await Self.image(for: asset.asset.id)
+                    )
+                }
+            }
+            return await group.compactMap { $0 }.reduce(into: []) { $0.append($1) }
+        }
+    }
+
+    private static func image(for assetId: AssetId) async -> Image? {
+        switch assetId.type {
+        case .native: Images.name(assetId.chain.rawValue)
+        case .token: await fetchRemoteImage(url: AssetImageFormatter.shared.getURL(for: assetId))
+        }
+    }
+
+    private static func fetchRemoteImage(url: URL) async -> Image? {
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            guard let uiImage = UIImage(data: data) else {
+                throw AnyError("wrong image format")
+            }
+            return Image(uiImage: uiImage)
+        } catch {
+            debugLog("WidgetPriceService: Failed to fetch image from \(url): \(error)")
+            return nil
         }
     }
 }

--- a/GemPriceWidget/Types/CoinPrice.swift
+++ b/GemPriceWidget/Types/CoinPrice.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import SwiftUI
 import Primitives
 
 internal struct CoinPrice: Sendable, Identifiable {
@@ -9,24 +10,7 @@ internal struct CoinPrice: Sendable, Identifiable {
     let symbol: String
     let price: Double
     let priceChangePercentage24h: Double
-    
+    let image: Image?
+
     var id: AssetId { assetId }
-    
-    init(
-        assetId: AssetId,
-        name: String,
-        symbol: String,
-        price: Double,
-        priceChangePercentage24h: Double,
-    ) {
-        self.assetId = assetId
-        self.name = name
-        self.symbol = symbol
-        self.price = price
-        self.priceChangePercentage24h = priceChangePercentage24h
-    }
- 
-    var imageURL: URL {
-        AssetImageFormatter.shared.getURL(for: id)
-    }
 }

--- a/GemPriceWidget/Types/PriceWidgetEntry.swift
+++ b/GemPriceWidget/Types/PriceWidgetEntry.swift
@@ -3,6 +3,7 @@
 import Foundation
 import WidgetKit
 import Primitives
+import Style
 
 internal struct PriceWidgetEntry: TimelineEntry, Sendable {
     let date: Date
@@ -10,7 +11,7 @@ internal struct PriceWidgetEntry: TimelineEntry, Sendable {
     let currency: String
     let error: String?
     let widgetFamily: WidgetFamily
-    
+
     init(
         date: Date,
         coinPrices: [CoinPrice],
@@ -24,7 +25,7 @@ internal struct PriceWidgetEntry: TimelineEntry, Sendable {
         self.error = error
         self.widgetFamily = widgetFamily
     }
-    
+
     static func error(error: String, widgetFamily: WidgetFamily = .systemMedium) -> PriceWidgetEntry {
         PriceWidgetEntry(
             date: Date(),
@@ -33,7 +34,7 @@ internal struct PriceWidgetEntry: TimelineEntry, Sendable {
             widgetFamily: widgetFamily
         )
     }
-    
+
     static func placeholder(widgetFamily: WidgetFamily = .systemMedium) -> PriceWidgetEntry {
         let placeholderCoins = [
             CoinPrice(
@@ -41,24 +42,27 @@ internal struct PriceWidgetEntry: TimelineEntry, Sendable {
                 name: "Bitcoin",
                 symbol: "BTC",
                 price: 69000,
-                priceChangePercentage24h: 2.5
+                priceChangePercentage24h: 2.5,
+                image: Images.name(Chain.bitcoin.rawValue)
             ),
             CoinPrice(
                 assetId: AssetId(chain: .ethereum, tokenId: nil),
                 name: "Ethereum",
                 symbol: "ETH",
                 price: 3500,
-                priceChangePercentage24h: 1.2
+                priceChangePercentage24h: 1.2,
+                image: Images.name(Chain.ethereum.rawValue)
             ),
             CoinPrice(
                 assetId: AssetId(chain: .solana, tokenId: nil),
                 name: "Solana",
                 symbol: "SOL",
                 price: 150,
-                priceChangePercentage24h: -0.8
+                priceChangePercentage24h: -0.8,
+                image: Images.name(Chain.solana.rawValue)
             )
         ]
-        
+
         return PriceWidgetEntry(
             date: Date(),
             coinPrices: widgetFamily == .systemSmall ? Array(placeholderCoins.prefix(1)) : placeholderCoins,

--- a/GemPriceWidget/ViewModels/CoinPriceRowViewModel.swift
+++ b/GemPriceWidget/ViewModels/CoinPriceRowViewModel.swift
@@ -4,6 +4,7 @@ import SwiftUI
 import Formatters
 import Style
 import Components
+import PrimitivesComponents
 
 @Observable
 @MainActor
@@ -11,7 +12,7 @@ internal final class CoinPriceRowViewModel {
     private let coin: CoinPrice
     private let currencyFormatter: CurrencyFormatter
     private let percentFormatter: CurrencyFormatter
-    
+
     internal init(
         coin: CoinPrice,
         currencyFormatter: CurrencyFormatter,
@@ -21,31 +22,31 @@ internal final class CoinPriceRowViewModel {
         self.currencyFormatter = currencyFormatter
         self.percentFormatter = percentFormatter
     }
-    
+
     var name: String {
         coin.name
     }
-    
+
     var symbol: String {
         coin.symbol
     }
-    
-    var imageURL: URL? {
-        coin.imageURL
+
+    var chainImage: Image {
+        ChainImage(chain: coin.assetId.chain).image
     }
-    
+
     var priceText: String {
         currencyFormatter.string(coin.price)
     }
-    
+
     var percentageText: String {
         percentFormatter.string(coin.priceChangePercentage24h)
     }
-    
+
     var percentageColor: Color {
         PriceChangeColor.color(for: coin.priceChangePercentage24h)
     }
-    
+
     var percentageChange: Double {
         coin.priceChangePercentage24h
     }

--- a/GemPriceWidget/ViewModels/CoinPriceRowViewModel.swift
+++ b/GemPriceWidget/ViewModels/CoinPriceRowViewModel.swift
@@ -4,7 +4,6 @@ import SwiftUI
 import Formatters
 import Style
 import Components
-import PrimitivesComponents
 
 @Observable
 @MainActor
@@ -31,8 +30,19 @@ internal final class CoinPriceRowViewModel {
         coin.symbol
     }
 
-    var chainImage: Image {
-        ChainImage(chain: coin.assetId.chain).image
+    var assetImage: AssetImage {
+        AssetImage(
+            type: coin.symbol,
+            placeholder: coin.image,
+            chainPlaceholder: chainPlaceholder
+        )
+    }
+    
+    var chainPlaceholder: Image? {
+        switch coin.assetId.type {
+        case .native: nil
+        case .token: Images.name(coin.assetId.chain.rawValue)
+        }
     }
 
     var priceText: String {

--- a/GemPriceWidget/Views/CoinPriceRow.swift
+++ b/GemPriceWidget/Views/CoinPriceRow.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import Style
+import Components
 
 struct CoinPriceRow: View {
     private let model: CoinPriceRowViewModel
@@ -12,9 +13,7 @@ struct CoinPriceRow: View {
 
     var body: some View {
         HStack(spacing: Spacing.small) {
-            model.chainImage
-                .resizable()
-                .frame(size: .list.assets.widget)
+            AssetImageView(assetImage: model.assetImage, size: .list.assets.widget)
 
             VStack(alignment: .leading, spacing: Spacing.extraSmall) {
                 Text(model.name)

--- a/GemPriceWidget/Views/CoinPriceRow.swift
+++ b/GemPriceWidget/Views/CoinPriceRow.swift
@@ -1,42 +1,51 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import SwiftUI
-import Components
 import Style
 
 struct CoinPriceRow: View {
     private let model: CoinPriceRowViewModel
-    
+
     init(model: CoinPriceRowViewModel) {
         self.model = model
     }
-    
+
     var body: some View {
         HStack(spacing: Spacing.small) {
-            AsyncImageView(url: model.imageURL)
-    
+            model.chainImage
+                .resizable()
+                .frame(size: .list.assets.widget)
+
             VStack(alignment: .leading, spacing: Spacing.extraSmall) {
                 Text(model.name)
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.system(size: Constants.textFontSize, weight: .medium))
                     .foregroundColor(Colors.black)
-                
+
                 Text(model.symbol)
                     .font(.caption)
                     .foregroundColor(Colors.secondaryText)
             }
-            
+
             Spacer()
-        
+
             VStack(alignment: .trailing, spacing: Spacing.extraSmall) {
                 Text(model.priceText)
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.system(size: Constants.textFontSize, weight: .medium))
                     .foregroundColor(Colors.black)
-                
+
                 Text(model.percentageText)
                     .font(.caption)
                     .foregroundColor(model.percentageColor)
             }
         }
         .padding(.vertical, Spacing.tiny)
+    }
+}
+
+// MARK: - Constants
+
+extension CoinPriceRow {
+    enum Constants {
+        static let textFontSize: CGFloat = 14
     }
 }

--- a/GemPriceWidget/Views/SmallCoinView.swift
+++ b/GemPriceWidget/Views/SmallCoinView.swift
@@ -2,56 +2,69 @@
 
 import SwiftUI
 import Style
-import Components
 
 struct SmallCoinView: View {
     private let model: CoinPriceRowViewModel
-    
+
     init(model: CoinPriceRowViewModel) {
         self.model = model
     }
-    
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: .zero) {
             HStack {
-                AsyncImageView(url: model.imageURL)
+                model.chainImage
+                    .resizable()
+                    .frame(size: .list.assets.widget)
                 Spacer()
                 Images.Logo.logo
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 32, height: 32)
+                    .frame(width: Constants.logoSize, height: Constants.logoSize)
             }
-            
+
             Spacer()
                 .frame(height: Spacing.small)
-            
+
             Text(model.name)
-                .font(.system(size: 16, weight: .regular))
+                .font(.system(size: Constants.nameFontSize, weight: .regular))
                 .foregroundColor(Colors.black)
-            
+
             Spacer()
                 .frame(height: Spacing.tiny)
-            
+
             Text(model.priceText)
-                .font(.system(size: 32, weight: .bold))
+                .font(.system(size: Constants.priceFontSize, weight: .bold))
                 .foregroundColor(Colors.black)
-                .minimumScaleFactor(0.5)
+                .minimumScaleFactor(Constants.priceMinScaleFactor)
                 .lineLimit(1)
-            
+
             Spacer()
                 .frame(height: Spacing.tiny)
-            
+
             HStack {
                 Text(model.percentageText)
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(.system(size: Constants.percentageFontSize, weight: .semibold))
                     .foregroundColor(Colors.black)
                     .padding(.vertical, Spacing.tiny + Spacing.extraSmall)
                     .padding(.horizontal, Spacing.tiny + Spacing.extraSmall)
                     .background(model.percentageColor)
-                    .cornerRadius(10)
+                    .cornerRadius(Constants.percentageCornerRadius)
             }
         }
-        .padding(0)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Constants
+
+extension SmallCoinView {
+    enum Constants {
+        static let logoSize: CGFloat = 32
+        static let nameFontSize: CGFloat = 16
+        static let priceFontSize: CGFloat = 32
+        static let priceMinScaleFactor: CGFloat = 0.5
+        static let percentageFontSize: CGFloat = 16
+        static let percentageCornerRadius: CGFloat = 10
     }
 }

--- a/GemPriceWidget/Views/SmallCoinView.swift
+++ b/GemPriceWidget/Views/SmallCoinView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import Style
+import Components
 
 struct SmallCoinView: View {
     private let model: CoinPriceRowViewModel
@@ -13,9 +14,7 @@ struct SmallCoinView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
             HStack {
-                model.chainImage
-                    .resizable()
-                    .frame(size: .list.assets.widget)
+                AssetImageView(assetImage: model.assetImage, size: .list.assets.widget)
                 Spacer()
                 Images.Logo.logo
                     .resizable()

--- a/Packages/Style/Sources/Spacing.swift
+++ b/Packages/Style/Sources/Spacing.swift
@@ -121,6 +121,8 @@ public extension Sizing {
 
         public struct assets {
             public static let height: CGFloat = Sizing.image.asset
+            /// 40
+            public static let widget: CGFloat = 40
         }
 
         public struct transactions {


### PR DESCRIPTION
## Summary
  - Add asset icon support for price widget
  - Native tokens use local chain images from Style assets
  - Token icons are fetched from API in TimelineProvider before rendering

  AsyncImage/CachedAsyncImage doesn't work in WidgetKit because widget views are rendered synchronously from
  pre-archived timeline data. Network requests get cancelled before completing.

  As recommended by Apple engineer: https://developer.apple.com/forums/thread/652581?answerId=618126022#618126022

  > download the images in the timeline provider and send the timeline when they are all done
  
  ## Screenshots
  
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-09 at 13 55 41" src="https://github.com/user-attachments/assets/f4e17797-a57b-4a04-9fd5-5488d9bd9221" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-09 at 13 56 13" src="https://github.com/user-attachments/assets/1457cfa7-ad18-423f-a698-2d5c5e53c9b2" />


Fix: https://github.com/gemwalletcom/gem-ios/issues/1464