### PR TITLE
Cleanup

### DIFF
--- a/Features/Assets/Sources/ViewModels/AddTokenViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AddTokenViewModel.swift
@@ -70,25 +70,17 @@ public final class AddTokenViewModel {
 extension AddTokenViewModel {
     func fetch() async {
         guard let chain = input.chain, let address = input.address, !address.isEmpty else {
-            await MainActor.run { [self] in
-                self.state = .noData
-            }
+            state = .noData
             return
         }
 
-        await MainActor.run { [self] in
-            self.state = .loading
-        }
+        state = .loading
 
         do {
             let asset = try await service.getTokenData(chain: chain, tokenId: address)
-            await MainActor.run { [self] in
-                self.state = .data(AddAssetViewModel(asset: asset))
-            }
+            state = .data(AddAssetViewModel(asset: asset))
         } catch {
-            await MainActor.run { [self] in
-                self.state = .error(error)
-            }
+            state = .error(error)
         }
     }
 }

--- a/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/SelectAssetViewModel.swift
@@ -345,7 +345,7 @@ extension SelectAssetViewModel {
             )
             state = .data(assets)
         } catch {
-            await handle(error: error)
+            handle(error: error)
         }
     }
 
@@ -358,16 +358,14 @@ extension SelectAssetViewModel {
                 try await priceAlertService.delete(priceAlerts: [.default(for: assetId, currency: currency)])
             }
         } catch {
-            await handle(error: error)
+            handle(error: error)
         }
     }
 
-    private func handle(error: any Error) async {
-        await MainActor.run { [self] in
-            if !error.isCancelled {
-                self.state = .error(error)
-                debugLog("SelectAssetScene scene error: \(error)")
-            }
+    private func handle(error: any Error) {
+        if !error.isCancelled {
+            state = .error(error)
+            debugLog("SelectAssetScene scene error: \(error)")
         }
     }
 }

--- a/Features/Staking/Sources/ViewModels/StakeValidatorsViewModel.swift
+++ b/Features/Staking/Sources/ViewModels/StakeValidatorsViewModel.swift
@@ -51,7 +51,7 @@ public final class StakeValidatorsViewModel {
                     title: Localized.Stake.active,
                     validators: validators
                 ),
-            ].filter { $0.values.count > 0 }
+            ].filter { $0.values.isNotEmpty }
         case .unstake:
             return [
                 listSection(

--- a/Features/Transfer/Sources/Services/ConfirmService.swift
+++ b/Features/Transfer/Sources/Services/ConfirmService.swift
@@ -80,7 +80,7 @@ public struct ConfirmService: Sendable {
         do {
             try activityService.updateRecent(data: data, walletId: walletId)
         } catch {
-            print("Failed to update recent activity: \(error)")
+            debugLog("Failed to update recent activity: \(error)")
         }
     }
 

--- a/Packages/Primitives/Sources/Extensions/Wallet+Primitives.swift
+++ b/Packages/Primitives/Sources/Extensions/Wallet+Primitives.swift
@@ -23,7 +23,7 @@ public extension Wallet {
     }
 
     var hasTokenSupport: Bool {
-        accounts.map { $0.chain }.asSet().intersection(AssetConfiguration.supportedChainsWithTokens).count > 0
+        accounts.map { $0.chain }.asSet().intersection(AssetConfiguration.supportedChainsWithTokens).isNotEmpty
     }
 
     func account(for chain: Chain) throws -> Account {

--- a/Packages/Store/Sources/Models/AssetRecord.swift
+++ b/Packages/Store/Sources/Models/AssetRecord.swift
@@ -116,7 +116,7 @@ extension Asset {
 
 extension AssetRecord {
     func mapToAsset() -> Asset {
-        let tokenId = tokenId.count == 0 ? nil : tokenId
+        let tokenId = tokenId.isEmpty ? nil : tokenId
         return Asset(
             id: AssetId(chain: chain, tokenId: tokenId),
             name: name,

--- a/Packages/Store/Sources/Requests/NFTRequest.swift
+++ b/Packages/Store/Sources/Requests/NFTRequest.swift
@@ -44,6 +44,6 @@ public struct NFTRequest: ValueObservationQueryable {
         return try request
             .fetchAll(db)
             .map { $0.mapToNFTData() }
-            .filter { $0.assets.count > 0 }
+            .filter { $0.assets.isNotEmpty }
     }
 }


### PR DESCRIPTION
 - Remove redundant MainActor.run blocks in @MainActor ViewModels to prevent potential memory leaks
 - Replace print() with debugLog() for consistent logging
 - Simplify collection checks using isEmpty/isNotEmpty instead of .count comparisons