### PR TITLE
Improve UI padding and test reliability

### DIFF
--- a/GemUITestsAppTests/CreateWalletUITests.swift
+++ b/GemUITestsAppTests/CreateWalletUITests.swift
@@ -9,7 +9,7 @@ final class CreateWalletUITests: XCTestCase {
         continueAfterFailure = false
     }
 
-    func testImportWalletAndReceiveBitcoin() throws {
+    func testCreateWalletAndReceiveBitcoin() throws {
         let app = XCUIApplication()
         setupPermissionHandler()
         app.launch()

--- a/GemUITestsAppTests/Extensions/XCUIApplication+GemUITestsAppTests.swift
+++ b/GemUITestsAppTests/Extensions/XCUIApplication+GemUITestsAppTests.swift
@@ -53,6 +53,8 @@ extension XCUIApplication {
     }
     
     func tapImportWallet() {
-        buttons["Import an Existing Wallet"].firstMatch.tap()
+        let button = buttons["Import an Existing Wallet"].firstMatch
+        XCTAssertTrue(button.waitForExistence(timeout: 2), "button not found")
+        button.tap()
     }
 }

--- a/Packages/Components/Sources/CalloutView.swift
+++ b/Packages/Components/Sources/CalloutView.swift
@@ -41,7 +41,8 @@ public struct CalloutView: View {
                     .multilineTextAlignment(.center)
             }
         }
-        .padding()
+        .frame(maxWidth: .infinity)
+        .padding(.small)
         .background(style.backgroundColor)
         .cornerRadius(.small)
         .padding(.horizontal, .medium)

--- a/Packages/PrimitivesComponents/Sources/Components/SecretPhraseGridView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/SecretPhraseGridView.swift
@@ -44,7 +44,7 @@ public struct SecretPhraseGridView: View {
                             }
                         }
                     }
-                }.padding(2)
+                }.padding(.vertical, .space2)
             }
         }
         .padding(.horizontal, .medium)


### PR DESCRIPTION
Updated CalloutView and SecretPhraseGridView to use more consistent and semantic padding values for better layout. Enhanced tapImportWallet UI test helper to wait for button existence, improving test reliability.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-27 at 14 42 58" src="https://github.com/user-attachments/assets/82a7a5e0-9b1b-4416-9d68-e393a8c3fa29" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-27 at 14 43 03" src="https://github.com/user-attachments/assets/f279d78b-729f-47c5-9ab7-84f260716010" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2025-12-27 at 14 43 14" src="https://github.com/user-attachments/assets/14649f87-f2ec-4860-9d00-1462fe07b1a4" />
