### PR TITLE
Add deep links for fiat buy/sell and price alerts

### DIFF
--- a/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -217,8 +217,8 @@ extension AssetSceneViewModel {
 
     func onSelectHeader(_ buttonType: HeaderButtonType) {
         let selectType: SelectedAssetType = switch buttonType {
-        case .buy: .buy(assetData.asset)
-        case .sell: .sell(assetData.asset)
+        case .buy: .buy(assetData.asset, amount: nil)
+        case .sell: .sell(assetData.asset, amount: nil)
         case .send: .send(.asset(assetData.asset))
         case .swap: swapAssetType
         case .receive: .receive(.asset)

--- a/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
+++ b/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
@@ -50,7 +50,8 @@ public final class FiatSceneViewModel {
         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencyCode: Currency.usd.rawValue),
         assetAddress: AssetAddress,
         walletId: String,
-        type: FiatQuoteType = .buy
+        type: FiatQuoteType = .buy,
+        amount: Int? = nil
     ) {
         self.fiatService = fiatService
         self.securePreferences = securePreferences
@@ -80,6 +81,10 @@ public final class FiatSceneViewModel {
             asset: assetAddress.asset,
             currencyFormatter: currencyFormatter
         )
+
+        if let amount {
+            currentViewModel.inputValidationModel.text = String(amount)
+        }
     }
 
     var currentViewModel: FiatOperationViewModel {

--- a/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
+++ b/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
@@ -60,7 +60,10 @@ public struct SetPriceAlertScene: View {
         }
         .onChange(of: model.state.type, model.onChangeAlertType)
         .onChange(of: model.state.amount, onChangeAmount)
-        .onAppear { focusedField = true }
+        .onAppear {
+            focusedField = true
+            model.setAlertDirection(for: assetData.price)
+        }
     }
 }
 

--- a/Features/PriceAlerts/Sources/Types/SetPriceAlertViewModelState.swift
+++ b/Features/PriceAlerts/Sources/Types/SetPriceAlertViewModelState.swift
@@ -5,7 +5,7 @@ import Primitives
 
 struct SetPriceAlertViewModelState {
     var type: SetPriceAlertType = .price
-    
+
     var amount: String {
         get {
             switch type {
@@ -20,7 +20,7 @@ struct SetPriceAlertViewModelState {
             }
         }
     }
-    
+
     var alertDirection: PriceAlertDirection? {
         get {
             switch type {
@@ -35,10 +35,17 @@ struct SetPriceAlertViewModelState {
             }
         }
     }
-    
+
     private var priceAmount: String = .empty
     private var percentageAmount: String = "5"
-    
+
     private var priceDirection: PriceAlertDirection?
     private var percentageDirection: PriceAlertDirection = .up
+
+    init(price: Double? = nil) {
+        if let price {
+            self.type = .price
+            self.priceAmount = String(price)
+        }
+    }
 }

--- a/Features/PriceAlerts/Sources/ViewModels/SetPriceAlertViewModel.swift
+++ b/Features/PriceAlerts/Sources/ViewModels/SetPriceAlertViewModel.swift
@@ -27,13 +27,14 @@ public final class SetPriceAlertViewModel {
         walletId: WalletId,
         assetId: AssetId,
         priceAlertService: PriceAlertService,
+        price: Double? = nil,
         onComplete: StringAction
     ) {
         self.walletId = walletId
         self.assetId = assetId
         self.priceAlertService = priceAlertService
         self.onComplete = onComplete
-        self.state = .init()
+        self.state = SetPriceAlertViewModelState(price: price)
     }
 
     var assetRequest: AssetRequest {

--- a/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
@@ -82,20 +82,22 @@ struct SelectedAssetNavigationStack: View  {
                             walletsService: walletsService,
                         )
                     )
-                case .buy:
+                case let .buy(_, amount):
                     FiatConnectNavigationView(
                         model: viewModelFactory.fiatScene(
                             assetAddress: input.assetAddress,
                             walletId: wallet.walletId,
-                            type: .buy
+                            type: .buy,
+                            amount: amount
                         )
                     )
-                case .sell:
+                case let .sell(_, amount):
                     FiatConnectNavigationView(
                         model: viewModelFactory.fiatScene(
                             assetAddress: input.assetAddress,
                             walletId: wallet.walletId,
-                            type: .sell
+                            type: .sell,
+                            amount: amount
                         )
                     )
                 case let .swap(fromAsset, toAsset):

--- a/Gem/Services/ViewModelFactory.swift
+++ b/Gem/Services/ViewModelFactory.swift
@@ -138,12 +138,14 @@ public struct ViewModelFactory: Sendable {
     public func fiatScene(
         assetAddress: AssetAddress,
         walletId: WalletId,
-        type: FiatQuoteType = .buy
+        type: FiatQuoteType = .buy,
+        amount: Int? = nil
     ) -> FiatSceneViewModel {
         FiatSceneViewModel(
             assetAddress: assetAddress,
             walletId: walletId.id,
-            type: type
+            type: type,
+            amount: amount
         )
     }
     

--- a/Gem/ViewModels/RootSceneViewModel.swift
+++ b/Gem/ViewModels/RootSceneViewModel.swift
@@ -125,6 +125,12 @@ extension RootSceneViewModel {
                 notificationHandler.notify(notification: PushNotification.perpetuals)
             case .rewards(let code):
                 notificationHandler.notify(notification: PushNotification.referral(code: code))
+            case let .buy(assetId, amount):
+                notificationHandler.notify(notification: PushNotification.buyAsset(assetId, amount: amount))
+            case let .sell(assetId, amount):
+                notificationHandler.notify(notification: PushNotification.sellAsset(assetId, amount: amount))
+            case let .setPriceAlert(assetId, price):
+                notificationHandler.notify(notification: PushNotification.setPriceAlert(assetId, price: price))
             case .none:
                 break
             }

--- a/Packages/Primitives/Sources/DeepLink.swift
+++ b/Packages/Primitives/Sources/DeepLink.swift
@@ -10,6 +10,9 @@ public enum DeepLink: Sendable {
     case swap(AssetId, AssetId?)
     case perpetuals
     case rewards(code: String?)
+    case buy(AssetId, amount: Int?)
+    case sell(AssetId, amount: Int?)
+    case setPriceAlert(AssetId, price: Double)
 
     public enum PathComponent: String {
         case tokens
@@ -17,6 +20,9 @@ public enum DeepLink: Sendable {
         case perpetuals
         case rewards
         case join
+        case buy
+        case sell
+        case setPriceAlert
     }
 
     public var pathComponent: PathComponent {
@@ -25,6 +31,9 @@ public enum DeepLink: Sendable {
         case .swap: .swap
         case .perpetuals: .perpetuals
         case .rewards: .rewards
+        case .buy: .buy
+        case .sell: .sell
+        case .setPriceAlert: .setPriceAlert
         }
     }
 
@@ -41,11 +50,18 @@ public enum DeepLink: Sendable {
             case .none: "/\(pathComponent.rawValue)/\(fromAssetId.identifier)"
             }
         case .perpetuals: "/\(pathComponent.rawValue)"
-        case .rewards(let code): 
+        case .rewards(let code):
             switch code {
             case .some(let code): "/\(pathComponent.rawValue)?code=\(code)"
             case .none: "/\(pathComponent.rawValue)"
             }
+        case let .buy(assetId, amount), let .sell(assetId, amount):
+            switch amount {
+            case .some(let amount): "/\(pathComponent.rawValue)/\(assetId.identifier)?amount=\(amount)"
+            case .none: "/\(pathComponent.rawValue)/\(assetId.identifier)"
+            }
+        case let .setPriceAlert(assetId, price):
+            "/\(pathComponent.rawValue)/\(assetId.identifier)?price=\(price)"
         }
     }
     

--- a/Packages/Primitives/Sources/DeepLink.swift
+++ b/Packages/Primitives/Sources/DeepLink.swift
@@ -12,7 +12,7 @@ public enum DeepLink: Sendable {
     case rewards(code: String?)
     case buy(AssetId, amount: Int?)
     case sell(AssetId, amount: Int?)
-    case setPriceAlert(AssetId, price: Double)
+    case setPriceAlert(AssetId, price: Double?)
 
     public enum PathComponent: String {
         case tokens
@@ -61,14 +61,17 @@ public enum DeepLink: Sendable {
             case .none: "/\(pathComponent.rawValue)/\(assetId.identifier)"
             }
         case let .setPriceAlert(assetId, price):
-            "/\(pathComponent.rawValue)/\(assetId.identifier)?price=\(price)"
+            switch price {
+            case .some(let price): "/\(pathComponent.rawValue)/\(assetId.identifier)?price=\(price)"
+            case .none: "/\(pathComponent.rawValue)/\(assetId.identifier)"
+            }
         }
     }
-    
+
     public var url: URL {
         URL(string: "https://\(Self.host)\(path)")!
     }
-    
+
     public var localUrl: URL {
         URL(string: "gem://\(path)")!
     }

--- a/Packages/Primitives/Sources/Extensions/URL+Primitives.swift
+++ b/Packages/Primitives/Sources/Extensions/URL+Primitives.swift
@@ -32,4 +32,8 @@ extension URL {
             .first { $0.name == name }?
             .value
     }
+
+    public func queryValue<T: LosslessStringConvertible>(for name: String) -> T? {
+        queryValue(for: name).flatMap { T($0) }
+    }
 }

--- a/Packages/Primitives/Sources/PushNotification+Primitives.swift
+++ b/Packages/Primitives/Sources/PushNotification+Primitives.swift
@@ -6,7 +6,9 @@ public enum PushNotification: Equatable, Sendable {
     case transaction(walletIndex: Int, AssetId, transaction: Transaction)
     case asset(AssetId)
     case priceAlert(AssetId)
-    case buyAsset(AssetId)
+    case setPriceAlert(AssetId, price: Double)
+    case buyAsset(AssetId, amount: Int?)
+    case sellAsset(AssetId, amount: Int?)
     case swapAsset(AssetId, AssetId?)
     case perpetuals
     case referral(code: String)
@@ -38,8 +40,9 @@ public enum PushNotification: Equatable, Sendable {
             let asset = try decoder.decode(PushNotificationAsset.self, from: data)
             self = .priceAlert(try AssetId(id: asset.assetId))
         case .buyAsset:
+            // TODO: parse amount from push notification data
             let asset = try decoder.decode(PushNotificationAsset.self, from: data)
-            self = .buyAsset(try AssetId(id: asset.assetId))
+            self = .buyAsset(try AssetId(id: asset.assetId), amount: nil)
         case .swapAsset:
             let swapAsset = try decoder.decode(PushNotificationSwapAsset.self, from: data)
             let fromAssetId = try AssetId(id: swapAsset.fromAssetId)

--- a/Packages/Primitives/Sources/PushNotification+Primitives.swift
+++ b/Packages/Primitives/Sources/PushNotification+Primitives.swift
@@ -6,7 +6,7 @@ public enum PushNotification: Equatable, Sendable {
     case transaction(walletIndex: Int, AssetId, transaction: Transaction)
     case asset(AssetId)
     case priceAlert(AssetId)
-    case setPriceAlert(AssetId, price: Double)
+    case setPriceAlert(AssetId, price: Double?)
     case buyAsset(AssetId, amount: Int?)
     case sellAsset(AssetId, amount: Int?)
     case swapAsset(AssetId, AssetId?)

--- a/Packages/Primitives/Sources/Scenes.swift
+++ b/Packages/Primitives/Sources/Scenes.swift
@@ -181,9 +181,11 @@ public struct Scenes {
     
     public struct AssetPriceAlert: Hashable {
         public let asset: Primitives.Asset
+        public let price: Double?
 
-        public init(asset: Primitives.Asset) {
+        public init(asset: Primitives.Asset, price: Double? = nil) {
             self.asset = asset
+            self.price = price
         }
     }
 }

--- a/Packages/Primitives/Sources/SelectedAssetType.swift
+++ b/Packages/Primitives/Sources/SelectedAssetType.swift
@@ -6,8 +6,8 @@ public enum SelectedAssetType: Sendable, Hashable, Identifiable {
     case send(RecipientAssetType)
     case receive(ReceiveAssetType)
     case stake(Asset)
-    case buy(Asset)
-    case sell(Asset)
+    case buy(Asset, amount: Int?)
+    case sell(Asset, amount: Int?)
     case swap(Asset, Asset?)
 
     public var id: String {
@@ -15,8 +15,8 @@ public enum SelectedAssetType: Sendable, Hashable, Identifiable {
         case .send(let type): "send_\(type.id)"
         case .receive(let type): "receive_\(type.id)"
         case .stake(let asset): "stake_\(asset.id)"
-        case .buy(let asset): "buy_\(asset.id)"
-        case .sell(let asset): "sell_\(asset.id)"
+        case .buy(let asset, _): "buy_\(asset.id)"
+        case .sell(let asset, _): "sell_\(asset.id)"
         case .swap(let fromAsset, let toAsset): "swap_\(fromAsset.id)_\(toAsset?.id.identifier ?? "")"
         }
     }

--- a/Packages/Primitives/Sources/SetPriceAlertInput.swift
+++ b/Packages/Primitives/Sources/SetPriceAlertInput.swift
@@ -5,9 +5,9 @@ import Foundation
 public struct SetPriceAlertInput: Identifiable, Sendable {
     public var id: String { assetId.identifier }
     public let assetId: AssetId
-    public let price: Double
+    public let price: Double?
 
-    public init(assetId: AssetId, price: Double) {
+    public init(assetId: AssetId, price: Double?) {
         self.assetId = assetId
         self.price = price
     }

--- a/Packages/Primitives/Sources/SetPriceAlertInput.swift
+++ b/Packages/Primitives/Sources/SetPriceAlertInput.swift
@@ -1,0 +1,14 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public struct SetPriceAlertInput: Identifiable, Sendable {
+    public var id: String { assetId.identifier }
+    public let assetId: AssetId
+    public let price: Double
+
+    public init(assetId: AssetId, price: Double) {
+        self.assetId = assetId
+        self.price = price
+    }
+}

--- a/Packages/Primitives/Sources/URLAction.swift
+++ b/Packages/Primitives/Sources/URLAction.swift
@@ -10,5 +10,8 @@ public enum URLAction: Equatable {
     case swap(AssetId, AssetId?)
     case perpetuals
     case rewards(code: String)
+    case buy(AssetId, amount: Int?)
+    case sell(AssetId, amount: Int?)
+    case setPriceAlert(AssetId, price: Double)
     case none
 }

--- a/Packages/Primitives/Sources/URLAction.swift
+++ b/Packages/Primitives/Sources/URLAction.swift
@@ -12,6 +12,6 @@ public enum URLAction: Equatable {
     case rewards(code: String)
     case buy(AssetId, amount: Int?)
     case sell(AssetId, amount: Int?)
-    case setPriceAlert(AssetId, price: Double)
+    case setPriceAlert(AssetId, price: Double?)
     case none
 }

--- a/Packages/Primitives/Tests/PrimitivesTests/URLParserTests.swift
+++ b/Packages/Primitives/Tests/PrimitivesTests/URLParserTests.swift
@@ -56,4 +56,44 @@ struct URLParserTests {
         #expect(try URLParser.from(url: URL(string: "https://gemwallet.com/join?code=gemcoder")!) == .rewards(code: "gemcoder"))
         #expect(try URLParser.from(url: URL(string: "https://gemwallet.com/rewards?code=gemcoder")!) == .rewards(code: "gemcoder"))
     }
+
+    @Test
+    func buyUrl() async throws {
+        let buyChain = try URLParser.from(url: URL(string: "https://gemwallet.com/buy/bitcoin")!)
+        #expect(buyChain == .buy(AssetId(chain: .bitcoin, tokenId: nil), amount: nil))
+
+        let buyToken = try URLParser.from(url: URL(string: "https://gemwallet.com/buy/ethereum_0xdAC17F958D2ee523a2206206994597C13D831ec7")!)
+        #expect(buyToken == .buy(AssetId(chain: .ethereum, tokenId: "0xdAC17F958D2ee523a2206206994597C13D831ec7"), amount: nil))
+
+        let buyWithAmount = try URLParser.from(url: URL(string: "https://gemwallet.com/buy/bitcoin?amount=100")!)
+        #expect(buyWithAmount == .buy(AssetId(chain: .bitcoin, tokenId: nil), amount: 100))
+
+        let buyTokenWithAmount = try URLParser.from(url: URL(string: "https://gemwallet.com/buy/ethereum_0xdAC17F958D2ee523a2206206994597C13D831ec7?amount=50")!)
+        #expect(buyTokenWithAmount == .buy(AssetId(chain: .ethereum, tokenId: "0xdAC17F958D2ee523a2206206994597C13D831ec7"), amount: 50))
+    }
+
+    @Test
+    func sellUrl() async throws {
+        let sellChain = try URLParser.from(url: URL(string: "https://gemwallet.com/sell/bitcoin")!)
+        #expect(sellChain == .sell(AssetId(chain: .bitcoin, tokenId: nil), amount: nil))
+
+        let sellWithAmount = try URLParser.from(url: URL(string: "https://gemwallet.com/sell/ethereum?amount=200")!)
+        #expect(sellWithAmount == .sell(AssetId(chain: .ethereum, tokenId: nil), amount: 200))
+    }
+
+    @Test
+    func setPriceAlertUrl() async throws {
+        let alertWithPrice = try URLParser.from(url: URL(string: "https://gemwallet.com/setPriceAlert/bitcoin?price=50000")!)
+        #expect(alertWithPrice == .setPriceAlert(AssetId(chain: .bitcoin, tokenId: nil), price: 50000))
+
+        let alertTokenWithPrice = try URLParser.from(url: URL(string: "https://gemwallet.com/setPriceAlert/ethereum_0xdAC17F958D2ee523a2206206994597C13D831ec7?price=1.5")!)
+        #expect(alertTokenWithPrice == .setPriceAlert(AssetId(chain: .ethereum, tokenId: "0xdAC17F958D2ee523a2206206994597C13D831ec7"), price: 1.5))
+    }
+
+    @Test
+    func setPriceAlertUrlWithoutPrice() async throws {
+        #expect(throws: URLParserError.self) {
+            try URLParser.from(url: URL(string: "https://gemwallet.com/setPriceAlert/bitcoin")!)
+        }
+    }
 }

--- a/Packages/Primitives/Tests/PrimitivesTests/URLParserTests.swift
+++ b/Packages/Primitives/Tests/PrimitivesTests/URLParserTests.swift
@@ -92,8 +92,7 @@ struct URLParserTests {
 
     @Test
     func setPriceAlertUrlWithoutPrice() async throws {
-        #expect(throws: URLParserError.self) {
-            try URLParser.from(url: URL(string: "https://gemwallet.com/setPriceAlert/bitcoin")!)
-        }
+        let alertWithoutPrice = try URLParser.from(url: URL(string: "https://gemwallet.com/setPriceAlert/bitcoin")!)
+        #expect(alertWithoutPrice == .setPriceAlert(AssetId(chain: .bitcoin, tokenId: nil), price: nil))
     }
 }


### PR DESCRIPTION
  - Add buy/sell deep links with optional amount parameter (Int)
  - Add setPriceAlert deep link with required price parameter (Double)
  - Update URLParser, URLAction, DeepLink, PushNotification
  - Add SetPriceAlertInput for presenting price alert sheet
  - Handle new notification cases in MainTabView
  
  Close: https://github.com/gemwalletcom/gem-ios/issues/1502