### PR TITLE
Remove chatClosed handler and add script to hide close button

### DIFF
--- a/Features/Support/Sources/Types/ChatwootHandler.swift
+++ b/Features/Support/Sources/Types/ChatwootHandler.swift
@@ -8,7 +8,6 @@ enum ChatwootJSEvent: String {
 }
 
 enum ChatwootHandler: String {
-    case chatClosed
     case chatOpened
 }
 

--- a/Features/Support/Sources/ViewModels/ChatwootWebViewModel.swift
+++ b/Features/Support/Sources/ViewModels/ChatwootWebViewModel.swift
@@ -49,19 +49,44 @@ public final class ChatwootWebViewModel: NSObject, Sendable {
             \(sdkInitializationScript)
             \(toggleChatScript)
             \(setDeviceIdScript)
-            \(chatCloseEventHandler)
             \(chatOpenEventHandler)
           "></script>
         </body>
         </html>
         """
     }
-    
+
     func configureWebView() -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
-        configuration.userContentController.add(self, name: ChatwootHandler.chatClosed.rawValue)
         configuration.userContentController.add(self, name: ChatwootHandler.chatOpened.rawValue)
+        configuration.userContentController.addUserScript(hideCloseButtonUserScript)
         return configuration
+    }
+
+    private var hideCloseButtonUserScript: WKUserScript {
+        let css = """
+        .rn-close-button,
+        button.rn-close-button,
+        .close-button,
+        button.close-button {
+            display: none !important;
+            visibility: hidden !important;
+        }
+        """
+
+        let source = """
+        (function() {
+            var style = document.createElement('style');
+            style.innerHTML = \(css.debugDescription);
+            document.head.appendChild(style);
+        })();
+        """
+
+        return WKUserScript(
+            source: source,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: false
+        )
     }
     
     // MARK: - Private properties
@@ -113,11 +138,7 @@ public final class ChatwootWebViewModel: NSObject, Sendable {
     private var sdkSourceURL: String {
         "\(baseUrl.absoluteString)/packs/js/sdk.js"
     }
-    
-    private var chatCloseEventHandler: String {
-        eventHandler(event: .closed, handler: .chatClosed, message: .closed)
-    }
-    
+
     private var chatOpenEventHandler: String {
         eventHandler(event: .ready, handler: .chatOpened, message: .ready)
     }
@@ -141,7 +162,6 @@ public final class ChatwootWebViewModel: NSObject, Sendable {
 extension ChatwootWebViewModel: WKNavigationDelegate, WKScriptMessageHandler {
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         switch ChatwootHandler(rawValue: message.name) {
-        case .chatClosed: isPresentingSupport.wrappedValue = false
         case .chatOpened: isLoading = false
         default: break
         }

--- a/Features/Support/Sources/ViewModels/ChatwootWebViewModel.swift
+++ b/Features/Support/Sources/ViewModels/ChatwootWebViewModel.swift
@@ -64,29 +64,12 @@ public final class ChatwootWebViewModel: NSObject, Sendable {
     }
 
     private var hideCloseButtonUserScript: WKUserScript {
-        let css = """
-        .rn-close-button,
-        button.rn-close-button,
-        .close-button,
-        button.close-button {
-            display: none !important;
-            visibility: hidden !important;
-        }
-        """
-
         let source = """
-        (function() {
-            var style = document.createElement('style');
-            style.innerHTML = \(css.debugDescription);
-            document.head.appendChild(style);
-        })();
+        var style = document.createElement('style');
+        style.textContent = '.close-button, .rn-close-button { display: none !important; visibility: hidden !important; }';
+        document.head.appendChild(style);
         """
-
-        return WKUserScript(
-            source: source,
-            injectionTime: .atDocumentEnd,
-            forMainFrameOnly: false
-        )
+        return WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
     }
     
     // MARK: - Private properties


### PR DESCRIPTION
Eliminates the unused chatClosed handler from ChatwootHandler and related code in ChatwootWebViewModel. Adds a WKUserScript to hide the chat close button in the web view for improved UI control.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-23 at 13 01 43" src="https://github.com/user-attachments/assets/8f594dc9-d8f6-4740-a3e1-3a0c873c0292" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-23 at 13 01 47" src="https://github.com/user-attachments/assets/8ade4e23-3c83-4371-a962-8afcd0a9d836" />


Close: https://github.com/gemwalletcom/gem-ios/issues/1524