### PR TITLE
Add max brightness modifier to ReceiveScene

### DIFF
--- a/Features/Transfer/Sources/Scenes/ReceiveScene.swift
+++ b/Features/Transfer/Sources/Scenes/ReceiveScene.swift
@@ -95,6 +95,7 @@ public struct ReceiveScene: View {
             await model.onLoadImage()
         }
         .taskOnce(model.onTaskOnce)
+        .maxBrightness()
     }
 }
 

--- a/Packages/Components/Sources/ViewModifiers/MaxBrightnessModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/MaxBrightnessModifier.swift
@@ -1,0 +1,34 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import UIKit
+
+public extension View {
+    func maxBrightness() -> some View {
+        modifier(MaxBrightnessModifier())
+    }
+}
+
+private struct MaxBrightnessModifier: ViewModifier {
+    @State private var brightness: CGFloat = UIScreen.main.brightness
+
+    func body(content: Content) -> some View {
+        content
+            .task {
+                brightness = UIScreen.main.brightness
+                await setBrightness(1.0)
+            }
+            .onDisappear {
+                Task { await setBrightness(brightness) }
+            }
+    }
+
+    private func setBrightness(_ target: CGFloat) async {
+        let start = UIScreen.main.brightness
+        let steps = 20
+        for step in 1...steps {
+            try? await Task.sleep(nanoseconds: 15_000_000)
+            UIScreen.main.brightness = start + (target - start) * CGFloat(step) / CGFloat(steps)
+        }
+    }
+}


### PR DESCRIPTION
Description:
Increase screen brightness to maximum when showing QR code on ReceiveScene for better scanning visibility. Brightness smoothly animates to max on appear and restores to previous level on disappear.

Close: https://github.com/gemwalletcom/gem-ios/issues/1501