### PR TITLE
Add walletconnect Bitcoin support

### DIFF
--- a/Packages/ChainServices/WalletConnectorService/Extensions/WalletConnectTransaction+ChainServices.swift
+++ b/Packages/ChainServices/WalletConnectorService/Extensions/WalletConnectTransaction+ChainServices.swift
@@ -14,6 +14,7 @@ extension WalletConnectTransaction {
         case .solana(let data, let outputType): .solana(data.transaction, outputType.map())
         case .sui(let data, let outputType): .sui(data.transaction, outputType.map())
         case .ton(let messages, let outputType): .ton(messages, outputType.map())
+        case .bitcoin(let data, let outputType): .bitcoin(data, outputType.map())
         }
     }
 }

--- a/Packages/ChainServices/WalletConnectorService/WalletConnectorTransaction.swift
+++ b/Packages/ChainServices/WalletConnectorService/WalletConnectorTransaction.swift
@@ -8,4 +8,5 @@ public enum WalletConnectorTransaction {
     case solana(String, TransferDataOutputType)
     case sui(String, TransferDataOutputType)
     case ton(String, TransferDataOutputType)
+    case bitcoin(String, TransferDataOutputType)
 }

--- a/Packages/Primitives/Sources/WalletConnect.swift
+++ b/Packages/Primitives/Sources/WalletConnect.swift
@@ -4,6 +4,20 @@
 
 import Foundation
 
+public struct WCBitcoinTransfer: Codable, Equatable, Hashable, Sendable {
+	public let account: String
+	public let recipientAddress: String
+	public let amount: String
+	public let memo: String?
+
+	public init(account: String, recipientAddress: String, amount: String, memo: String?) {
+		self.account = account
+		self.recipientAddress = recipientAddress
+		self.amount = amount
+		self.memo = memo
+	}
+}
+
 public struct WCEthereumTransaction: Codable, Equatable, Hashable, Sendable {
 	public let chainId: String?
 	public let from: String

--- a/Packages/Primitives/Sources/WalletConnector.swift
+++ b/Packages/Primitives/Sources/WalletConnector.swift
@@ -111,4 +111,6 @@ public enum WalletConnectionMethods: String, Codable, CaseIterable, Sendable {
 	case suiSignAndExecuteTransaction = "sui_signAndExecuteTransaction"
 	case tonSendMessage = "ton_sendMessage"
 	case tonSignData = "ton_signData"
+	case btcSendTransfer = "sendTransfer"
+	case btcSignMessage = "signMessage"
 }


### PR DESCRIPTION
Add Bitcoin WalletConnect integration

  - Add bitcoin case to WalletConnectorTransaction
  - Handle Bitcoin transactions in WalletConnectorSigner
  - Add signMessage support in BitcoinSigner
  
Implement two basic methods: signMessage and sendTransfer. 
Two advanced methods (signPsbt, getAccountAddresses) require further research.

Close: https://github.com/gemwalletcom/gem-ios/issues/1476