### PR TITLE
Add support for sign/send actions in generic transfers

### DIFF
--- a/Features/Transactions/Sources/ViewModels/TransactionParticipantViewModel.swift
+++ b/Features/Transactions/Sources/ViewModels/TransactionParticipantViewModel.swift
@@ -69,8 +69,13 @@ extension TransactionParticipantViewModel {
             case .incoming: Localized.Transaction.sender
             case .outgoing, .selfTransfer: Localized.Transaction.recipient
             }
-        case .tokenApproval, .smartContractCall:
+        case .tokenApproval:
             Localized.Asset.contract
+        case .smartContractCall:
+            switch transactionViewModel.transaction.transaction.metadata?.walletConnectOutputAction {
+            case .send: Localized.Transaction.recipient
+            case .sign, .none: Localized.Asset.contract
+            }
         case .stakeDelegate:
             Localized.Stake.validator
         case .stakeFreeze, .stakeUnfreeze:

--- a/Features/Transfer/Sources/ViewModels/ConfirmRecipientViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmRecipientViewModel.swift
@@ -49,7 +49,12 @@ extension ConfirmRecipientViewModel {
             case .stake, .unstake, .redelegate, .rewards, .withdraw: Localized.Stake.validator
             case .freeze: Localized.Stake.resource
             }
-        case .transfer, .deposit, .withdrawal, .transferNft, .tokenApprove, .generic, .account, .perpetual: Localized.Transfer.Recipient.title
+        case .generic:
+            switch model.type.outputAction {
+            case .sign: Localized.Asset.contract
+            case .send: Localized.Transfer.Recipient.title
+            }
+        case .transfer, .deposit, .withdrawal, .transferNft, .tokenApprove, .account, .perpetual: Localized.Transfer.Recipient.title
         }
     }
 

