### PR TITLE
Add perpetuals to search

### DIFF
--- a/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
@@ -65,7 +65,7 @@ public struct PerpetualsScene: View {
             }
 
             if model.showRecent {
-                RecentActivitySectionView(models: model.activityModels, headerPadding: .medium + .tiny) { assetModel in
+                RecentActivitySectionView(models: model.activityModels) { assetModel in
                     Button {
                         model.onSelectRecentPerpetual(asset: assetModel.asset)
                     } label: {
@@ -99,6 +99,7 @@ public struct PerpetualsScene: View {
                         Text(model.pinnedSectionTitle)
                     }
                 }
+                .listRowInsets(.assetListRowInsets)
             }
 
             if model.showMarkets {
@@ -112,6 +113,7 @@ public struct PerpetualsScene: View {
                 } header: {
                     Text(model.marketsSectionTitle)
                 }
+                .listRowInsets(.assetListRowInsets)
             }
         }
         .contentMargins([.top], .space12, for: .scrollContent)

--- a/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
@@ -76,18 +76,14 @@ public struct PerpetualsScene: View {
 
             if model.showPositions {
                 Section {
-                    ForEach(model.positions) { position in
-                        NavigationCustomLink(
-                            with: ListAssetItemView(
-                                model: PerpetualPositionItemViewModel(model: PerpetualPositionViewModel(position))
-                            ),
-                            action: { model.onSelectPerpetual(asset: position.perpetualData.asset) }
-                        )
-                        .listRowInsets(.assetListRowInsets)
-                    }
+                    PerpetualPositionsList(
+                        positions: model.positions,
+                        onSelect: model.onSelectPerpetual
+                    )
                 } header: {
                     Text(model.positionsSectionTitle)
                 }
+                .listRowInsets(.assetListRowInsets)
             }
 
             if model.showPinned {

--- a/Features/Perpetuals/Sources/Views/PerpetualPositionsList.swift
+++ b/Features/Perpetuals/Sources/Views/PerpetualPositionsList.swift
@@ -1,0 +1,42 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Primitives
+import PrimitivesComponents
+import Components
+
+public struct PerpetualPositionsList: View {
+    private let positions: [PerpetualPositionData]
+    private let onSelect: AssetAction
+
+    public init(
+        positions: [PerpetualPositionData],
+        onSelect: AssetAction = nil
+    ) {
+        self.positions = positions
+        self.onSelect = onSelect
+    }
+
+    public var body: some View {
+        ForEach(positions) { position in
+            if let onSelect {
+                NavigationCustomLink(
+                    with: listItem(for: position),
+                    action: { onSelect(position.perpetualData.asset) }
+                )
+            } else {
+                NavigationLink(value: Scenes.Perpetual(position.perpetualData)) {
+                    listItem(for: position)
+                }
+            }
+        }
+    }
+
+    private func listItem(for position: PerpetualPositionData) -> ListAssetItemView {
+        ListAssetItemView(
+            model: PerpetualPositionItemViewModel(
+                model: PerpetualPositionViewModel(position)
+            )
+        )
+    }
+}

--- a/Features/WalletTab/Sources/Scenes/WalletScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletScene.swift
@@ -37,6 +37,7 @@ public struct WalletScene: View {
                 } header: {
                     HeaderNavigationLinkView(title: model.perpetualsTitle, destination: Scenes.Perpetuals())
                 }
+                .listRowInsets(.assetListRowInsets)
             }
             
             if let banner = model.walletBannersModel.allBanners.first {
@@ -59,13 +60,13 @@ public struct WalletScene: View {
                         onCopyAddress: model.onCopyAddress,
                         showBalancePrivacy: $preferences.isHideBalanceEnabled
                     )
-                    .listRowInsets(.assetListRowInsets)
                 } header: {
                     HStack {
                         model.pinImage
                         Text(model.pinnedTitle)
                     }
                 }
+                .listRowInsets(.assetListRowInsets)
             }
 
             Section {
@@ -77,7 +78,6 @@ public struct WalletScene: View {
                     onCopyAddress: model.onCopyAddress,
                     showBalancePrivacy: $preferences.isHideBalanceEnabled
                 )
-                .listRowInsets(.assetListRowInsets)
             } header: {
                 if model.isLoadingAssets {
                     LoadingTextView(isAnimating: .constant(true))
@@ -94,7 +94,9 @@ public struct WalletScene: View {
                 .padding(.medium)
                 .frame(maxWidth: .infinity, alignment: .center)
             }
+            .listRowInsets(.assetListRowInsets)
         }
+//        .listSectionSpacing(.compact)
         .refreshable {
             model.fetch()
         }

--- a/Features/WalletTab/Sources/Scenes/WalletScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletScene.swift
@@ -96,7 +96,6 @@ public struct WalletScene: View {
             }
             .listRowInsets(.assetListRowInsets)
         }
-//        .listSectionSpacing(.compact)
         .refreshable {
             model.fetch()
         }

--- a/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
@@ -39,6 +39,7 @@ public struct WalletSearchScene: View {
         }
         .observeQuery(request: $model.request, value: $model.assets)
         .observeQuery(request: $model.recentActivityRequest, value: $model.recentActivities)
+        .observeQuery(request: $model.positionsRequest, value: $model.positions)
         .searchable(
             text: $model.searchModel.searchableQuery,
             isPresented: $model.isSearchPresented,
@@ -83,10 +84,10 @@ public struct WalletSearchScene: View {
 
             if model.showPerpetuals {
                 Section {
-                    PerpetualsPreviewView(wallet: model.wallet)
+                    PerpetualPositionsList(positions: model.positions)
                 } header: {
                     HeaderNavigationLinkView(
-                        title: model.perpetualsTitle,
+                        title: Localized.Perpetuals.title,
                         destination: Scenes.Perpetuals()
                     )
                 }

--- a/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
@@ -82,18 +82,6 @@ public struct WalletSearchScene: View {
                 }
             }
 
-            if model.showPerpetuals {
-                Section {
-                    PerpetualPositionsList(positions: model.positions)
-                } header: {
-                    HeaderNavigationLinkView(
-                        title: Localized.Perpetuals.title,
-                        destination: Scenes.Perpetuals()
-                    )
-                }
-                .listRowInsets(.assetListRowInsets)
-            }
-
             if model.showPinned {
                 Section(
                     content: { list(for: model.sections.pinned) },
@@ -104,6 +92,18 @@ public struct WalletSearchScene: View {
                         }
                     }
                 )
+                .listRowInsets(.assetListRowInsets)
+            }
+
+            if model.showPerpetuals {
+                Section {
+                    PerpetualPositionsList(positions: model.positions)
+                } header: {
+                    HeaderNavigationLinkView(
+                        title: Localized.Perpetuals.title,
+                        destination: Scenes.Perpetuals()
+                    )
+                }
                 .listRowInsets(.assetListRowInsets)
             }
 

--- a/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
@@ -8,6 +8,7 @@ import Style
 import Localization
 import PrimitivesComponents
 import AssetsService
+import Perpetuals
 
 public struct WalletSearchScene: View {
     @State private var model: WalletSearchSceneViewModel
@@ -80,7 +81,19 @@ public struct WalletSearchScene: View {
                 }
             }
 
-            if model.showPinnedSection {
+            if model.showPerpetuals {
+                Section {
+                    PerpetualsPreviewView(wallet: model.wallet)
+                } header: {
+                    HeaderNavigationLinkView(
+                        title: model.perpetualsTitle,
+                        destination: Scenes.Perpetuals()
+                    )
+                }
+                .listRowInsets(.assetListRowInsets)
+            }
+
+            if model.showPinned {
                 Section(
                     content: { list(for: model.sections.pinned) },
                     header: {
@@ -93,7 +106,7 @@ public struct WalletSearchScene: View {
                 .listRowInsets(.assetListRowInsets)
             }
 
-            if model.showAssetsSection {
+            if model.showAssets {
                 Section(
                     content: { list(for: model.sections.assets) },
                     header: {

--- a/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -87,7 +87,7 @@ public final class WalletSearchSceneViewModel: Sendable {
     var showRecent: Bool { searchModel.searchableQuery.isEmpty && recentActivities.isNotEmpty }
     var showPerpetuals: Bool { positions.isNotEmpty && preferences.isPerpetualEnabled && wallet.isMultiCoins }
     var showLoading: Bool { state.isLoading && showEmpty }
-    var showEmpty: Bool { !showAssets && !showPinned }
+    var showEmpty: Bool { !showRecent && !showPerpetuals && !showPinned && !showAssets }
     var showPinned: Bool { sections.pinned.isNotEmpty }
     var showAssets: Bool { sections.assets.isNotEmpty }
     var showAddToken: Bool { wallet.hasTokenSupport }

--- a/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -21,7 +21,7 @@ public final class WalletSearchSceneViewModel: Sendable {
     private let walletsService: WalletsService
     private let preferences: Preferences
 
-    private let wallet: Wallet
+    public let wallet: Wallet
     private let onDismissSearch: VoidAction
     private let onAddToken: VoidAction
 
@@ -70,50 +70,23 @@ public final class WalletSearchSceneViewModel: Sendable {
         )
     }
 
-    var sections: AssetsSections {
-        AssetsSections.from(assets)
-    }
-
     var pinnedImage: Image { Images.System.pin }
     var pinnedTitle: String { Localized.Common.pinned }
-
+    var perpetualsTitle: String { Localized.Perpetuals.title }
     var assetsTitle: String { Localized.Assets.title }
 
-    var showTags: Bool {
-        searchModel.searchableQuery.isEmpty
-    }
+    var sections: AssetsSections { AssetsSections.from(assets) }
+    var activityModels: [AssetViewModel] { recentActivities.map { AssetViewModel(asset: $0) } }
+    var currencyCode: String { preferences.currency }
 
-    var showRecent: Bool {
-        searchModel.searchableQuery.isEmpty && recentActivities.isNotEmpty
-    }
-
-    var activityModels: [AssetViewModel] {
-        recentActivities.map { AssetViewModel(asset: $0) }
-    }
-
-    var showLoading: Bool {
-        state.isLoading && showEmpty
-    }
-
-    var showEmpty: Bool {
-        !showAssetsSection && !showPinnedSection
-    }
-
-    var showPinnedSection: Bool {
-        sections.pinned.isNotEmpty
-    }
-
-    var showAssetsSection: Bool {
-        sections.assets.isNotEmpty
-    }
-
-    var currencyCode: String {
-        preferences.currency
-    }
-
-    var showAddToken: Bool {
-        wallet.hasTokenSupport
-    }
+    var showTags: Bool { searchModel.searchableQuery.isEmpty }
+    var showRecent: Bool { searchModel.searchableQuery.isEmpty && recentActivities.isNotEmpty }
+    var showPerpetuals: Bool { searchModel.searchableQuery.isEmpty && preferences.isPerpetualEnabled && wallet.isMultiCoins }
+    var showLoading: Bool { state.isLoading && showEmpty }
+    var showEmpty: Bool { !showAssets && !showPinned }
+    var showPinned: Bool { sections.pinned.isNotEmpty }
+    var showAssets: Bool { sections.assets.isNotEmpty }
+    var showAddToken: Bool { wallet.hasTokenSupport }
 }
 
 // MARK: - Actions
@@ -127,6 +100,7 @@ extension WalletSearchSceneViewModel {
     func onSearch(query: String) async {
         let query = query.trim()
         guard !query.isEmpty else { return }
+
         await searchAssets(
             query: query,
             priorityAssetsQuery: searchModel.priorityAssetsQuery,

--- a/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -29,8 +29,11 @@ public final class WalletSearchSceneViewModel: Sendable {
 
     var assets: [AssetData] = []
     var recentActivities: [Asset] = []
+    var positions: [PerpetualPositionData] = []
     var searchModel: AssetSearchViewModel
+
     var request: AssetsRequest
+    var positionsRequest: PerpetualPositionsRequest
     var recentActivityRequest: RecentActivityRequest
 
     var isPresentingToastMessage: ToastMessage? = nil
@@ -68,6 +71,7 @@ public final class WalletSearchSceneViewModel: Sendable {
             limit: 10,
             types: RecentActivityType.allCases.filter { $0 != .perpetual }
         )
+        self.positionsRequest = PerpetualPositionsRequest(walletId: wallet.walletId.id)
     }
 
     var pinnedImage: Image { Images.System.pin }
@@ -81,7 +85,7 @@ public final class WalletSearchSceneViewModel: Sendable {
 
     var showTags: Bool { searchModel.searchableQuery.isEmpty }
     var showRecent: Bool { searchModel.searchableQuery.isEmpty && recentActivities.isNotEmpty }
-    var showPerpetuals: Bool { searchModel.searchableQuery.isEmpty && preferences.isPerpetualEnabled && wallet.isMultiCoins }
+    var showPerpetuals: Bool { positions.isNotEmpty && preferences.isPerpetualEnabled && wallet.isMultiCoins }
     var showLoading: Bool { state.isLoading && showEmpty }
     var showEmpty: Bool { !showAssets && !showPinned }
     var showPinned: Bool { sections.pinned.isNotEmpty }
@@ -214,6 +218,7 @@ extension WalletSearchSceneViewModel {
             searchModel.tagsViewModel.selectedTag = AssetTagSelection.all
         }
         request.searchBy = searchModel.priorityAssetsQuery.or(.empty)
+        positionsRequest.searchQuery = searchModel.searchableQuery
         state = .loading
     }
 

--- a/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSearchSceneViewModel.swift
@@ -21,7 +21,7 @@ public final class WalletSearchSceneViewModel: Sendable {
     private let walletsService: WalletsService
     private let preferences: Preferences
 
-    public let wallet: Wallet
+    private let wallet: Wallet
     private let onDismissSearch: VoidAction
     private let onAddToken: VoidAction
 

--- a/Features/WalletTab/Sources/Views/PerpetualsPreviewView.swift
+++ b/Features/WalletTab/Sources/Views/PerpetualsPreviewView.swift
@@ -3,9 +3,6 @@
 import SwiftUI
 import Components
 import Primitives
-import Style
-import PrimitivesComponents
-import Formatters
 import Store
 import Perpetuals
 
@@ -29,17 +26,7 @@ public struct PerpetualsPreviewView: View {
                     )
                 }
             } else {
-                ForEach(viewModel.positions) { position in
-                    NavigationLink(
-                        value: Scenes.Perpetual(position.perpetualData)
-                    ) {
-                        ListAssetItemView(
-                            model: PerpetualPositionItemViewModel(
-                                model: PerpetualPositionViewModel(position)
-                            )
-                        )
-                    }
-                }
+                PerpetualPositionsList(positions: viewModel.positions)
             }
         }
         .observeQuery(request: $viewModel.positionsRequest, value: $viewModel.positions)


### PR DESCRIPTION
Introduces a Perpetuals section in WalletSearchScene when the user has a multi-coin wallet and perpetuals are enabled. Refactors WalletSearchSceneViewModel to expose new properties for perpetuals visibility and cleans up section visibility logic.
Updated section headers in Perps & Wallet & Wallet search for consistency

images:

<img width="340" height="2868" alt="image" src="https://github.com/user-attachments/assets/253ee097-b093-42e9-827f-5e3a9175e4c4" />
<img width="340" height="2868" alt="image" src="https://github.com/user-attachments/assets/bdc54b37-0518-4ec4-ad47-cd74cc83b446" />

closes #1442 