### PR TITLE
Improved unit tests for Amount*ViewModel

### DIFF
--- a/Features/Transfer/Tests/ViewModels/AmountFreezeViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountFreezeViewModelTests.swift
@@ -1,0 +1,94 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import BigInt
+import Testing
+import Primitives
+import PrimitivesTestKit
+
+@testable import Transfer
+
+struct AmountFreezeViewModelTests {
+
+    @Test
+    func title() {
+        #expect(AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .bandwidth)).title == "Freeze")
+        #expect(AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .unfreeze, resource: .bandwidth)).title == "Unfreeze")
+    }
+
+    @Test
+    func resourceSelection() {
+        let model = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .energy))
+
+        #expect(model.resourceSelection.options == [.bandwidth, .energy])
+        #expect(model.resourceSelection.selected == .energy)
+        #expect(model.resourceSelection.isEnabled == true)
+    }
+
+    @Test
+    func minimumValue() {
+        #expect(AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .bandwidth)).minimumValue > .zero)
+        #expect(AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .unfreeze, resource: .bandwidth)).minimumValue == .zero)
+    }
+
+    @Test
+    func reserveForFee() {
+        #expect(AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .bandwidth)).reserveForFee > .zero)
+        #expect(AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .unfreeze, resource: .bandwidth)).reserveForFee == .zero)
+    }
+
+    @Test
+    func availableValue() {
+        let assetData = AssetData.mock(asset: .mockTron(), balance: .mock(available: 1000, frozen: 500, locked: 300))
+
+        let freeze = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .bandwidth))
+        let unfreezeBandwidth = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .unfreeze, resource: .bandwidth))
+        let unfreezeEnergy = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .unfreeze, resource: .energy))
+
+        #expect(freeze.availableValue(from: assetData) == 1000)
+        #expect(unfreezeBandwidth.availableValue(from: assetData) == 500)
+        #expect(unfreezeEnergy.availableValue(from: assetData) == 300)
+    }
+
+    @Test
+    func shouldReserveFee() {
+        let assetData = AssetData.mock(asset: .mockTron(), balance: .mock(available: 10_000_000_000))
+
+        let freeze = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .bandwidth))
+        let unfreeze = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .unfreeze, resource: .bandwidth))
+
+        #expect(freeze.shouldReserveFee(from: assetData) == true)
+        #expect(unfreeze.shouldReserveFee(from: assetData) == false)
+    }
+
+    @Test
+    func recipientData() {
+        let model = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .energy))
+        model.resourceSelection.selected = .bandwidth
+
+        #expect(model.recipientData().recipient.name == "Bandwidth")
+    }
+
+    @Test
+    func makeTransferData() throws {
+        let freeze = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .bandwidth))
+        let unfreeze = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .unfreeze, resource: .energy))
+
+        let freezeData = try freeze.makeTransferData(value: 100)
+        let unfreezeData = try unfreeze.makeTransferData(value: 200)
+
+        #expect(freezeData.type.transactionType == .stakeFreeze)
+        #expect(unfreezeData.type.transactionType == .stakeUnfreeze)
+        #expect(freezeData.value == 100)
+        #expect(unfreezeData.value == 200)
+    }
+
+    @Test
+    func makeTransferDataUsesSelectedResource() throws {
+        let model = AmountFreezeViewModel(asset: .mockTron(), data: FreezeData(freezeType: .freeze, resource: .bandwidth))
+        model.resourceSelection.selected = .energy
+
+        let transferData = try model.makeTransferData(value: 100)
+
+        #expect(transferData.type.metadata.resourceType == .energy)
+    }
+}

