### PR TITLE
Improve walletBar tap reliability in UI tests

### DIFF
--- a/GemUITestsAppTests/Extensions/XCUIApplication+GemUITestsAppTests.swift
+++ b/GemUITestsAppTests/Extensions/XCUIApplication+GemUITestsAppTests.swift
@@ -28,7 +28,9 @@ extension XCUIApplication {
     }
     
     func tapWalletBar() {
-        buttons.element(matching: .button, identifier: "walletBar").tap()
+        let walletBar = buttons["walletBar"].firstMatch
+        XCTAssertTrue(walletBar.waitForExistence(timeout: 2), "walletBar not found")
+        walletBar.tap()
     }
     
     func logout() {


### PR DESCRIPTION
Updated tapWalletBar to wait for the walletBar button to exist before tapping, ensuring more robust and reliable UI test execution.