### PR TITLE
Refactor asset and wallet search list sections

### DIFF
--- a/Features/Assets/Sources/Scenes/SelectAssetScene.swift
+++ b/Features/Assets/Sources/Scenes/SelectAssetScene.swift
@@ -21,7 +21,6 @@ public struct SelectAssetScene: View {
             isSearching: $model.isSearching,
             dismissSearch: $model.isDismissSearch
         )
-        .listSectionSpacing(.compact)
         .searchable(
             text: $model.searchModel.searchableQuery,
             placement: .navigationBarDrawer(displayMode: .always)
@@ -58,23 +57,20 @@ public struct SelectAssetScene: View {
                 isPresenting: $model.isPresentingCopyToast
             )
         }
-        .listSectionSpacing(.compact)
         .navigationBarTitle(model.title)
     }
 
     var list: some View {
         List {
-            Section {} header: {
-                TagsView(
-                    tags: model.searchModel.tagsViewModel.items,
-                    onSelect: { model.setSelected(tag: $0.tag) }
-                )
-                .isVisible(model.showTags)
-            }
-            .textCase(nil)
-            .listRowInsets(EdgeInsets())
-            .if(model.showRecent) {
-                $0.listSectionSpacing(.small)
+            if model.showTags {
+                Section {} header: {
+                    TagsView(
+                        tags: model.searchModel.tagsViewModel.items,
+                        onSelect: { model.setSelected(tag: $0.tag) }
+                    )
+                }
+                .textCase(nil)
+                .listRowInsets(EdgeInsets())
             }
 
             if model.showRecent {
@@ -96,36 +92,41 @@ public struct SelectAssetScene: View {
                 }
             }
 
-            if model.enablePopularSection && model.sections.popular.isNotEmpty {
+            if model.showPopularSection {
                 Section {
                     assetsList(assets: model.sections.popular)
                 } header: {
                     HStack {
-                        Images.System.starFill
-                        Text(Localized.Common.popular)
+                        model.popularImage
+                        Text(model.popularTitle)
                     }
                 }
                 .listRowInsets(.assetListRowInsets)
             }
 
-            if model.sections.pinned.isNotEmpty {
+            if model.showPinnedSection {
                 Section {
                     assetsList(assets: model.sections.pinned)
                 } header: {
                     HStack {
-                        Images.System.pin
-                        Text(Localized.Common.pinned)
+                        model.pinnedImage
+                        Text(model.pinnedTitle)
                     }
                 }
                 .listRowInsets(.assetListRowInsets)
             }
 
-            Section {
-                assetsList(assets: model.sections.assets)
+            if model.showAssetsSection {
+                Section {
+                    assetsList(assets: model.sections.assets)
+                } header: {
+                    Text(model.assetsTitle)
+                }
+                .listRowInsets(.assetListRowInsets)
             }
-            .listRowInsets(.assetListRowInsets)
         }
         .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.compact)
     }
 
     func assetsList(assets: [AssetData]) -> some View {

--- a/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import SwiftUI
 import Primitives
 import Store
 import Components
@@ -11,6 +12,7 @@ import WalletsService
 import Preferences
 import PriceAlertService
 import ActivityService
+import Style
 
 @Observable
 @MainActor
@@ -109,6 +111,26 @@ public final class SelectAssetViewModel {
     var enablePopularSection: Bool {
         [.buy, .priceAlert].contains(selectType)
     }
+
+    var showPopularSection: Bool {
+        enablePopularSection && sections.popular.isNotEmpty
+    }
+
+    var showPinnedSection: Bool {
+        sections.pinned.isNotEmpty
+    }
+
+    var showAssetsSection: Bool {
+        sections.assets.isNotEmpty
+    }
+
+    var popularImage: Image { Images.System.starFill }
+    var popularTitle: String { Localized.Common.popular }
+
+    var pinnedImage: Image { Images.System.pin }
+    var pinnedTitle: String { Localized.Common.pinned }
+
+    var assetsTitle: String { Localized.Assets.title }
 
     public var showAddToken: Bool {
         selectType == .manage && wallet.hasTokenSupport && !filterModel.chainsFilter.isEmpty

--- a/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
@@ -62,24 +62,22 @@ public struct WalletSearchScene: View {
     private var assetsList: some View {
         List {
             if model.showTags {
-                Section {
+                Section {} header: {
                     TagsView(
                         tags: model.searchModel.tagsViewModel.items,
                         onSelect: { model.onSelectTag(tag: $0.tag) }
                     )
                 }
-                .cleanListRow(topOffset: .zero)
-                .lineSpacing(.zero)
-                .listSectionSpacing(.zero)
+                .textCase(nil)
+                .listRowInsets(EdgeInsets())
             }
 
             if model.showRecent {
-                RecentActivitySectionView(models: model.activityModels, ) { assetModel in
+                RecentActivitySectionView(models: model.activityModels) { assetModel in
                     NavigationLink(value: Scenes.Asset(asset: assetModel.asset)) {
                         AssetChipView(model: assetModel)
                     }
                 }
-                .listSectionSpacing(.zero)
             }
 
             if model.showPinnedSection {
@@ -105,7 +103,8 @@ public struct WalletSearchScene: View {
                 .listRowInsets(.assetListRowInsets)
             }
         }
-        .contentMargins(.top, .zero, for: .scrollContent)
+        .contentMargins([.top], .extraSmall, for: .scrollContent)
+        .listSectionSpacing(.compact)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Refactored SelectAssetScene and WalletSearchScene to improve section visibility logic and UI consistency. Moved section display conditions and header content to the view model, standardized list section spacing, and adjusted list row insets and content margins for a more uniform appearance.

images:
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/796af323-445b-40a1-b880-1df050d7f5e4" style="width: 45%;" /></td>
    <td><img src="https://github.com/user-attachments/assets/53be0362-61ea-438a-a486-ff30f95ac422" style="width: 45%;" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/4c2f29bf-32c1-425a-9a8a-dbdda3b3b9bf" style="width: 45%;" /></td>
    <td><img src="https://github.com/user-attachments/assets/71e1a9f0-995d-4302-bb60-766fc6fd5c36" style="width: 45%;" /></td>
  </tr>
</table>

closes #1499 
