### PR TITLE
Fix leverage picker crash when opening perpetual position

### DIFF
--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -77,9 +77,10 @@ public final class AmountSceneViewModel {
         if case .perpetual(let data) = type {
             switch data.positionAction {
             case .open:
-                let defaultLeverage = Preferences.standard.perpetualLeverage
-                let maxLeverage = data.positionAction.transferData.leverage
-                self.selectedLeverage = LeverageOption(value: min(defaultLeverage, maxLeverage))
+                self.selectedLeverage = LeverageOption.option(
+                    desiredValue: Preferences.standard.perpetualLeverage,
+                    from: leverageOptions
+                )
             case .increase, .reduce:
                 self.selectedLeverage = LeverageOption(value: data.positionAction.transferData.leverage)
             }

--- a/Packages/PrimitivesComponents/Sources/Types/LeverageOption.swift
+++ b/Packages/PrimitivesComponents/Sources/Types/LeverageOption.swift
@@ -18,8 +18,8 @@ public struct LeverageOption: WheelPickerDisplayable, Sendable {
     public static func option(desiredValue: UInt8, from available: [LeverageOption]) -> LeverageOption {
         guard !available.isEmpty else { return allOptions[0] }
         return available.min { lhs, rhs in
-            let lhsDist = max(lhs.value, desiredValue) - min(lhs.value, desiredValue)
-            let rhsDist = max(rhs.value, desiredValue) - min(rhs.value, desiredValue)
+            let lhsDist = abs(Int(lhs.value) - Int(desiredValue))
+            let rhsDist = abs(Int(rhs.value) - Int(desiredValue))
             return lhsDist != rhsDist ? lhsDist < rhsDist : lhs.value > rhs.value
         }!
     }

--- a/Packages/PrimitivesComponents/Sources/Types/LeverageOption.swift
+++ b/Packages/PrimitivesComponents/Sources/Types/LeverageOption.swift
@@ -14,4 +14,13 @@ public struct LeverageOption: WheelPickerDisplayable, Sendable {
 
     public var id: UInt8 { value }
     public var displayText: String { "\(value)x" }
+
+    public static func option(desiredValue: UInt8, from available: [LeverageOption]) -> LeverageOption {
+        guard !available.isEmpty else { return allOptions[0] }
+        return available.min { lhs, rhs in
+            let lhsDist = max(lhs.value, desiredValue) - min(lhs.value, desiredValue)
+            let rhsDist = max(rhs.value, desiredValue) - min(rhs.value, desiredValue)
+            return lhsDist != rhsDist ? lhsDist < rhsDist : lhs.value > rhs.value
+        }!
+    }
 }

--- a/Packages/PrimitivesComponents/Sources/Types/LeverageOption.swift
+++ b/Packages/PrimitivesComponents/Sources/Types/LeverageOption.swift
@@ -3,8 +3,8 @@
 import Foundation
 import Components
 
-public struct LeverageOption: WheelPickerDisplayable, Sendable {
-    public static let allOptions: [LeverageOption] = [1, 2, 3, 5, 10, 20, 25, 30, 40, 50].map { LeverageOption(value: $0) }
+public struct LeverageOption: WheelPickerDisplayable, Comparable, Sendable {
+    public static let allOptions: [LeverageOption] = [1, 2, 3, 5, 10, 20, 25, 30, 40, 50].map { .init(value: $0) }
 
     public let value: UInt8
 
@@ -15,12 +15,11 @@ public struct LeverageOption: WheelPickerDisplayable, Sendable {
     public var id: UInt8 { value }
     public var displayText: String { "\(value)x" }
 
+    public static func < (lhs: LeverageOption, rhs: LeverageOption) -> Bool {
+        lhs.value < rhs.value
+    }
+
     public static func option(desiredValue: UInt8, from available: [LeverageOption]) -> LeverageOption {
-        guard !available.isEmpty else { return allOptions[0] }
-        return available.min { lhs, rhs in
-            let lhsDist = abs(Int(lhs.value) - Int(desiredValue))
-            let rhsDist = abs(Int(rhs.value) - Int(desiredValue))
-            return lhsDist != rhsDist ? lhsDist < rhsDist : lhs.value > rhs.value
-        }!
+        available.filter { $0.value <= desiredValue }.max() ?? available.min() ?? allOptions[0]
     }
 }

--- a/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/LeverageOptionTests.swift
+++ b/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/LeverageOptionTests.swift
@@ -1,0 +1,21 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+@testable import PrimitivesComponents
+
+struct LeverageOptionTests {
+
+    @Test
+    func testLeverageOption() {
+        let allOptions = LeverageOption.allOptions
+        let maxLeverage4 = allOptions.filter { $0.value <= 4 }
+
+        #expect(LeverageOption.option(desiredValue: 10, from: allOptions).value == 10)
+        #expect(LeverageOption.option(desiredValue: 5, from: allOptions).value == 5)
+        #expect(LeverageOption.option(desiredValue: 4, from: allOptions).value == 5)
+        #expect(LeverageOption.option(desiredValue: 8, from: allOptions).value == 10)
+        #expect(LeverageOption.option(desiredValue: 10, from: maxLeverage4).value == 3)
+        #expect(LeverageOption.option(desiredValue: 50, from: maxLeverage4).value == 3)
+        #expect(LeverageOption.option(desiredValue: 10, from: []).value == 1)
+    }
+}

--- a/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/LeverageOptionTests.swift
+++ b/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/LeverageOptionTests.swift
@@ -12,8 +12,8 @@ struct LeverageOptionTests {
 
         #expect(LeverageOption.option(desiredValue: 10, from: allOptions).value == 10)
         #expect(LeverageOption.option(desiredValue: 5, from: allOptions).value == 5)
-        #expect(LeverageOption.option(desiredValue: 4, from: allOptions).value == 5)
-        #expect(LeverageOption.option(desiredValue: 8, from: allOptions).value == 10)
+        #expect(LeverageOption.option(desiredValue: 4, from: allOptions).value == 3)
+        #expect(LeverageOption.option(desiredValue: 8, from: allOptions).value == 5)
         #expect(LeverageOption.option(desiredValue: 10, from: maxLeverage4).value == 3)
         #expect(LeverageOption.option(desiredValue: 50, from: maxLeverage4).value == 3)
         #expect(LeverageOption.option(desiredValue: 10, from: []).value == 1)


### PR DESCRIPTION
  - Fix array index out of bounds crash in SwiftUI Picker when opening perpetual position
  - Add `LeverageOption.option(desiredValue:from:)` to select closest valid leverage option
  - Add unit tests for leverage option selection
  
closes #1505 