### PR TITLE
Integrate asset enabling after reward redemption

### DIFF
--- a/Features/Settings/Sources/Settings/Scenes/RewardsScene.swift
+++ b/Features/Settings/Sources/Settings/Scenes/RewardsScene.swift
@@ -261,7 +261,10 @@ public struct RewardsScene: View {
             message: "",
             actions: [
                 AlertAction(title: Localized.Transfer.confirm, isDefaultAction: true) {
-                    Task { await model.redeem(option: option) }
+                    Task {
+                        await model.redeem(option: option)
+                        await model.fetch()
+                    }
                 },
                 .cancel(title: Localized.Common.cancel)
             ]

--- a/Features/Settings/Sources/Settings/Scenes/RewardsScene.swift
+++ b/Features/Settings/Sources/Settings/Scenes/RewardsScene.swift
@@ -49,7 +49,7 @@ public struct RewardsScene: View {
                 if model.isInfoEnabled {
                     infoSection(rewards: rewards)
                 }
-                if !rewards.redemptionOptions.isEmpty {
+                if rewards.redemptionOptions.isNotEmpty {
                     redemptionOptionsSection(options: rewards.redemptionOptions)
                 }
             case .noData:

--- a/Gem/Navigation/Settings/SettingsNavigationStack.swift
+++ b/Gem/Navigation/Settings/SettingsNavigationStack.swift
@@ -153,7 +153,6 @@ struct SettingsNavigationStack: View {
                     RewardsScene(
                         model: RewardsViewModel(
                             rewardsService: rewardsService,
-                            assetsService: assetsService,
                             assetsEnabler: walletsService,
                             wallet: wallet,
                             wallets: wallets,

--- a/Gem/Navigation/Settings/SettingsNavigationStack.swift
+++ b/Gem/Navigation/Settings/SettingsNavigationStack.swift
@@ -153,6 +153,8 @@ struct SettingsNavigationStack: View {
                     RewardsScene(
                         model: RewardsViewModel(
                             rewardsService: rewardsService,
+                            assetsService: assetsService,
+                            assetsEnabler: walletsService,
                             wallet: wallet,
                             wallets: wallets,
                             activateCode: scene.code,

--- a/Packages/FeatureServices/WalletsService/AssetsEnablerService.swift
+++ b/Packages/FeatureServices/WalletsService/AssetsEnablerService.swift
@@ -35,4 +35,13 @@ struct AssetsEnablerService: AssetsEnabler {
             debugLog("enableAssets error: \(error)")
         }
     }
+
+    func enableAssetId(walletId: WalletId, assetId: AssetId) async {
+        do {
+            let asset = try await assetsService.getOrFetchAsset(for: assetId)
+            await enableAssets(walletId: walletId, assetIds: [asset.id], enabled: true)
+        } catch {
+            debugLog("enableAssetId error: \(error)")
+        }
+    }
 }

--- a/Packages/FeatureServices/WalletsService/Protocols/AssetsEnabler.swift
+++ b/Packages/FeatureServices/WalletsService/Protocols/AssetsEnabler.swift
@@ -5,4 +5,5 @@ import Primitives
 
 public protocol AssetsEnabler: Sendable {
     func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool) async
+    func enableAssetId(walletId: WalletId, assetId: AssetId) async
 }

--- a/Packages/FeatureServices/WalletsService/Protocols/AssetsEnabler.swift
+++ b/Packages/FeatureServices/WalletsService/Protocols/AssetsEnabler.swift
@@ -3,6 +3,6 @@
 import Foundation
 import Primitives
 
-protocol AssetsEnabler: Sendable {
+public protocol AssetsEnabler: Sendable {
     func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool) async
 }

--- a/Packages/FeatureServices/WalletsService/WalletsService.swift
+++ b/Packages/FeatureServices/WalletsService/WalletsService.swift
@@ -105,6 +105,10 @@ extension WalletsService: AssetsEnabler {
     public func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool) async {
         await assetsEnabler.enableAssets(walletId: walletId, assetIds: assetIds, enabled: enabled)
     }
+
+    public func enableAssetId(walletId: WalletId, assetId: AssetId) async {
+        await assetsEnabler.enableAssetId(walletId: walletId, assetId: assetId)
+    }
 }
 
 // MARK: - PriceUpdater


### PR DESCRIPTION
Updated RewardsViewModel to enable assets in a wallet after successful reward redemption by injecting AssetsEnabler and AssetsService dependencies. Made AssetsEnabler protocol public, updated dependency lists, and adjusted related initializations and usages. Also replaced isEmpty check with isNotEmpty in RewardsScene.

Close: https://github.com/gemwalletcom/gem-ios/issues/1580