### PR TITLE
Remove wallet name input from import flow

### DIFF
--- a/Features/Onboarding/Sources/Navigation/ImportWalletNavigationStack.swift
+++ b/Features/Onboarding/Sources/Navigation/ImportWalletNavigationStack.swift
@@ -86,12 +86,7 @@ extension ImportWalletNavigationStack {
         Task {
             do {
                 let wallet = try await model.importWallet(data: data)
-
-                if model.hasExistingWallets {
-                    navigate(to: .walletProfile(wallet: wallet))
-                } else {
-                    try await model.setupWalletComplete(wallet: wallet)
-                }
+                navigate(to: .walletProfile(wallet: wallet))
             } catch {
                 debugLog("Failed to import wallet: \(error)")
             }

--- a/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
+++ b/Features/Onboarding/Sources/Scenes/ImportWalletScene.swift
@@ -10,7 +10,7 @@ import PrimitivesComponents
 
 struct ImportWalletScene: View {
     enum Field {
-        case name, input
+        case input
     }
 
     @FocusState private var focusedField: Field?
@@ -22,16 +22,6 @@ struct ImportWalletScene: View {
 
     var body: some View {
         Form {
-            if model.showNameField {
-                Section {
-                    FloatTextField(
-                        model.walletFieldTitle,
-                        text: $model.name,
-                        allowClean: focusedField == .name
-                    )
-                    .focused($focusedField, equals: .name)
-                }
-            }
             Section {
                 VStack {
                     if model.showImportTypes {

--- a/Features/Onboarding/Sources/ViewModels/ImportWalletSceneViewModel.swift
+++ b/Features/Onboarding/Sources/ViewModels/ImportWalletSceneViewModel.swift
@@ -18,9 +18,7 @@ final class ImportWalletSceneViewModel {
     private let nameService: any NameServiceable
 
     let type: ImportWalletType
-    let showNameField: Bool
 
-    var name: String
     var input: String = ""
     var wordsSuggestion: [String] = []
     var importType: WalletImportType = .phrase
@@ -41,8 +39,6 @@ final class ImportWalletSceneViewModel {
         self.walletService = walletService
         self.nameService = nameService
         self.type = type
-        self.name = WalletNameGenerator(type: type, walletService: walletService).name
-        self.showNameField = walletService.wallets.isEmpty
         self.onComplete = onComplete
     }
 
@@ -55,12 +51,9 @@ final class ImportWalletSceneViewModel {
 
     var pasteButtonTitle: String { Localized.Common.paste }
     var pasteButtonImage: Image { Images.System.paste }
-
     var qrButtonTitle: String { Localized.Wallet.scan }
     var qrButtonImage: Image { Images.System.qrCodeViewfinder }
-
     var alertTitle: String { Localized.Errors.validation("") }
-    var walletFieldTitle: String { Localized.Wallet.name }
 
     var chain: Chain? {
         switch type {
@@ -155,8 +148,7 @@ extension ImportWalletSceneViewModel {
             if let result = nameResolveState.result {
                 return RecipientImport(name: result.name, address: result.address)
             }
-            let walletName = name.isEmpty ? WalletNameGenerator(type: type, walletService: walletService).name : name
-            return RecipientImport(name: walletName, address: input)
+            return RecipientImport(name: WalletNameGenerator(type: type, walletService: walletService).name, address: input)
         }()
         switch importType {
         case .phrase:
@@ -197,9 +189,6 @@ extension ImportWalletSceneViewModel {
     }
 
     private func validateForm(type: WalletImportType, address: String, words: [String]) throws  -> Bool {
-        guard !name.isEmpty else {
-             throw WalletImportError.emptyName
-        }
         switch type {
         case .phrase:
             for word in words {

--- a/Features/Onboarding/Sources/ViewModels/ImportWalletViewModel.swift
+++ b/Features/Onboarding/Sources/ViewModels/ImportWalletViewModel.swift
@@ -16,7 +16,6 @@ public final class ImportWalletViewModel {
     let walletService: WalletService
     let avatarService: AvatarService
     let nameService: any NameServiceable
-    let hasExistingWallets: Bool
 
     var isPresentingWallets: Binding<Bool>
     var isPresentingSelectImageWallet: Wallet?
@@ -31,7 +30,6 @@ public final class ImportWalletViewModel {
         self.avatarService = avatarService
         self.nameService = nameService
         self.isPresentingWallets = isPresentingWallets
-        self.hasExistingWallets = walletService.wallets.isNotEmpty
     }
 
     public var isAcceptTermsCompleted: Bool {

--- a/GemUITestsAppTests/ImportWalletReceiveBitcoinUITests.swift
+++ b/GemUITestsAppTests/ImportWalletReceiveBitcoinUITests.swift
@@ -44,9 +44,6 @@ final class ImportWalletReceiveBitcoinUITests: XCTestCase {
         app.tapImportWallet()
 
         importFlow(app: app, words: UITestKitConstants.words2)
-
-        // SetupWalletScene
-        app.buttons["Done"].firstMatch.tap()
     }
     
     func importFlow(app: XCUIApplication, words: String) {
@@ -56,5 +53,8 @@ final class ImportWalletReceiveBitcoinUITests: XCTestCase {
         // ImportWalletScene
         app.textFields["importInputField"].typeText(words)
         app.buttons["Import"].firstMatch.tap()
+        
+        // SetupWalletScene
+        app.buttons["Done"].firstMatch.tap()
     }
 }


### PR DESCRIPTION
Eliminated the wallet name field and related logic from the import wallet scene and view models. The wallet name is now auto-generated during import, simplifying the user experience and reducing required input.