### PR TITLE
Add .id modifier to WalletScene list

### DIFF
--- a/Features/WalletTab/Sources/Scenes/WalletScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletScene.swift
@@ -39,7 +39,7 @@ public struct WalletScene: View {
                 }
                 .listRowInsets(.assetListRowInsets)
             }
-            
+
             if let banner = model.walletBannersModel.allBanners.first {
                 Section {
                     BannerView(
@@ -96,6 +96,7 @@ public struct WalletScene: View {
             }
             .listRowInsets(.assetListRowInsets)
         }
+        .id(model.wallet.id)
         .refreshable {
             model.fetch()
         }


### PR DESCRIPTION
Fix scroll position reset when switching wallets. ScrollViewReader.scrollTo() doesn't work with List section headers, so using .id(wallet.id) to recreate List on wallet change.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1566