### PR TITLE
  Refactor AmountSceneViewModel: Extract type-specific logic into protocol-based ViewModels

### DIFF
--- a/Features/Transfer/Sources/Navigation/AmountNavigationView.swift
+++ b/Features/Transfer/Sources/Navigation/AmountNavigationView.swift
@@ -38,12 +38,13 @@ public struct AmountNavigationView: View {
                         .toolbar { ToolbarDismissItem(title: .done, placement: .topBarLeading) }
                     }
                 case .leverageSelector:
-                    if let perpetualModel = model.amountTypeModel.perpetual {
+                    if let perpetualModel = model.amountTypeModel.perpetual,
+                       let firstItem = perpetualModel.items.first {
                         LeveragePickerSheet(
                             title: perpetualModel.selectionTitle,
                             leverageOptions: perpetualModel.items,
                             selectedLeverage: Binding(
-                                get: { perpetualModel.selectedItem ?? LeverageOption(value: 1) },
+                                get: { perpetualModel.selectedItem ?? firstItem },
                                 set: { perpetualModel.selectedItem = $0 }
                             )
                         )

--- a/Features/Transfer/Sources/Navigation/AmountNavigationView.swift
+++ b/Features/Transfer/Sources/Navigation/AmountNavigationView.swift
@@ -38,11 +38,16 @@ public struct AmountNavigationView: View {
                         .toolbar { ToolbarDismissItem(title: .done, placement: .topBarLeading) }
                     }
                 case .leverageSelector:
-                    LeveragePickerSheet(
-                        title: model.leverageTitle,
-                        leverageOptions: model.leverageOptions,
-                        selectedLeverage: $model.selectedLeverage
-                    )
+                    if let perpetualModel = model.amountTypeModel.perpetual {
+                        LeveragePickerSheet(
+                            title: perpetualModel.selectionTitle,
+                            leverageOptions: perpetualModel.items,
+                            selectedLeverage: Binding(
+                                get: { perpetualModel.selectedItem ?? LeverageOption(value: 1) },
+                                set: { perpetualModel.selectedItem = $0 }
+                            )
+                        )
+                    }
                 case .autoclose(let openData):
                     AutocloseSheet(
                         openData: openData,
@@ -58,16 +63,18 @@ public struct AmountNavigationView: View {
                         .disabled(!model.isNextEnabled)
                 }
             }
-            .navigationDestination(for: $model.delegation) { value in
-                StakeValidatorsScene(
-                    model: StakeValidatorsViewModel(
-                        type: model.stakeValidatorsType,
-                        chain: model.asset.chain,
-                        currentValidator: value,
-                        validators: model.validators,
-                        selectValidator: model.onSelectValidator
+            .navigationDestination(for: DelegationValidator.self) { value in
+                if let stakingModel = model.amountTypeModel.staking {
+                    StakeValidatorsScene(
+                        model: StakeValidatorsViewModel(
+                            type: stakingModel.stakeValidatorsType,
+                            chain: model.asset.chain,
+                            currentValidator: value,
+                            validators: stakingModel.items,
+                            selectValidator: model.onSelectValidator
+                        )
                     )
-                )
+                }
             }
     }
 }

--- a/Features/Transfer/Sources/Protocols/AmountTypeConfigurable.swift
+++ b/Features/Transfer/Sources/Protocols/AmountTypeConfigurable.swift
@@ -1,0 +1,15 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public protocol AmountTypeConfigurable<Item, ItemViewModel> {
+    associatedtype Item: Hashable & Sendable
+    associatedtype ItemViewModel
+
+    var items: [Item] { get }
+    var defaultItem: Item? { get }
+    var selectedItem: Item? { get set }
+    var selectedItemViewModel: ItemViewModel? { get }
+    var isSelectionEnabled: Bool { get }
+    var selectionTitle: String { get }
+}

--- a/Features/Transfer/Sources/Scenes/AmountScene.swift
+++ b/Features/Transfer/Sources/Scenes/AmountScene.swift
@@ -59,28 +59,31 @@ struct AmountScene: View {
                 }
             }
 
-            switch model.type {
-            case .transfer, .deposit, .withdraw:
+            switch model.amountTypeModel {
+            case .none:
                 EmptyView()
-            case .stake, .stakeUnstake, .stakeRedelegate, .stakeWithdraw:
-                if let viewModel = model.stakeValidatorViewModel {
-                    Section(model.validatorTitle) {
-                        if model.isSelectValidatorEnabled {
-                            NavigationCustomLink(
-                                with: ValidatorView(model: viewModel),
-                                action: model.onSelectCurrentValidator
-                            )
+            case .staking(let stakingModel):
+                if let validatorModel = stakingModel.selectedItemViewModel,
+                   let selectedItem = stakingModel.selectedItem {
+                    Section(stakingModel.selectionTitle) {
+                        if stakingModel.isSelectionEnabled {
+                            NavigationLink(value: selectedItem) {
+                                ValidatorView(model: validatorModel)
+                            }
                         } else {
-                            ValidatorView(model: viewModel)
+                            ValidatorView(model: validatorModel)
                         }
                     }
                 }
-            case .freeze:
-                if model.isSelectResourceEnabled {
+            case .freeze(let freezeModel):
+                if freezeModel.isSelectionEnabled {
                     Section {
-                        Picker("", selection: $model.selectedResource) {
-                            ForEach(model.availableResources) { resource in
-                                Text(resource.title).tag(resource)
+                        Picker("", selection: Binding(
+                            get: { freezeModel.selectedItem ?? .bandwidth },
+                            set: { model.onSelectResource($0) }
+                        )) {
+                            ForEach(freezeModel.pickerItems()) { resource in
+                                Text(resource.title).tag(resource.resource)
                             }
                         }
                         .pickerStyle(.segmented)
@@ -88,26 +91,26 @@ struct AmountScene: View {
                     }
                     .cleanListRow()
                 }
-            case .perpetual:
-                if model.isPerpetualLeverageEnabled {
+            case .perpetual(let perpetualModel):
+                if perpetualModel.isSelectionEnabled {
                     Section {
                         NavigationCustomLink(
                             with: ListItemView(
-                                title: model.leverageTitle,
-                                subtitle: model.leverageText,
-                                subtitleStyle: model.leverageTextStyle
+                                title: perpetualModel.selectionTitle,
+                                subtitle: perpetualModel.leverageText,
+                                subtitleStyle: perpetualModel.leverageTextStyle
                             ),
                             action: model.onSelectLeverage
                         )
                     }
                 }
-                if model.isAutocloseEnabled {
+                if perpetualModel.isAutocloseEnabled {
                     Section {
                         NavigationCustomLink(
                             with: ListItemView(
-                                title: model.autocloseTitle,
-                                subtitle: model.autocloseText.subtitle,
-                                subtitleExtra: model.autocloseText.subtitleExtra
+                                title: perpetualModel.autocloseTitle,
+                                subtitle: perpetualModel.autocloseText.subtitle,
+                                subtitleExtra: perpetualModel.autocloseText.subtitleExtra
                             ),
                             action: model.onSelectAutoclose
                         )

--- a/Features/Transfer/Sources/Types/AmountTypeModel.swift
+++ b/Features/Transfer/Sources/Types/AmountTypeModel.swift
@@ -1,0 +1,42 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Formatters
+import Primitives
+
+public enum AmountTypeModel {
+    case none
+    case staking(StakingAmountTypeViewModel)
+    case perpetual(PerpetualAmountTypeViewModel)
+    case freeze(FreezeAmountTypeViewModel)
+
+    public static func from(
+        type: AmountType,
+        currencyFormatter: CurrencyFormatter
+    ) -> AmountTypeModel {
+        switch type {
+        case .stake, .stakeUnstake, .stakeRedelegate, .stakeWithdraw: .staking(StakingAmountTypeViewModel(amountType: type))
+        case .perpetual(let data): .perpetual(PerpetualAmountTypeViewModel(
+            positionAction: data.positionAction,
+            currencyFormatter: currencyFormatter
+        ))
+        case .freeze(let data): .freeze(FreezeAmountTypeViewModel(freezeData: data))
+        case .transfer, .deposit, .withdraw: .none
+        }
+    }
+
+    public var staking: StakingAmountTypeViewModel? {
+        if case .staking(let model) = self { return model }
+        return nil
+    }
+
+    public var perpetual: PerpetualAmountTypeViewModel? {
+        if case .perpetual(let model) = self { return model }
+        return nil
+    }
+
+    public var freeze: FreezeAmountTypeViewModel? {
+        if case .freeze(let model) = self { return model }
+        return nil
+    }
+}

--- a/Features/Transfer/Sources/ViewModels/FreezeAmountTypeViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/FreezeAmountTypeViewModel.swift
@@ -1,0 +1,47 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Localization
+import Primitives
+import PrimitivesComponents
+
+@Observable
+public final class FreezeAmountTypeViewModel: AmountTypeConfigurable {
+    public typealias Item = Resource
+    public typealias ItemViewModel = ResourceViewModel
+
+    private var freezeData: FreezeData
+
+    public var selectedItem: Resource? {
+        didSet {
+            if let selectedItem {
+                freezeData = freezeData.with(resource: selectedItem)
+            }
+        }
+    }
+
+    public init(freezeData: FreezeData) {
+        self.freezeData = freezeData
+        self.selectedItem = freezeData.resource
+    }
+
+    public var items: [Resource] { [.bandwidth, .energy] }
+
+    public var defaultItem: Resource? { freezeData.resource }
+
+    public var selectedItemViewModel: ResourceViewModel? {
+        selectedItem.map { ResourceViewModel(resource: $0) }
+    }
+
+    public var isSelectionEnabled: Bool { true }
+
+    public var selectionTitle: String { Localized.Stake.resource }
+
+    public var freezeType: FreezeType { freezeData.freezeType }
+
+    public var currentFreezeData: FreezeData { freezeData }
+
+    public func pickerItems() -> [ResourceViewModel] {
+        items.map { ResourceViewModel(resource: $0) }
+    }
+}

--- a/Features/Transfer/Sources/ViewModels/PerpetualAmountTypeViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/PerpetualAmountTypeViewModel.swift
@@ -1,0 +1,101 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Formatters
+import Localization
+import Preferences
+import Primitives
+import PrimitivesComponents
+import Style
+
+@Observable
+public final class PerpetualAmountTypeViewModel: AmountTypeConfigurable {
+    public typealias Item = LeverageOption
+    public typealias ItemViewModel = LeverageOption
+
+    private let positionAction: PerpetualPositionAction
+    private let currencyFormatter: CurrencyFormatter
+    private let autocloseFormatter: AutocloseFormatter
+
+    public var selectedItem: LeverageOption?
+    public var takeProfit: String?
+    public var stopLoss: String?
+
+    public init(
+        positionAction: PerpetualPositionAction,
+        currencyFormatter: CurrencyFormatter = CurrencyFormatter(type: .currency, currencyCode: Preferences.standard.currency),
+        autocloseFormatter: AutocloseFormatter = AutocloseFormatter()
+    ) {
+        self.positionAction = positionAction
+        self.currencyFormatter = currencyFormatter
+        self.autocloseFormatter = autocloseFormatter
+        self.selectedItem = defaultItem
+    }
+
+    public var items: [LeverageOption] {
+        LeverageOption.allOptions.filter { $0.value <= maxLeverage }
+    }
+
+    public var defaultItem: LeverageOption? {
+        switch positionAction {
+        case .open:
+            LeverageOption.option(
+                desiredValue: Preferences.standard.perpetualLeverage,
+                from: items
+            )
+        case .increase(let data):
+            LeverageOption(value: data.leverage)
+        case .reduce(let data, _, _):
+            LeverageOption(value: data.leverage)
+        }
+    }
+
+    public var selectedItemViewModel: LeverageOption? { selectedItem }
+
+    public var isSelectionEnabled: Bool {
+        switch positionAction {
+        case .open: true
+        case .increase, .reduce: false
+        }
+    }
+
+    public var selectionTitle: String { Localized.Perpetual.leverage }
+
+    public var maxLeverage: UInt8 {
+        positionAction.transferData.leverage
+    }
+
+    public var leverageText: String {
+        selectedItem?.displayText ?? ""
+    }
+
+    public var leverageTextStyle: TextStyle {
+        guard case .open(let transferData) = positionAction else {
+            return .callout
+        }
+        return TextStyle(
+            font: .callout,
+            color: PerpetualDirectionViewModel(direction: transferData.direction).color
+        )
+    }
+
+    public var isAutocloseEnabled: Bool {
+        switch positionAction {
+        case .open: true
+        case .increase, .reduce: false
+        }
+    }
+
+    public var autocloseTitle: String { Localized.Perpetual.autoClose }
+
+    public var autocloseText: (subtitle: String, subtitleExtra: String?) {
+        autocloseFormatter.format(
+            takeProfit: takeProfit.flatMap { currencyFormatter.double(from: $0) },
+            stopLoss: stopLoss.flatMap { currencyFormatter.double(from: $0) }
+        )
+    }
+
+    public var transferData: PerpetualTransferData {
+        positionAction.transferData
+    }
+}

--- a/Features/Transfer/Sources/ViewModels/PerpetualAmountTypeViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/PerpetualAmountTypeViewModel.swift
@@ -37,17 +37,16 @@ public final class PerpetualAmountTypeViewModel: AmountTypeConfigurable {
     }
 
     public var defaultItem: LeverageOption? {
-        switch positionAction {
+        let candidate: LeverageOption? = switch positionAction {
         case .open:
-            LeverageOption.option(
-                desiredValue: Preferences.standard.perpetualLeverage,
-                from: items
-            )
-        case .increase(let data):
-            LeverageOption(value: data.leverage)
-        case .reduce(let data, _, _):
+            LeverageOption.option(desiredValue: Preferences.standard.perpetualLeverage, from: items)
+        case .increase(let data), .reduce(let data, _, _):
             LeverageOption(value: data.leverage)
         }
+        guard let candidate, items.contains(candidate) else {
+            return items.first
+        }
+        return candidate
     }
 
     public var selectedItemViewModel: LeverageOption? { selectedItem }

--- a/Features/Transfer/Sources/ViewModels/StakingAmountTypeViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/StakingAmountTypeViewModel.swift
@@ -1,0 +1,69 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Localization
+import Primitives
+import Staking
+
+@Observable
+public final class StakingAmountTypeViewModel: AmountTypeConfigurable {
+    public typealias Item = DelegationValidator
+    public typealias ItemViewModel = StakeValidatorViewModel
+
+    private let amountType: AmountType
+
+    public var selectedItem: DelegationValidator?
+
+    public init(amountType: AmountType) {
+        self.amountType = amountType
+        self.selectedItem = defaultItem
+    }
+
+    public var items: [DelegationValidator] {
+        switch amountType {
+        case .stake(let validators, _): validators
+        case .stakeUnstake(let delegation): [delegation.validator]
+        case .stakeRedelegate(_, let validators, _): validators
+        case .stakeWithdraw(let delegation): [delegation.validator]
+        case .transfer, .deposit, .withdraw, .perpetual, .freeze: []
+        }
+    }
+
+    public var defaultItem: DelegationValidator? {
+        switch amountType {
+        case .stake(_, let recommended): recommended ?? items.first
+        case .stakeRedelegate(_, _, let recommended): recommended ?? items.first
+        case .transfer, .deposit, .withdraw, .perpetual, .stakeUnstake, .stakeWithdraw, .freeze: items.first
+        }
+    }
+
+    public var selectedItemViewModel: StakeValidatorViewModel? {
+        selectedItem.map { StakeValidatorViewModel(validator: $0) }
+    }
+
+    public var isSelectionEnabled: Bool {
+        switch amountType {
+        case .stake, .stakeRedelegate: true
+        case .stakeUnstake, .stakeWithdraw: false
+        case .transfer, .deposit, .withdraw, .perpetual, .freeze: false
+        }
+    }
+
+    public var selectionTitle: String { Localized.Stake.validator }
+
+    public var stakeValidatorsType: StakeValidatorsType {
+        switch amountType {
+        case .stakeUnstake, .stakeWithdraw: .unstake
+        case .transfer, .deposit, .withdraw, .perpetual, .stake, .stakeRedelegate, .freeze: .stake
+        }
+    }
+
+    public var delegations: [Delegation] {
+        switch amountType {
+        case .stakeUnstake(let delegation): [delegation]
+        case .stakeRedelegate(let delegation, _, _): [delegation]
+        case .stakeWithdraw(let delegation): [delegation]
+        case .transfer, .deposit, .withdraw, .perpetual, .stake, .freeze: []
+        }
+    }
+}


### PR DESCRIPTION
 - Extract domain-specific logic from AmountSceneViewModel into dedicated ViewModels (Staking, Perpetual, Freeze)
  - Introduce AmountTypeConfigurable protocol for unified domain selection API
  - Replace 3 optional domain properties with single AmountTypeModel enum
  - Replace optional delegation binding with value-based NavigationLink