--- a/Features/Transfer/Tests/ViewModels/AmountPerpetualViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountPerpetualViewModelTests.swift
@@ -1,0 +1,116 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import BigInt
+import Testing
+import Primitives
+import PrimitivesTestKit
+
+@testable import Transfer
+
+struct AmountPerpetualViewModelTests {
+
+    @Test
+    func title() {
+        let openLong = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .open(.mock(direction: .long))))
+        let openShort = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .open(.mock(direction: .short))))
+
+        #expect(openLong.title == "Long")
+        #expect(openShort.title == "Short")
+    }
+
+    @Test
+    func increaseReduceTitle() {
+        let increase = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .increase(.mock(direction: .long))))
+        let reduce = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .reduce(.mock(), available: 1000, positionDirection: .long)))
+
+        #expect(increase.title.contains("Long"))
+        #expect(reduce.title.contains("Long"))
+    }
+
+    @Test
+    func leverageSelection() {
+        let open = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .open(.mock(leverage: 10))))
+        let increase = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .increase(.mock())))
+
+        #expect(open.leverageSelection != nil)
+        #expect(open.leverageSelection?.isEnabled == true)
+        #expect(increase.leverageSelection == nil)
+    }
+
+    @Test
+    func isAutocloseEnabled() {
+        let open = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .open(.mock())))
+        let increase = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .increase(.mock())))
+        let reduce = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .reduce(.mock(), available: 1000, positionDirection: .long)))
+
+        #expect(open.isAutocloseEnabled == true)
+        #expect(increase.isAutocloseEnabled == false)
+        #expect(reduce.isAutocloseEnabled == false)
+    }
+
+    @Test
+    func availableValue() {
+        let assetData = AssetData.mock(balance: .mock(available: 5000))
+
+        let open = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .open(.mock())))
+        let reduce = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .reduce(.mock(), available: 1000, positionDirection: .long)))
+
+        #expect(open.availableValue(from: assetData) == 5000)
+        #expect(reduce.availableValue(from: assetData) == 1000)
+    }
+
+    @Test
+    func reserveForFee() {
+        let model = AmountPerpetualViewModel(asset: .mock(), data: .mock())
+        #expect(model.reserveForFee == .zero)
+        #expect(model.shouldReserveFee(from: .mock()) == false)
+    }
+
+    @Test
+    func minimumValue() {
+        let model = AmountPerpetualViewModel(asset: .mock(), data: .mock())
+        #expect(model.minimumValue > .zero)
+    }
+
+    @Test
+    func autocloseText() {
+        let model = AmountPerpetualViewModel(asset: .mock(), data: .mock())
+
+        #expect(model.autocloseText.subtitle == "-")
+        #expect(model.autocloseText.subtitleExtra == nil)
+
+        model.takeProfit = "100"
+        #expect(model.autocloseText.subtitle.contains("TP"))
+
+        model.stopLoss = "50"
+        #expect(model.autocloseText.subtitleExtra != nil)
+    }
+
+    @Test
+    func makeAutocloseData() {
+        let model = AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .open(.mock(direction: .long))))
+        model.takeProfit = "100"
+        model.stopLoss = "50"
+
+        let data = model.makeAutocloseData(size: 1000)
+
+        #expect(data.direction == .long)
+        #expect(data.takeProfit == "100")
+        #expect(data.stopLoss == "50")
+        #expect(data.size == 1000)
+    }
+
+    @Test
+    func makeTransferData() throws {
+        let open = try AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .open(.mock()))).makeTransferData(value: 100)
+        let increase = try AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .increase(.mock()))).makeTransferData(value: 200)
+        let reduce = try AmountPerpetualViewModel(asset: .mock(), data: .mock(positionAction: .reduce(.mock(), available: 1000, positionDirection: .long))).makeTransferData(value: 300)
+
+        #expect(open.type.transactionType == .perpetualOpenPosition)
+        #expect(increase.type.transactionType == .perpetualOpenPosition)
+        #expect(reduce.type.transactionType == .perpetualClosePosition)
+        #expect(open.value == 100)
+        #expect(increase.value == 200)
+        #expect(reduce.value == 300)
+    }
+}

--- a/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountSceneViewModelTests.swift
@@ -1,11 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Testing
-import WalletsServiceTestKit
-import StakeServiceTestKit
 import PrimitivesTestKit
-import BalanceServiceTestKit
-import PriceServiceTestKit
 import Primitives
 import Store
 
