### PR TITLE
Fix AutocloseSheet input data being cleared on price updates

### DIFF
--- a/Features/Perpetuals/Sources/Views/AutocloseSheet.swift
+++ b/Features/Perpetuals/Sources/Views/AutocloseSheet.swift
@@ -6,17 +6,15 @@ import Primitives
 import PrimitivesComponents
 
 public struct AutocloseSheet: View {
-    private let openData: AutocloseOpenData
-    private let onComplete: AutocloseCompletion
+    @State private var model: AutocloseSceneViewModel
 
     public init(openData: AutocloseOpenData, onComplete: @escaping AutocloseCompletion) {
-        self.openData = openData
-        self.onComplete = onComplete
+        _model = State(initialValue: AutocloseSceneViewModel(type: .open(openData, onComplete: onComplete)))
     }
 
     public var body: some View {
         NavigationStack {
-            AutocloseScene(model: AutocloseSceneViewModel(type: .open(openData, onComplete: onComplete)))
+            AutocloseScene(model: model)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar { ToolbarDismissItem(title: .cancel, placement: .topBarLeading) }
         }


### PR DESCRIPTION
Changed AutocloseSheet to store its AutocloseSceneViewModel in a @State property instead of creating a new instance in the body. This improves state management and ensures the ViewModel persists across view updates.

The fix stores the AutocloseSceneViewModel as @State in AutocloseSheet, ensuring the model persists across parent re-renders.

closes #1513 