### PR TITLE
Refactor StakeDetailSceneViewModel and add unit tests

### DIFF
--- a/Features/Staking/Sources/ViewModels/StakeDetailSceneViewModel.swift
+++ b/Features/Staking/Sources/ViewModels/StakeDetailSceneViewModel.swift
@@ -16,12 +16,12 @@ public struct StakeDetailSceneViewModel {
     public let onTransferAction: TransferDataAction
 
     private let wallet: Wallet
-    private let service: StakeService
+    private let service: any StakeServiceable
 
     public init(
         wallet: Wallet,
         model: StakeDelegationViewModel,
-        service: StakeService,
+        service: any StakeServiceable,
         onAmountInputAction: AmountInputAction,
         onTransferAction: TransferDataAction
     ) {
@@ -67,7 +67,8 @@ public struct StakeDetailSceneViewModel {
     }
     
     public var showManage: Bool {
-        [
+        guard wallet.canSign else { return false }
+        return [
             isStakeAvailable,
             isUnstakeAvailable,
             isRedelegateAvailable,

--- a/Features/Staking/Tests/ViewModels/StakeDetailSceneViewModelTests.swift
+++ b/Features/Staking/Tests/ViewModels/StakeDetailSceneViewModelTests.swift
@@ -1,0 +1,36 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Testing
+import StakeService
+import StakeServiceTestKit
+import PrimitivesTestKit
+import Primitives
+
+@testable import Staking
+
+struct StakeDetailSceneViewModelTests {
+
+    @Test
+    func showManage() {
+        #expect(StakeDetailSceneViewModel.mock(wallet: .mock(type: .multicoin)).showManage == true)
+        #expect(StakeDetailSceneViewModel.mock(wallet: .mock(type: .view)).showManage == false)
+    }
+}
+
+extension StakeDetailSceneViewModel {
+    static func mock(
+        wallet: Wallet = .mock(),
+        model: StakeDelegationViewModel = StakeDelegationViewModel.mock(),
+        service: any StakeServiceable = MockStakeService()
+    ) -> StakeDetailSceneViewModel {
+        StakeDetailSceneViewModel(
+            wallet: wallet,
+            model: model,
+            service: service,
+            onAmountInputAction: nil,
+            onTransferAction: nil
+        )
+    }
+}
+


### PR DESCRIPTION
Replaced StakeService with StakeServiceable protocol in StakeDetailSceneViewModel for improved abstraction. Added StakeDetailSceneViewModelTests to verify showManage logic based on wallet type.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1535