--- a/Features/Transfer/Sources/ViewModels/TransferDataViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/TransferDataViewModel.swift
@@ -30,8 +30,11 @@ struct TransferDataViewModel {
         case .withdrawal: Localized.Wallet.withdraw
         case .transferNft: Localized.Transfer.Send.title
         case .swap, .tokenApprove: Localized.Wallet.swap
-        //case .approval: Localized.Transfer.Approve.title
-        case .generic: Localized.Transfer.Approve.title
+        case .generic:
+            switch type.outputAction {
+            case .sign: Localized.Transfer.SignTransaction.title
+            case .send: Localized.Transfer.Send.title
+            }
         case .stake(_, let type):
             switch type {
             case .stake: Localized.Transfer.Stake.title

--- a/Features/Transfer/Tests/ViewModels/ConfirmRecipientViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmRecipientViewModelTests.swift
@@ -51,15 +51,27 @@ struct ConfirmRecipientViewModelTests {
     }
 
     @Test
-    func generic() {
+    func genericSend() {
         let model = ConfirmRecipientViewModel(
-            model: .mock(type: .generic(asset: .mock(), metadata: .mock(), extra: .mock())),
+            model: .mock(type: .generic(asset: .mock(), metadata: .mock(), extra: .mock(outputAction: .send))),
             addressName: nil,
             addressLink: .mock()
         )
 
         guard case .recipient(let item) = model.itemModel else { return }
         #expect(item.title == Localized.Transfer.Recipient.title)
+    }
+
+    @Test
+    func genericSign() {
+        let model = ConfirmRecipientViewModel(
+            model: .mock(type: .generic(asset: .mock(), metadata: .mock(), extra: .mock(outputAction: .sign))),
+            addressName: nil,
+            addressLink: .mock()
+        )
+
+        guard case .recipient(let item) = model.itemModel else { return }
+        #expect(item.title == Localized.Asset.contract)
     }
 
     @Test

--- a/Features/Transfer/Tests/ViewModels/TransferDataViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/TransferDataViewModelTests.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Testing
+import Localization
 @testable import Transfer
 @testable import Primitives
 import PrimitivesTestKit
@@ -11,13 +12,25 @@ struct TransferDataViewModelTests {
     func depositTitle() {
         #expect(TransferDataViewModel.mock(type: .deposit(.mock())).title == "Deposit")
     }
+
+    @Test
+    func genericSendTitle() {
+        let type = TransferDataType.generic(asset: .mock(), metadata: .mock(), extra: .mock(outputAction: .send))
+        #expect(TransferDataViewModel.mock(type: type).title == Localized.Transfer.Send.title)
+    }
+
+    @Test
+    func genericSignTitle() {
+        let type = TransferDataType.generic(asset: .mock(), metadata: .mock(), extra: .mock(outputAction: .sign))
+        #expect(TransferDataViewModel.mock(type: type).title == Localized.Transfer.SignTransaction.title)
+    }
 }
 
 private extension TransferDataViewModel {
     static func mock(
         type: TransferDataType = .transfer(.mock())
     ) -> TransferDataViewModel {
-        return TransferDataViewModel(
+        TransferDataViewModel(
             data: TransferData.mock(type: type)
         )
     }

--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -1420,6 +1420,10 @@ public enum Localized {
       /// Send
       public static let title = Localized.tr("Localizable", "transfer.send.title", fallback: "Send")
     }
+    public enum SignTransaction {
+      /// Sign Transaction
+      public static let title = Localized.tr("Localizable", "transfer.sign_transaction.title", fallback: "Sign Transaction")
+    }
     public enum SmartContract {
       /// Smart Contract
       public static let title = Localized.tr("Localizable", "transfer.smart_contract.title", fallback: "Smart Contract")

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "يحصل %@";
 "rewards.insufficient_points" = "نقاط غير كافية";
 "rewards.confirm_redeem" = "يحصل %@ ل %@!";
+"transfer.sign_transaction.title" = "توقيع المعاملة";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "পান %@";
 "rewards.insufficient_points" = "অপর্যাপ্ত পয়েন্ট";
 "rewards.confirm_redeem" = "পান %@ জন্য %@!";
+"transfer.sign_transaction.title" = "লেনদেন স্বাক্ষর করুন";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Získat %@";
 "rewards.insufficient_points" = "Nedostatek bodů";
 "rewards.confirm_redeem" = "Získat %@ pro %@!";
+"transfer.sign_transaction.title" = "Podepsat transakci";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Få %@";
 "rewards.insufficient_points" = "Utilstrækkelige point";
 "rewards.confirm_redeem" = "Få %@ for %@!";
+"transfer.sign_transaction.title" = "Underskriv transaktion";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Erhalten %@";
 "rewards.insufficient_points" = "Unzureichende Punkte";
 "rewards.confirm_redeem" = "Erhalten %@ für %@!";
+"transfer.sign_transaction.title" = "Transaktion signieren";

--- a/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Get %@";
 "rewards.insufficient_points" = "Insufficient points";
 "rewards.confirm_redeem" = "Get %@ for %@!";
+"transfer.sign_transaction.title" = "Sign Transaction";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Conseguir %@";
 "rewards.insufficient_points" = "Puntos insuficientes";
 "rewards.confirm_redeem" = "Conseguir %@ para %@!";
+"transfer.sign_transaction.title" = "Firmar transacción";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "دریافت %@";
 "rewards.insufficient_points" = "امتیاز ناکافی";
 "rewards.confirm_redeem" = "دریافت %@ برای %@!";
+"transfer.sign_transaction.title" = "ثبت تراکنش";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Kunin %@";
 "rewards.insufficient_points" = "Hindi sapat na puntos";
 "rewards.confirm_redeem" = "Kunin %@ para sa %@!";
+"transfer.sign_transaction.title" = "Pirmahan ang Transaksyon";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Obtenir %@";
 "rewards.insufficient_points" = "Points insuffisants";
 "rewards.confirm_redeem" = "Obtenir %@ pour %@!";
+"transfer.sign_transaction.title" = "Signer la transaction";

--- a/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Samu %@";
 "rewards.insufficient_points" = "Rashin isassun maki";
 "rewards.confirm_redeem" = "Samu %@ don %@!";
+"transfer.sign_transaction.title" = "Sa hannu kan Ma'amala";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "לְקַבֵּל %@";
 "rewards.insufficient_points" = "נקודות לא מספיקות";
 "rewards.confirm_redeem" = "לְקַבֵּל %@ עֲבוּר %@!";
+"transfer.sign_transaction.title" = "חתימה על עסקה";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "पाना %@";
 "rewards.insufficient_points" = "अपर्याप्त अंक";
 "rewards.confirm_redeem" = "पाना %@ के लिए %@!";
+"transfer.sign_transaction.title" = "लेनदेन पर हस्ताक्षर करें";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Mendapatkan %@";
 "rewards.insufficient_points" = "Poin tidak mencukupi";
 "rewards.confirm_redeem" = "Mendapatkan %@ untuk %@!";
+"transfer.sign_transaction.title" = "Menandatangani Transaksi";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Ottenere %@";
 "rewards.insufficient_points" = "Punti insufficienti";
 "rewards.confirm_redeem" = "Ottenere %@ per %@!";
+"transfer.sign_transaction.title" = "Firma la transazione";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "得る %@";
 "rewards.insufficient_points" = "ポイントが足りない";
 "rewards.confirm_redeem" = "得る %@ のために %@!";
+"transfer.sign_transaction.title" = "トランザクションに署名";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "얻다 %@";
 "rewards.insufficient_points" = "점수가 부족합니다";
 "rewards.confirm_redeem" = "얻다 %@ ~을 위한 %@!";
+"transfer.sign_transaction.title" = "거래 서명";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Dapatkan %@";
 "rewards.insufficient_points" = "Mata tidak mencukupi";
 "rewards.confirm_redeem" = "Dapatkan %@ untuk %@!";
+"transfer.sign_transaction.title" = "Tandatangan Transaksi";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Krijgen %@";
 "rewards.insufficient_points" = "Onvoldoende punten";
 "rewards.confirm_redeem" = "Krijgen %@ voor %@!";
+"transfer.sign_transaction.title" = "Transactie ondertekenen";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Dostawać %@";
 "rewards.insufficient_points" = "Za mało punktów";
 "rewards.confirm_redeem" = "Dostawać %@ Do %@!";
+"transfer.sign_transaction.title" = "Podpisz transakcję";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Pegar %@";
 "rewards.insufficient_points" = "Pontos insuficientes";
 "rewards.confirm_redeem" = "Pegar %@ para %@!";
+"transfer.sign_transaction.title" = "Assinar transação";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Obţine %@";
 "rewards.insufficient_points" = "Puncte insuficiente";
 "rewards.confirm_redeem" = "Obţine %@ pentru %@!";
+"transfer.sign_transaction.title" = "Semnează tranzacția";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Получать %@";
 "rewards.insufficient_points" = "Недостаточно баллов";
 "rewards.confirm_redeem" = "Получать %@ для %@!";
+"transfer.sign_transaction.title" = "Подписать транзакцию";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Pata %@";
 "rewards.insufficient_points" = "Pointi zisizotosha";
 "rewards.confirm_redeem" = "Pata %@ kwa %@!";
+"transfer.sign_transaction.title" = "Saini Muamala";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "รับ %@";
 "rewards.insufficient_points" = "คะแนนไม่เพียงพอ";
 "rewards.confirm_redeem" = "รับ %@ สำหรับ %@-";
+"transfer.sign_transaction.title" = "ลงนามในธุรกรรม";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Elde etmek %@";
 "rewards.insufficient_points" = "Yetersiz puan";
 "rewards.confirm_redeem" = "Elde etmek %@ için %@!";
+"transfer.sign_transaction.title" = "İmza İşlemi";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Отримати %@";
 "rewards.insufficient_points" = "Недостатньо балів";
 "rewards.confirm_redeem" = "Отримати %@ для %@!";
+"transfer.sign_transaction.title" = "Підписати транзакцію";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "حاصل کریں۔ %@";
 "rewards.insufficient_points" = "ناکافی پوائنٹس";
 "rewards.confirm_redeem" = "حاصل کریں۔ %@ کے لیے %@!";
+"transfer.sign_transaction.title" = "لین دین پر دستخط کریں۔";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "Lấy %@";
 "rewards.insufficient_points" = "Không đủ điểm";
 "rewards.confirm_redeem" = "Lấy %@ vì %@!";
+"transfer.sign_transaction.title" = "Ký giao dịch";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "得到 %@";
 "rewards.insufficient_points" = "分数不足";
 "rewards.confirm_redeem" = "得到 %@ 为了 %@！";
+"transfer.sign_transaction.title" = "签署交易";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -545,3 +545,4 @@
 "rewards.ways_spend.asset.title" = "得到 %@";
 "rewards.insufficient_points" = "分數不足";
 "rewards.confirm_redeem" = "得到 %@ 為了 %@！";
+"transfer.sign_transaction.title" = "簽署交易";

--- a/Packages/Primitives/Sources/TransactionMetadata.swift
+++ b/Packages/Primitives/Sources/TransactionMetadata.swift
@@ -73,4 +73,9 @@ public enum TransactionMetadata: Codable, Sendable {
         guard case .generic(let dict) = self else { return nil }
         return try? dict.mapTo(TransactionResourceTypeMetadata.self).resourceType
     }
+
+    public var walletConnectOutputAction: TransferDataOutputAction? {
+        guard case .generic(let dict) = self else { return nil }
+        return try? dict.mapTo(TransactionWalletConnectMetadata.self).outputAction
+    }
 }

--- a/Packages/Primitives/Sources/TransactionWalletConnectMetadata.swift
+++ b/Packages/Primitives/Sources/TransactionWalletConnectMetadata.swift
@@ -1,0 +1,11 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public struct TransactionWalletConnectMetadata: Codable, Sendable {
+    public let outputAction: TransferDataOutputAction
+
+    public init(outputAction: TransferDataOutputAction) {
+        self.outputAction = outputAction
+    }
+}

--- a/Packages/Primitives/Sources/TransferDataType.swift
+++ b/Packages/Primitives/Sources/TransferDataType.swift
@@ -89,8 +89,9 @@ public enum TransferDataType: Hashable, Equatable, Sendable {
             case .stake, .unstake, .redelegate, .rewards, .withdraw:
                 return .null
             }
-        case .generic,
-            .transfer,
+        case .generic(_, _, let extra):
+            return .generic(from: TransactionWalletConnectMetadata(outputAction: extra.outputAction))
+        case .transfer,
             .deposit,
             .withdrawal,
             .tokenApprove,

--- a/Packages/Primitives/TestKit/TransferDataExtra+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/TransferDataExtra+PrimitivesTestKit.swift
@@ -10,14 +10,16 @@ public extension TransferDataExtra {
         gasLimit: BigInt? = nil,
         gasPrice: GasPriceType? = nil,
         data: Data? = nil,
-        outputType: TransferDataOutputType = .encodedTransaction
+        outputType: TransferDataOutputType = .encodedTransaction,
+        outputAction: TransferDataOutputAction = .send
     ) -> TransferDataExtra {
         TransferDataExtra(
             to: to,
             gasLimit: gasLimit,
             gasPrice: gasPrice,
             data: data,
-            outputType: outputType
+            outputType: outputType,
+            outputAction: outputAction
         )
     }
 }


### PR DESCRIPTION
Introduces handling for distinguishing between 'sign' and 'send' actions in generic transfer flows. Updates view models, tests, and localization to reflect the new 'Sign Transaction' title. Adds TransactionWalletConnectMetadata for output action metadata and propagates this through TransferDataType and TransactionMetadata.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-06 at 17 56 49" src="https://github.com/user-attachments/assets/b7c2d58d-42c2-4f7f-b34c-a4b1b458197f" />
<img width="320"  alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-06 at 17 58 11" src="https://github.com/user-attachments/assets/2e470e57-f844-46a4-a781-17df44178ecb" />


Fix: https://github.com/gemwalletcom/gem-ios/issues/1398