### PR TITLE
Add toast vertical offset support for better UI placement

### DIFF
--- a/Gem/Scenes/RootScene.swift
+++ b/Gem/Scenes/RootScene.swift
@@ -70,9 +70,10 @@ struct RootScene: View {
             message: ToastMessage(
                 title: "\(Localized.WalletConnect.brandName)...",
                 image: SystemImage.network
-            )
+            ),
+            offsetY: -model.toastOffset
         )
-        .toast(message: $model.isPresentingToastMessage)
+        .toast(message: $model.isPresentingToastMessage, offsetY: -model.toastOffset)
     }
 }
 

--- a/Gem/ViewModels/RootSceneViewModel.swift
+++ b/Gem/ViewModels/RootSceneViewModel.swift
@@ -60,6 +60,10 @@ final class RootSceneViewModel {
         set { walletConnectorPresenter.isPresentingConnectionBar = newValue }
     }
 
+    var toastOffset: CGFloat {
+        UIDevice.current.userInterfaceIdiom == .phone ? .space32 + .space16 : .zero
+    }
+
     init(
         walletConnectorPresenter: WalletConnectorPresenter,
         onstartAsyncService: OnstartAsyncService,

--- a/Packages/Components/Sources/AlertToast/AlertToast.swift
+++ b/Packages/Components/Sources/AlertToast/AlertToast.swift
@@ -59,6 +59,7 @@ public struct AlertToastModifier: ViewModifier {
 
     var duration: Double = 2
     var tapToDismiss: Bool = true
+    var offsetY: CGFloat = 0
 
     var alert: () -> AlertToast
 
@@ -71,6 +72,7 @@ public struct AlertToastModifier: ViewModifier {
     private func main() -> some View {
         if isPresenting {
             alert()
+                .offset(y: offsetY)
                 .onTapGesture {
                     onTap?()
                     if tapToDismiss {
@@ -126,6 +128,7 @@ public extension View {
         isPresenting: Binding<Bool>,
         duration: Double = 2,
         tapToDismiss: Bool = true,
+        offsetY: CGFloat = 0,
         alert: @escaping () -> AlertToast,
         onTap: (() -> Void)? = nil,
         completion: (() -> Void)? = nil
@@ -134,6 +137,7 @@ public extension View {
             isPresenting: isPresenting,
             duration: duration,
             tapToDismiss: tapToDismiss,
+            offsetY: offsetY,
             alert: alert,
             onTap: onTap,
             completion: completion

--- a/Packages/Components/Sources/ViewModifiers/ToastModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/ToastModifier.swift
@@ -10,22 +10,25 @@ struct ToastModifier: ViewModifier {
     private let message: ToastMessage
     private let duration: Double
     private let tapToDismiss: Bool
+    private let offsetY: CGFloat
 
     init(
         isPresenting: Binding<Bool>,
         message: ToastMessage,
         duration: Double,
-        tapToDismiss: Bool
+        tapToDismiss: Bool,
+        offsetY: CGFloat
     ) {
         self.isPresenting = isPresenting
         self.message = message
         self.duration = duration
         self.tapToDismiss = tapToDismiss
+        self.offsetY = offsetY
     }
 
     func body(content: Content) -> some View {
         content
-            .toast(isPresenting: isPresenting, duration: duration, tapToDismiss: tapToDismiss) {
+            .toast(isPresenting: isPresenting, duration: duration, tapToDismiss: tapToDismiss, offsetY: offsetY) {
                 AlertToast(
                     systemImage: message.image,
                     imageColor: Colors.black,
@@ -39,11 +42,13 @@ private struct OptionalMessageToastModifier: ViewModifier {
     @Binding var message: ToastMessage?
     private let duration: Double
     private let tapToDismiss: Bool
+    private let offsetY: CGFloat
 
-    init(message: Binding<ToastMessage?>, duration: Double, tapToDismiss: Bool) {
+    init(message: Binding<ToastMessage?>, duration: Double, tapToDismiss: Bool, offsetY: CGFloat) {
         _message = message
         self.duration = duration
         self.tapToDismiss = tapToDismiss
+        self.offsetY = offsetY
     }
 
     func body(content: Content) -> some View {
@@ -57,7 +62,8 @@ private struct OptionalMessageToastModifier: ViewModifier {
                 ),
                 message: message ?? .empty(),
                 duration: duration,
-                tapToDismiss: tapToDismiss
+                tapToDismiss: tapToDismiss,
+                offsetY: offsetY
             )
         )
     }
@@ -72,25 +78,29 @@ public extension View {
         isPresenting: Binding<Bool>,
         message: ToastMessage,
         duration: Double = Self.toastDuration,
-        tapToDismiss: Bool = true
+        tapToDismiss: Bool = true,
+        offsetY: CGFloat = 0
     ) -> some View {
         modifier(ToastModifier(
             isPresenting: isPresenting,
             message: message,
             duration: duration,
-            tapToDismiss: tapToDismiss
+            tapToDismiss: tapToDismiss,
+            offsetY: offsetY
         ))
     }
 
     func toast(
         message: Binding<ToastMessage?>,
         duration: Double = Self.toastDuration,
-        tapToDismiss: Bool = true
+        tapToDismiss: Bool = true,
+        offsetY: CGFloat = 0
     ) -> some View {
         modifier(OptionalMessageToastModifier(
             message: message,
             duration: duration,
-            tapToDismiss: tapToDismiss
+            tapToDismiss: tapToDismiss,
+            offsetY: offsetY
         ))
     }
 }


### PR DESCRIPTION
Problem: 
Toast appeared at different heights depending on whether the screen has a tab bar or not. This affected both the WalletConnect connection toast and general toast messages in RootScene.

Solution:
Added offsetY parameter to adjust toast position consistently across all screens.