### PR TITLE
Fix receive warning message width

### DIFF
--- a/Features/Transfer/Sources/Scenes/ReceiveScene.swift
+++ b/Features/Transfer/Sources/Scenes/ReceiveScene.swift
@@ -59,7 +59,6 @@ public struct ReceiveScene: View {
                 Text(model.warningMessage)
                     .textStyle(.subHeadline)
                     .multilineTextAlignment(.center)
-                    .padding(.horizontal, .medium)
                     .padding(.top, .small)
                     .frame(maxWidth: model.qrSize + .extraLarge)
                 Spacer()

--- a/Features/Transfer/Sources/ViewModels/ReceiveViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ReceiveViewModel.swift
@@ -10,7 +10,9 @@ import Formatters
 @Observable
 @MainActor
 public final class ReceiveViewModel: Sendable {
-    let qrSize: CGFloat = 248
+    var qrSize: CGFloat {
+        UIDevice.current.userInterfaceIdiom == .pad ? 180 : 248
+    }
     
     let assetModel: AssetViewModel
     let walletId: WalletId

--- a/Features/Transfer/Sources/ViewModels/ReceiveViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ReceiveViewModel.swift
@@ -11,7 +11,7 @@ import Formatters
 @MainActor
 public final class ReceiveViewModel: Sendable {
     var qrSize: CGFloat {
-        UIDevice.current.userInterfaceIdiom == .pad ? 180 : 248
+        UIDevice.current.userInterfaceIdiom == .pad ? 180 : 260
     }
     
     let assetModel: AssetViewModel

--- a/Packages/Primitives/TestKit/Rewards+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/Rewards+PrimitivesTestKit.swift
@@ -19,12 +19,12 @@ public extension Rewards {
     }
 }
 
-public extension RewardsEventItem {
+public extension RewardEvent {
     static func mock(
-        event: RewardsEvent = .invite,
+        event: RewardEventType = .inviteNew,
         points: Int32 = 100,
         createdAt: Date = Date()
-    ) -> RewardsEventItem {
-        RewardsEventItem(event: event, points: points, createdAt: createdAt)
+    ) -> RewardEvent {
+        RewardEvent(event: event, points: points, createdAt: createdAt)
     }
 }


### PR DESCRIPTION

<img width="1032" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2025-12-16 at 00 28 12" src="https://github.com/user-attachments/assets/32f2aaa0-b013-4bdb-aa70-a7adae31337d" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-16 at 00 26 22" src="https://github.com/user-attachments/assets/7b9ccab6-d756-435d-be15-f94d638b2e5b" />

Fix: https://github.com/gemwalletcom/gem-ios/issues/1495