@@ -13,8 +9,9 @@ import Store
 
 @MainActor
 struct AmountSceneViewModelTests {
+
     @Test
-    func testMaxButton() {
+    func maxButton() {
         let model = AmountSceneViewModel.mock()
         #expect(model.amountInputModel.isValid)
 
@@ -27,104 +24,62 @@ struct AmountSceneViewModelTests {
     }
 
     @Test
-    func depositTitle() {
-        #expect(AmountSceneViewModel.mock(type: .deposit(recipient: .mock())).title == "Deposit")
-    }
-    
-    @Test
     func stakingReservedFeesText() {
-        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 2_000_000_000_000_000_000))
-        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
-        
-        model.onSelectMaxButton()
+        let assetData = AssetData.mock(
+            asset: .mockBNB(),
+            balance: .mock(available: 2_000_000_000_000_000_000)
+        )
+        let model = AmountSceneViewModel.mock(
+            type: .stake(validators: [.mock()], recommendedValidator: nil),
+            assetData: assetData
+        )
 
+        model.onSelectMaxButton()
         #expect(model.infoText != nil)
         #expect(model.amountInputModel.text == "1.99975")
-        
+
         model.amountInputModel.text = .zero
         #expect(model.infoText == nil)
     }
-    
-//    @Test
-//    func depositMinimumAmount() {
-//        let usdcAsset = Asset.mock(
-//            id: AssetId(chain: .ethereum, tokenId: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"),
-//            symbol: "USDC",
-//            decimals: 6
-//        )
-//        let model = AmountSceneViewModel.mock(type: .deposit(recipient: .mock()), asset: usdcAsset)
-//        
-//        model.amountInputModel.update(text: "4.99")
-//        let _ = model.amountInputModel.validate()
-//        #expect(!model.amountInputModel.isValid)
-//        
-//        model.amountInputModel.update(text: "5")
-//        let _ = model.amountInputModel.validate()
-//        #expect(model.amountInputModel.isValid)
-//    }
 
     @Test
-    func transferWithSmallAmount() {
-        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 10_000_000_000_000_000))
-        let model = AmountSceneViewModel.mock(type: .transfer(recipient: .mock()), assetData: assetData)
-
-        model.amountInputModel.update(text: "0.001")
-        #expect(model.amountInputModel.isValid)
-    }
-
-    @Test
-    func stakeWithInsufficientAmount() {
-        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 2_000_000_000_000_000_000))
-        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
+    func stakeValidation() {
+        let assetData = AssetData.mock(
+            asset: .mockBNB(),
+            balance: .mock(available: 5_000_000_000_000_000_000)
+        )
+        let model = AmountSceneViewModel.mock(
+            type: .stake(validators: [.mock()], recommendedValidator: nil),
+            assetData: assetData
+        )
 
         model.amountInputModel.update(text: "0.099")
         #expect(model.amountInputModel.isValid == false)
-    }
-
-    @Test
-    func stakeWithSufficientAmount() {
-        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 5_000_000_000_000_000_000))
-        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
 
         model.amountInputModel.update(text: "1.5")
         #expect(model.amountInputModel.isValid == true)
     }
 
     @Test
