### PR TITLE
Fix wallet setup order in onboarding view models

### DIFF
--- a/Features/Onboarding/Sources/ViewModels/CreateWalletModel.swift
+++ b/Features/Onboarding/Sources/ViewModels/CreateWalletModel.swift
@@ -57,7 +57,7 @@ extension CreateWalletModel {
     }
 
     func setupWalletComplete(wallet: Wallet) async throws {
-        try await walletService.setCurrent(wallet: wallet)
         dismiss()
+        try await walletService.setCurrent(wallet: wallet)
     }
 }

--- a/Features/Onboarding/Sources/ViewModels/ImportWalletViewModel.swift
+++ b/Features/Onboarding/Sources/ViewModels/ImportWalletViewModel.swift
@@ -58,7 +58,7 @@ extension ImportWalletViewModel {
     }
 
     func setupWalletComplete(wallet: Wallet) async throws {
-        try await walletService.setCurrent(wallet: wallet)
         dismiss()
+        try await walletService.setCurrent(wallet: wallet)
     }
 }


### PR DESCRIPTION
Moved the call to set the current wallet after dismissing the onboarding view in both CreateWalletModel and ImportWalletViewModel. This ensures the wallet is set after the UI is dismissed, potentially preventing race conditions or UI inconsistencies.