### PR TITLE
Add wallet dependency to AssetSceneBannersViewModel

### DIFF
--- a/Features/Assets/Sources/ViewModels/AssetSceneBannersViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneBannersViewModel.swift
@@ -10,13 +10,16 @@ import PrimitivesComponents
 public final class AssetSceneBannersViewModel: Sendable {
     private let assetData: AssetData
     private let banners: [Banner]
-    
+    private let wallet: Wallet
+
     public init(
         assetData: AssetData,
-        banners: [Banner]
+        banners: [Banner],
+        wallet: Wallet
     ) {
         self.assetData = assetData
         self.banners = banners
+        self.wallet = wallet
     }
     
     public var allBanners: [Banner] {
@@ -38,7 +41,7 @@ public final class AssetSceneBannersViewModel: Sendable {
         switch banner.event {
         case .enableNotifications, .accountBlockedMultiSignature, .tradePerpetuals: true
         case .accountActivation: assetData.balance.available == 0
-        case .stake: assetData.balance.staked.isZero && assetData.balance.frozen.isZero
+        case .stake: wallet.canSign && assetData.balance.staked.isZero && assetData.balance.frozen.isZero
         case .activateAsset: !assetData.metadata.isActive
         case .suspiciousAsset: AssetScoreTypeViewModel(score: assetData.metadata.rankScore).shouldShowBanner
         case .onboarding: false

--- a/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -148,7 +148,7 @@ public final class AssetSceneViewModel: Sendable {
     }
     
     var assetBannerViewModel: AssetSceneBannersViewModel {
-        AssetSceneBannersViewModel(assetData: assetData, banners: banners)
+        AssetSceneBannersViewModel(assetData: assetData, banners: banners, wallet: wallet)
     }
     
     var assetHeaderModel: AssetHeaderViewModel {

--- a/Features/Assets/Tests/AssetsTests/AssetBannersViewModelTests.swift
+++ b/Features/Assets/Tests/AssetsTests/AssetBannersViewModelTests.swift
@@ -9,57 +9,73 @@ import BigInt
 
 @MainActor
 struct AssetBannersViewModelTests {
-    
+
     @Test
     func stakingBannerFiltering() {
-        let withStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: BigInt(100))), banners: [.mock(event: .stake)])
+        let withStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: BigInt(100))), banners: [.mock(event: .stake)], wallet: .mock())
         #expect(withStake.allBanners.isEmpty)
-        
-        let noStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: .zero)), banners: [.mock(event: .stake)])
+
+        let noStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: .zero)), banners: [.mock(event: .stake)], wallet: .mock())
         #expect(noStake.allBanners.count == 1)
     }
-    
+
+    @Test
+    func stakeBannerHiddenForViewOnlyWallet() {
+        let viewOnlyWallet = AssetSceneBannersViewModel(
+            assetData: .mock(balance: Balance(staked: .zero)),
+            banners: [.mock(event: .stake)],
+            wallet: .mock(type: .view)
+        )
+        #expect(viewOnlyWallet.allBanners.isEmpty)
+
+        let regularWallet = AssetSceneBannersViewModel(
+            assetData: .mock(balance: Balance(staked: .zero)),
+            banners: [.mock(event: .stake)],
+            wallet: .mock(type: .multicoin)
+        )
+        #expect(regularWallet.allBanners.count == 1)
+    }
+
     @Test
     func activateAssetBanner() {
-        let inactive = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: false)), banners: [])
+        let inactive = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: false)), banners: [], wallet: .mock())
         #expect(inactive.allBanners.count == 1)
         #expect(inactive.allBanners.first?.event == .activateAsset)
 
-        let active = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: true)), banners: [])
+        let active = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: true)), banners: [], wallet: .mock())
         #expect(active.allBanners.isEmpty)
     }
-    
+
     @Test
     func suspiciousAssetBanner() {
-        let suspicious = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 5)), banners: [])
+        let suspicious = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 5)), banners: [], wallet: .mock())
         #expect(suspicious.allBanners.count == 1)
         #expect(suspicious.allBanners.first?.event == .suspiciousAsset)
 
-        #expect(AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 50)), banners: []).allBanners.isEmpty)
+        #expect(AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 50)), banners: [], wallet: .mock()).allBanners.isEmpty)
     }
-    
+
     @Test
     func accountActivationBanner() {
         #expect(AssetSceneBannersViewModel(
             assetData: .mock(asset: .mockXRP(), balance: .zero, metadata: .mock(rankScore: 16)),
-            banners: [
-                .mock(event: .accountActivation)
-            ]
+            banners: [.mock(event: .accountActivation)],
+            wallet: .mock()
         ).allBanners.first?.event == .accountActivation)
-        
+
         #expect(AssetSceneBannersViewModel(
             assetData: .mock(balance: Balance(available: BigInt(1)), metadata: .mock(rankScore: 16)),
-            banners: [
-                .mock(event: .accountActivation)
-            ]
+            banners: [.mock(event: .accountActivation)],
+            wallet: .mock()
         ).allBanners.isEmpty)
-	}
+    }
 
-	@Test
+    @Test
     func nonClosableBannersShowFirst() {
         let model = AssetSceneBannersViewModel(
             assetData: .mock(metadata: .mock(rankScore: 5)),
-            banners: [.mock(event: .stake, state: .active), .mock(event: .accountActivation, state: .alwaysActive)]
+            banners: [.mock(event: .stake, state: .active), .mock(event: .accountActivation, state: .alwaysActive)],
+            wallet: .mock()
         )
 
         #expect(model.allBanners.count == 3)
@@ -67,7 +83,7 @@ struct AssetBannersViewModelTests {
         #expect(model.allBanners[1].state == .alwaysActive)
         #expect(model.allBanners[2].state == .active)
     }
-    
+
     @Test
     func priorityBannerReturnsHighestPriority() {
         let model = AssetSceneBannersViewModel(
@@ -76,9 +92,10 @@ struct AssetBannersViewModelTests {
                 .mock(event: .stake, state: .active),
                 .mock(event: .enableNotifications, state: .cancelled),
                 .mock(event: .accountActivation, state: .alwaysActive)
-            ]
+            ],
+            wallet: .mock()
         )
-        
+
         #expect(model.allBanners.first?.state == .alwaysActive)
     }
 }


### PR DESCRIPTION
AssetSceneBannersViewModel now requires a Wallet instance, enabling logic that hides the stake banner for view-only wallets. Updated AssetSceneViewModel and related tests to provide the wallet parameter and added a new test to verify stake banner visibility based on wallet type.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1546