-    func unfreezeWithSufficientBalance() {
-        let assetData = AssetData.mock(asset: .mockTron(), balance: .mock(frozen: 1_000_000))
+    func transferValidation() {
+        let assetData = AssetData.mock(
+            asset: .mockBNB(),
+            balance: .mock(available: 10_000_000_000_000_000)
+        )
         let model = AmountSceneViewModel.mock(
-            type: .freeze(data: .init(freezeType: .unfreeze, resource: .bandwidth)),
+            type: .transfer(recipient: .mock()),
             assetData: assetData
         )
 
-        model.amountInputModel.update(text: "1.0")
+        model.amountInputModel.update(text: "0.001")
         #expect(model.amountInputModel.isValid == true)
+
+        model.amountInputModel.update(text: "100")
+        #expect(model.amountInputModel.isValid == false)
     }
 
     @Test
-    func unfreezeEnergyWithSufficientBalance() {
-        let assetData = AssetData.mock(asset: .mockTron(), balance: .mock(locked: 2_000_000))
-        let model = AmountSceneViewModel.mock(
-            type: .freeze(data: .init(freezeType: .unfreeze, resource: .energy)),
-            assetData: assetData
-        )
-
-        model.amountInputModel.update(text: "2.0")
-        #expect(model.amountInputModel.isValid == true)
-    }
-
-    @Test
-    func tronStakeWithoutFeeReservation() {
-        let assetData = AssetData.mock(asset: .mockTron(), balance: .mock(frozen: 10_000_000, locked: 0))
-        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
-
-        model.amountInputModel.update(text: "10")
-        #expect(model.amountInputModel.isValid == true)
-    }
-
-    @Test
-    func unfreezeResourceSwitchUpdatesValidators() throws {
+    func unfreezeResourceSwitch() {
         let assetData = AssetData.mock(
             asset: .mockTron(),
             balance: .mock(frozen: 0, locked: 5_000_000)
@@ -134,9 +89,7 @@ struct AmountSceneViewModelTests {
             assetData: assetData
         )
 
-        guard case let .freeze(freeze) = model.provider else {
-            return
-        }
+        guard case let .freeze(freeze) = model.provider else { return }
 
         freeze.resourceSelection.selected = .energy
         model.onChangeResource(.bandwidth, .energy)
@@ -150,20 +103,13 @@ struct AmountSceneViewModelTests {
     }
 
     @Test
-    func stakeWithZeroReservedFees() {
-        let assetData = AssetData.mock(asset: .mockHypercore(), balance: .mock(available: 5_000_000))
-        let model = AmountSceneViewModel.mock(type: .stake(validators: [], recommendedValidator: nil), assetData: assetData)
-
-        model.onSelectMaxButton()
-
-        #expect(model.infoText == nil)
-    }
-
-    @Test
     func selectValidatorPreservesAmount() {
-        let validator1 = DelegationValidator.mock(id: "1", name: "Validator 1")
-        let validator2 = DelegationValidator.mock(id: "2", name: "Validator 2")
-        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 5_000_000_000_000_000_000))
+        let validator1 = DelegationValidator.mock(id: "1")
+        let validator2 = DelegationValidator.mock(id: "2")
+        let assetData = AssetData.mock(
+            asset: .mockBNB(),
+            balance: .mock(available: 5_000_000_000_000_000_000)
+        )
         let model = AmountSceneViewModel.mock(
             type: .stake(validators: [validator1, validator2], recommendedValidator: validator1),
             assetData: assetData
@@ -173,6 +119,34 @@ struct AmountSceneViewModelTests {
         model.onValidatorSelected(validator2)
 
         #expect(model.amountInputModel.text == "1.5")
+    }
+
+    @Test
+    func actionButtonState() {
+        let model = AmountSceneViewModel.mock()
+
+        #expect(model.actionButtonState == .disabled)
+
+        model.amountInputModel.update(text: "1.0")
+        #expect(model.actionButtonState == .normal)
+
+        model.amountInputModel.update(text: "")
+        #expect(model.actionButtonState == .disabled)
+    }
+
+    @Test
+    func onAppearSetsMaxForFixedValue() {
+        let delegation = Delegation.mock(base: .mock(state: .active, balance: "1000000"))
+        let assetData = AssetData.mock(asset: .mockBNB())
+        let model = AmountSceneViewModel.mock(
+            type: .stakeWithdraw(delegation: delegation),
+            assetData: assetData
+        )
+
+        #expect(model.isInputDisabled == true)
+
+        model.onAppear()
+        #expect(model.amountInputModel.text.isEmpty == false)
     }
 }
 

--- a/Features/Transfer/Tests/ViewModels/AmountStakeViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountStakeViewModelTests.swift
@@ -101,5 +101,8 @@ struct AmountStakeViewModelTests {
         #expect(redelegate.type.transactionType == .stakeRedelegate)
         #expect(withdraw.type.transactionType == .stakeWithdraw)
         #expect(stake.value == 100)
+        #expect(unstake.value == 100)
+        #expect(redelegate.value == 100)
+        #expect(withdraw.value == 100)
     }
 }

--- a/Features/Transfer/Tests/ViewModels/AmountStakeViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountStakeViewModelTests.swift
@@ -1,0 +1,105 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import BigInt
+import Testing
+import Primitives
+import PrimitivesTestKit
+
+@testable import Transfer
+
+struct AmountStakeViewModelTests {
+
+    @Test
+    func title() {
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [.mock()], recommended: nil)).title == "Stake")
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .unstake(.mock())).title == "Unstake")
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .redelegate(.mock(), validators: [.mock()], recommended: nil)).title == "Redelegate")
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .withdraw(.mock())).title == "Withdraw")
+    }
+
+    @Test
+    func validatorSelectionEnabled() {
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [.mock()], recommended: nil)).validatorSelection.isEnabled == true)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .unstake(.mock())).validatorSelection.isEnabled == false)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .redelegate(.mock(), validators: [.mock()], recommended: nil)).validatorSelection.isEnabled == true)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .withdraw(.mock())).validatorSelection.isEnabled == false)
+    }
+
+    @Test
+    func validatorSelection() {
+        let recommended = DelegationValidator.mock(id: "recommended")
+        let first = DelegationValidator.mock(id: "first")
+
+        let withRecommended = AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [first, recommended], recommended: recommended))
+        let withoutRecommended = AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [first, recommended], recommended: nil))
+
+        #expect(withRecommended.validatorSelection.selected.id == "recommended")
+        #expect(withoutRecommended.validatorSelection.selected.id == "first")
+    }
+
+    @Test
+    func stakeValidatorsType() {
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [.mock()], recommended: nil)).stakeValidatorsType == .stake)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .redelegate(.mock(), validators: [.mock()], recommended: nil)).stakeValidatorsType == .stake)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .unstake(.mock())).stakeValidatorsType == .unstake)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .withdraw(.mock())).stakeValidatorsType == .unstake)
+    }
+
+    @Test
+    func canChangeValue() {
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [.mock()], recommended: nil)).canChangeValue == true)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .redelegate(.mock(), validators: [.mock()], recommended: nil)).canChangeValue == true)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .withdraw(.mock())).canChangeValue == false)
+    }
+
+    @Test
+    func reserveForFee() {
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [.mock()], recommended: nil)).reserveForFee > .zero)
+        #expect(AmountStakeViewModel(asset: .mockTron(), action: .stake(validators: [.mock()], recommended: nil)).reserveForFee == .zero)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .unstake(.mock())).reserveForFee == .zero)
+    }
+
+    @Test
+    func minimumValue() {
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [.mock()], recommended: nil)).minimumValue > .zero)
+        #expect(AmountStakeViewModel(asset: .mockBNB(), action: .unstake(.mock())).minimumValue == .zero)
+    }
+
+    @Test
+    func availableValue() {
+        let delegation = Delegation.mock(base: .mock(state: .active, balance: "5000000"))
+        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 1000))
+
+        let stake = AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [.mock()], recommended: nil))
+        let unstake = AmountStakeViewModel(asset: .mockBNB(), action: .unstake(delegation))
+
+        #expect(stake.availableValue(from: assetData) == 1000)
+        #expect(unstake.availableValue(from: assetData) == 5000000)
+    }
+
+    @Test
+    func shouldReserveFee() {
+        let assetData = AssetData.mock(asset: .mockBNB(), balance: .mock(available: 5_000_000_000_000_000_000))
+        let delegation = Delegation.mock(base: .mock(state: .active, balance: "1000000"))
+        let unstake = AmountStakeViewModel(asset: .mockBNB(), action: .unstake(delegation))
+
+        #expect(unstake.shouldReserveFee(from: assetData) == false)
+    }
+
+    @Test
+    func makeTransferData() throws {
+        let validator = DelegationValidator.mock(id: "validator1")
+        let delegation = Delegation.mock(validator: validator)
+
+        let stake = try AmountStakeViewModel(asset: .mockBNB(), action: .stake(validators: [validator], recommended: nil)).makeTransferData(value: 100)
+        let unstake = try AmountStakeViewModel(asset: .mockBNB(), action: .unstake(delegation)).makeTransferData(value: 100)
+        let redelegate = try AmountStakeViewModel(asset: .mockBNB(), action: .redelegate(delegation, validators: [validator], recommended: nil)).makeTransferData(value: 100)
+        let withdraw = try AmountStakeViewModel(asset: .mockBNB(), action: .withdraw(delegation)).makeTransferData(value: 100)
+
+        #expect(stake.type.transactionType == .stakeDelegate)
+        #expect(unstake.type.transactionType == .stakeUndelegate)
+        #expect(redelegate.type.transactionType == .stakeRedelegate)
+        #expect(withdraw.type.transactionType == .stakeWithdraw)
+        #expect(stake.value == 100)
+    }
+}

