### PR TITLE
Reduce HStack spacing in AddToken and AddNode scenes

### DIFF
--- a/Features/Assets/Sources/Scenes/AddTokenScene.swift
+++ b/Features/Assets/Sources/Scenes/AddTokenScene.swift
@@ -76,7 +76,7 @@ extension AddTokenScene {
             }
             Section {
                 FloatTextField(model.addressTitleField, text: model.addressBinding) {
-                    HStack(spacing: .medium) {
+                    HStack(spacing: .small) {
                         ListButton(image: model.pasteImage, action: onSelectPaste)
                         ListButton(image: model.qrImage, action: onSelectScan)
                     }

--- a/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
+++ b/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
@@ -79,7 +79,7 @@ extension AddNodeScene {
                 placeholder: model.inputFieldTitle,
                 onClean: { model.debounceInterval = nil }
             ) {
-                HStack(spacing: .medium) {
+                HStack(spacing: .small) {
                     ListButton(image: Images.System.paste, action: onSelectPaste)
                     ListButton(image: Images.System.qrCodeViewfinder, action: onSelectScan)
                 }


### PR DESCRIPTION
Changed HStack spacing from .medium to .small for button groups in AddTokenScene and AddNodeScene to improve UI compactness.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-05 at 12 35 37" src="https://github.com/user-attachments/assets/7ac07f9e-ae27-43be-bbc4-729238f434fc" />


Fix: https://github.com/gemwalletcom/gem-ios/issues/1552