### PR TITLE
Refactor banner logic to remove wallet dependency

### DIFF
--- a/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -28,7 +28,7 @@ public struct AssetScene: View {
             }
             .cleanListRow()
             
-            if let banner = model.assetBannerViewModel.allBanners.first {
+            if model.canSign, let banner = model.assetBannerViewModel.allBanners.first {
                 Section {
                     BannerView(
                         banner: banner,

--- a/Features/Assets/Sources/ViewModels/AssetSceneBannersViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneBannersViewModel.swift
@@ -10,16 +10,13 @@ import PrimitivesComponents
 public final class AssetSceneBannersViewModel: Sendable {
     private let assetData: AssetData
     private let banners: [Banner]
-    private let wallet: Wallet
 
     public init(
         assetData: AssetData,
-        banners: [Banner],
-        wallet: Wallet
+        banners: [Banner]
     ) {
         self.assetData = assetData
         self.banners = banners
-        self.wallet = wallet
     }
     
     public var allBanners: [Banner] {
@@ -41,7 +38,7 @@ public final class AssetSceneBannersViewModel: Sendable {
         switch banner.event {
         case .enableNotifications, .accountBlockedMultiSignature, .tradePerpetuals: true
         case .accountActivation: assetData.balance.available == 0
-        case .stake: wallet.canSign && assetData.balance.staked.isZero && assetData.balance.frozen.isZero
+        case .stake: assetData.balance.staked.isZero && assetData.balance.frozen.isZero
         case .activateAsset: !assetData.metadata.isActive
         case .suspiciousAsset: AssetScoreTypeViewModel(score: assetData.metadata.rankScore).shouldShowBanner
         case .onboarding: false

--- a/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -93,6 +93,8 @@ public final class AssetSceneViewModel: Sendable {
     var showTransactions: Bool { transactions.isNotEmpty }
     var showManageToken: Bool { !assetData.metadata.isBalanceEnabled }
 
+    var canSign: Bool { wallet.canSign }
+
     var pinText: String {
         assetData.metadata.isPinned ? Localized.Common.unpin : Localized.Common.pin
     }
@@ -148,7 +150,7 @@ public final class AssetSceneViewModel: Sendable {
     }
     
     var assetBannerViewModel: AssetSceneBannersViewModel {
-        AssetSceneBannersViewModel(assetData: assetData, banners: banners, wallet: wallet)
+        AssetSceneBannersViewModel(assetData: assetData, banners: banners)
     }
     
     var assetHeaderModel: AssetHeaderViewModel {

--- a/Features/Assets/Tests/AssetsTests/AssetBannersViewModelTests.swift
+++ b/Features/Assets/Tests/AssetsTests/AssetBannersViewModelTests.swift
@@ -12,61 +12,42 @@ struct AssetBannersViewModelTests {
 
     @Test
     func stakingBannerFiltering() {
-        let withStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: BigInt(100))), banners: [.mock(event: .stake)], wallet: .mock())
+        let withStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: BigInt(100))), banners: [.mock(event: .stake)])
         #expect(withStake.allBanners.isEmpty)
 
-        let noStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: .zero)), banners: [.mock(event: .stake)], wallet: .mock())
+        let noStake = AssetSceneBannersViewModel(assetData: .mock(balance: Balance(staked: .zero)), banners: [.mock(event: .stake)])
         #expect(noStake.allBanners.count == 1)
     }
 
     @Test
-    func stakeBannerHiddenForViewOnlyWallet() {
-        let viewOnlyWallet = AssetSceneBannersViewModel(
-            assetData: .mock(balance: Balance(staked: .zero)),
-            banners: [.mock(event: .stake)],
-            wallet: .mock(type: .view)
-        )
-        #expect(viewOnlyWallet.allBanners.isEmpty)
-
-        let regularWallet = AssetSceneBannersViewModel(
-            assetData: .mock(balance: Balance(staked: .zero)),
-            banners: [.mock(event: .stake)],
-            wallet: .mock(type: .multicoin)
-        )
-        #expect(regularWallet.allBanners.count == 1)
-    }
-
-    @Test
     func activateAssetBanner() {
-        let inactive = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: false)), banners: [], wallet: .mock())
+        let inactive = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: false)), banners: [])
         #expect(inactive.allBanners.count == 1)
         #expect(inactive.allBanners.first?.event == .activateAsset)
 
-        let active = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: true)), banners: [], wallet: .mock())
+        let active = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(isActive: true)), banners: [])
         #expect(active.allBanners.isEmpty)
     }
 
     @Test
     func suspiciousAssetBanner() {
-        let suspicious = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 5)), banners: [], wallet: .mock())
+        let suspicious = AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 5)), banners: [])
         #expect(suspicious.allBanners.count == 1)
         #expect(suspicious.allBanners.first?.event == .suspiciousAsset)
 
-        #expect(AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 50)), banners: [], wallet: .mock()).allBanners.isEmpty)
+        #expect(AssetSceneBannersViewModel(assetData: .mock(metadata: .mock(rankScore: 50)), banners: []).allBanners.isEmpty)
     }
 
     @Test
     func accountActivationBanner() {
         #expect(AssetSceneBannersViewModel(
             assetData: .mock(asset: .mockXRP(), balance: .zero, metadata: .mock(rankScore: 16)),
-            banners: [.mock(event: .accountActivation)],
-            wallet: .mock()
+            banners: [.mock(event: .accountActivation)]
         ).allBanners.first?.event == .accountActivation)
 
         #expect(AssetSceneBannersViewModel(
             assetData: .mock(balance: Balance(available: BigInt(1)), metadata: .mock(rankScore: 16)),
-            banners: [.mock(event: .accountActivation)],
-            wallet: .mock()
+            banners: [.mock(event: .accountActivation)]
         ).allBanners.isEmpty)
     }
 
@@ -74,8 +55,7 @@ struct AssetBannersViewModelTests {
     func nonClosableBannersShowFirst() {
         let model = AssetSceneBannersViewModel(
             assetData: .mock(metadata: .mock(rankScore: 5)),
-            banners: [.mock(event: .stake, state: .active), .mock(event: .accountActivation, state: .alwaysActive)],
-            wallet: .mock()
+            banners: [.mock(event: .stake, state: .active), .mock(event: .accountActivation, state: .alwaysActive)]
         )
 
         #expect(model.allBanners.count == 3)
@@ -92,8 +72,7 @@ struct AssetBannersViewModelTests {
                 .mock(event: .stake, state: .active),
                 .mock(event: .enableNotifications, state: .cancelled),
                 .mock(event: .accountActivation, state: .alwaysActive)
-            ],
-            wallet: .mock()
+            ]
         )
 
         #expect(model.allBanners.first?.state == .alwaysActive)


### PR DESCRIPTION
Removed the wallet parameter from AssetSceneBannersViewModel and updated related logic to use canSign from AssetSceneViewModel instead. Adjusted banner filtering and tests accordingly to decouple banner logic from wallet type, improving separation of concerns.