--- a/Features/Transfer/Tests/ViewModels/AmountTransferViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/AmountTransferViewModelTests.swift
@@ -1,0 +1,56 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import BigInt
+import Testing
+import Primitives
+import PrimitivesTestKit
+
+@testable import Transfer
+
+struct AmountTransferViewModelTests {
+
+    @Test
+    func title() {
+        #expect(AmountTransferViewModel(asset: .mock(), action: .send(.mock())).title == "Send")
+        #expect(AmountTransferViewModel(asset: .mock(), action: .deposit(.mock())).title == "Deposit")
+        #expect(AmountTransferViewModel(asset: .mock(), action: .withdraw(.mock())).title == "Withdraw")
+    }
+
+    @Test
+    func minimumValue() {
+        let usdc = Asset.mock(symbol: "USDC")
+
+        #expect(AmountTransferViewModel(asset: .mock(), action: .send(.mock())).minimumValue == .zero)
+        #expect(AmountTransferViewModel(asset: usdc, action: .deposit(.mock())).minimumValue == AmountPerpetualLimits.minDeposit)
+        #expect(AmountTransferViewModel(asset: usdc, action: .withdraw(.mock())).minimumValue == AmountPerpetualLimits.minWithdraw)
+    }
+
+    @Test
+    func availableValue() {
+        let assetData = AssetData.mock(balance: .mock(available: 1000, withdrawable: 500))
+
+        #expect(AmountTransferViewModel(asset: .mock(), action: .send(.mock())).availableValue(from: assetData) == 1000)
+        #expect(AmountTransferViewModel(asset: .mock(), action: .deposit(.mock())).availableValue(from: assetData) == 1000)
+        #expect(AmountTransferViewModel(asset: .mock(), action: .withdraw(.mock())).availableValue(from: assetData) == 500)
+    }
+
+    @Test
+    func recipientData() {
+        let recipient = RecipientData.mock(recipient: .mock(address: "0x123"))
+        #expect(AmountTransferViewModel(asset: .mock(), action: .send(recipient)).recipientData().recipient.address == "0x123")
+    }
+
+    @Test
+    func makeTransferData() throws {
+        let send = try AmountTransferViewModel(asset: .mock(), action: .send(.mock())).makeTransferData(value: 100)
+        let deposit = try AmountTransferViewModel(asset: .mock(), action: .deposit(.mock())).makeTransferData(value: 200)
+        let withdraw = try AmountTransferViewModel(asset: .mock(), action: .withdraw(.mock())).makeTransferData(value: 300)
+
+        #expect(send.type.transactionType == .transfer)
+        #expect(deposit.type.transactionType == .transfer)
+        #expect(withdraw.type.transactionType == .transfer)
+        #expect(send.value == 100)
+        #expect(deposit.value == 200)
+        #expect(withdraw.value == 300)
+    }
+}

