### PR TITLE
Add exponential reconnection to WebSocket client

### DIFF
--- a/Packages/SwiftHTTPClient/Package.swift
+++ b/Packages/SwiftHTTPClient/Package.swift
@@ -45,12 +45,17 @@ let package = Package(
             name: "WebSocketClient",
             dependencies: [],
             path: "WebSocketClient",
-            exclude: ["TestKit"]
+            exclude: ["TestKit", "Tests"]
         ),
         .target(
             name: "WebSocketClientTestKit",
             dependencies: ["WebSocketClient"],
             path: "WebSocketClient/TestKit"
+        ),
+        .testTarget(
+            name: "WebSocketClientTests",
+            dependencies: ["WebSocketClient"],
+            path: "WebSocketClient/Tests"
         ),
     ]
 )

--- a/Packages/SwiftHTTPClient/WebSocketClient/Tests/ExponentialReconnectionTests.swift
+++ b/Packages/SwiftHTTPClient/WebSocketClient/Tests/ExponentialReconnectionTests.swift
@@ -1,0 +1,20 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Testing
+
+@testable import WebSocketClient
+
+struct ExponentialReconnectionTests {
+
+    @Test
+    func reconnectAfterWithDefaultMultiplier() {
+        let reconnection = ExponentialReconnection(multiplier: 0.3, maxDelay: 10)
+
+        #expect(reconnection.reconnectAfter(attempt: 0) == 0.3 * exp(0))
+        #expect(reconnection.reconnectAfter(attempt: 1) == 0.3 * exp(1))
+        #expect(reconnection.reconnectAfter(attempt: 2) == 0.3 * exp(2))
+        #expect(reconnection.reconnectAfter(attempt: 10) == 10)
+        #expect(reconnection.reconnectAfter(attempt: 100) == 10)
+    }
+}

--- a/Packages/SwiftHTTPClient/WebSocketClient/Types/ExponentialReconnection.swift
+++ b/Packages/SwiftHTTPClient/WebSocketClient/Types/ExponentialReconnection.swift
@@ -1,0 +1,24 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public protocol Reconnectable: Sendable {
+    func reconnectAfter(attempt: Int) -> TimeInterval
+}
+
+public struct ExponentialReconnection: Reconnectable {
+    public let multiplier: Double
+    public let maxDelay: TimeInterval
+
+    public init(
+        multiplier: Double = 0.3,
+        maxDelay: TimeInterval = 60
+    ) {
+        self.multiplier = multiplier
+        self.maxDelay = maxDelay
+    }
+
+    public func reconnectAfter(attempt: Int) -> TimeInterval {
+        min(multiplier * exp(Double(attempt)), maxDelay)
+    }
+}

--- a/Packages/SwiftHTTPClient/WebSocketClient/Types/WebSocketConfiguration.swift
+++ b/Packages/SwiftHTTPClient/WebSocketClient/Types/WebSocketConfiguration.swift
@@ -4,19 +4,16 @@ import Foundation
 
 public struct WebSocketConfiguration: Sendable {
     public let url: URL
-    public let reconnectDelay: TimeInterval
-    public let maxReconnectDelay: TimeInterval
+    public let reconnection: any Reconnectable
     public let sessionConfiguration: URLSessionConfiguration
 
     public init(
         url: URL,
-        reconnectDelay: TimeInterval = 1,
-        maxReconnectDelay: TimeInterval = 30,
+        reconnection: any Reconnectable = ExponentialReconnection(),
         sessionConfiguration: URLSessionConfiguration = .default
     ) {
         self.url = url
-        self.reconnectDelay = reconnectDelay
-        self.maxReconnectDelay = maxReconnectDelay
+        self.reconnection = reconnection
         self.sessionConfiguration = sessionConfiguration
     }
 }

--- a/Packages/SwiftHTTPClient/WebSocketClient/WebSocketConnection.swift
+++ b/Packages/SwiftHTTPClient/WebSocketClient/WebSocketConnection.swift
@@ -82,6 +82,7 @@ public actor WebSocketConnection: WebSocketConnectable {
             }
         }
 
+        resetReconnectionAttempt()
         startConnection()
     }
 
@@ -122,7 +123,7 @@ public actor WebSocketConnection: WebSocketConnectable {
         guard state == .connecting else { return }
 
         state = .connected
-        reconnectAttempt = 0
+        resetReconnectionAttempt()
         continuation?.yield(.connected)
     }
 
@@ -189,5 +190,9 @@ public actor WebSocketConnection: WebSocketConnectable {
 
         guard state == .reconnecting, task == nil else { return }
         startConnection()
+    }
+    
+    private func resetReconnectionAttempt() {
+        reconnectAttempt = 0
     }
 }

--- a/Packages/SwiftHTTPClient/WebSocketClient/WebSocketSessionDelegate.swift
+++ b/Packages/SwiftHTTPClient/WebSocketClient/WebSocketSessionDelegate.swift
@@ -1,0 +1,34 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+final class WebSocketSessionDelegate: NSObject, URLSessionWebSocketDelegate, Sendable {
+
+    private let didOpen: @Sendable () -> Void
+    private let didClose: @Sendable (URLSessionWebSocketTask.CloseCode, Data?) -> Void
+
+    init(
+        didOpen: @escaping @Sendable () -> Void,
+        didClose: @escaping @Sendable (URLSessionWebSocketTask.CloseCode, Data?) -> Void
+    ) {
+        self.didOpen = didOpen
+        self.didClose = didClose
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        didOpen()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didCloseWith closeCode: URLSessionWebSocketTask.CloseCode,
+        reason: Data?
+    ) {
+        didClose(closeCode, reason)
+    }
+}


### PR DESCRIPTION
Introduced an ExponentialReconnection strategy and protocol for reconnection logic. Updated WebSocketConfiguration to use a Reconnectable type instead of fixed delays. Refactored WebSocketConnection to use the new reconnection logic and added a session delegate for handling connection events. Added tests for exponential reconnection behavior.

Close: https://github.com/gemwalletcom/gem-ios/issues/1548