--- a/Packages/Primitives/TestKit/Balance+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/Balance+PrimitivesTestKit.swift
@@ -12,7 +12,8 @@ extension Balance {
         staked: BigInt = .zero,
         pending: BigInt = .zero,
         rewards: BigInt = .zero,
-        reserved: BigInt = .zero
+        reserved: BigInt = .zero,
+        withdrawable: BigInt = .zero
     ) -> Balance {
         Balance(
             available: available,
@@ -21,7 +22,8 @@ extension Balance {
             staked: staked,
             pending: pending,
             rewards: rewards,
-            reserved: reserved
+            reserved: reserved,
+            withdrawable: withdrawable
         )
     }
 }

--- a/Packages/Primitives/TestKit/PerpetualRecipientData+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/PerpetualRecipientData+PrimitivesTestKit.swift
@@ -1,0 +1,16 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+
+public extension PerpetualRecipientData {
+    static func mock(
+        recipient: RecipientData = .mock(),
+        positionAction: PerpetualPositionAction = .open(.mock())
+    ) -> PerpetualRecipientData {
+        PerpetualRecipientData(
+            recipient: recipient,
+            positionAction: positionAction
+        )
+    }
+}


### PR DESCRIPTION
Introduces comprehensive unit tests for AmountFreezeViewModel, AmountPerpetualViewModel, AmountStakeViewModel, and AmountTransferViewModel. Updates AmountSceneViewModelTests with improved and additional test cases. Adds a mock utility for PerpetualRecipientData and extends Balance mock to support withdrawable balances, enhancing test coverage and reliability for transfer-related view models.