### PR TITLE
Refactor error handling in ChartScene and Perpetuals

### DIFF
--- a/Features/MarketInsight/Sources/Scenes/ChartScene.swift
+++ b/Features/MarketInsight/Sources/Scenes/ChartScene.swift
@@ -32,11 +32,7 @@ public struct ChartScene: View {
                         case .data(let model):
                             ChartView(model: model)
                         case .error(let error):
-                            StateEmptyView(
-                                title: model.errorTitle,
-                                description: model.description(for: error),
-                                image: Images.ErrorConent.error
-                            )
+                            StateEmptyView.error(error)
                         }
                     }
                     .frame(height: 320)

--- a/Features/MarketInsight/Sources/Scenes/ChartScene.swift
+++ b/Features/MarketInsight/Sources/Scenes/ChartScene.swift
@@ -32,7 +32,11 @@ public struct ChartScene: View {
                         case .data(let model):
                             ChartView(model: model)
                         case .error(let error):
-                            StateEmptyView.error(error)
+                            StateEmptyView(
+                                title: Localized.Errors.errorOccured,
+                                description: error.networkOrNoDataDescription,
+                                image: Images.ErrorConent.error
+                            )
                         }
                     }
                     .frame(height: 320)

--- a/Features/MarketInsight/Sources/ViewModels/ChartSceneViewModel.swift
+++ b/Features/MarketInsight/Sources/ViewModels/ChartSceneViewModel.swift
@@ -67,14 +67,6 @@ public final class ChartSceneViewModel {
         guard let priceData else { return nil }
         return AssetDetailsInfoViewModel(priceData: priceData)
     }
-    
-    func description(for error: Error) -> String {
-        if isNetworkError(error) {
-            error.localizedDescription
-        } else {
-            Localized.Errors.noDataAvailable
-        }
-    }
 }
 
 // MARK: - Business Logic

--- a/Features/Perpetuals/Sources/Scenes/PerpetualScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualScene.swift
@@ -24,7 +24,12 @@ public struct PerpetualScene: View {
                         case .noData: StateEmptyView.noData()
                         case .loading: LoadingView()
                         case .data(let data): CandlestickChartView(data: data, period: model.currentPeriod, lineModels: model.chartLineModels)
-                        case .error(let error): StateEmptyView.error(error)
+                        case .error(let error):
+                            StateEmptyView(
+                                title: Localized.Errors.errorOccured,
+                                description: error.networkOrNoDataDescription,
+                                image: Images.ErrorConent.error
+                            )
                         }
                     }
                     .frame(height: 320)

--- a/Packages/PrimitivesComponents/Sources/Extensions/Error+PrimitivesComponents.swift
+++ b/Packages/PrimitivesComponents/Sources/Extensions/Error+PrimitivesComponents.swift
@@ -1,0 +1,11 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import Localization
+
+public extension Error {
+    var networkOrNoDataDescription: String {
+        isNetworkError(self) ? localizedDescription : Localized.Errors.noDataAvailable
+    }
+}

--- a/Packages/PrimitivesComponents/Sources/Extensions/StateEmptyView+PrimitivesComponents.swift
+++ b/Packages/PrimitivesComponents/Sources/Extensions/StateEmptyView+PrimitivesComponents.swift
@@ -4,16 +4,17 @@ import SwiftUI
 import Components
 import Style
 import Localization
+import Primitives
 
 public extension StateEmptyView where Content == EmptyView {
     static func noData() -> StateEmptyView<EmptyView> {
         StateEmptyView(title: Localized.Common.notAvailable)
     }
-    
+
     static func error(_ error: Error) -> StateEmptyView<EmptyView> {
         StateEmptyView(
             title: Localized.Errors.errorOccured,
-            description: error.localizedDescription,
+            description: isNetworkError(error) ? error.localizedDescription : Localized.Errors.noDataAvailable,
             image: Images.ErrorConent.error
         )
     }

--- a/Packages/PrimitivesComponents/Sources/Extensions/StateEmptyView+PrimitivesComponents.swift
+++ b/Packages/PrimitivesComponents/Sources/Extensions/StateEmptyView+PrimitivesComponents.swift
@@ -4,7 +4,6 @@ import SwiftUI
 import Components
 import Style
 import Localization
-import Primitives
 
 public extension StateEmptyView where Content == EmptyView {
     static func noData() -> StateEmptyView<EmptyView> {
@@ -14,7 +13,7 @@ public extension StateEmptyView where Content == EmptyView {
     static func error(_ error: Error) -> StateEmptyView<EmptyView> {
         StateEmptyView(
             title: Localized.Errors.errorOccured,
-            description: isNetworkError(error) ? error.localizedDescription : Localized.Errors.noDataAvailable,
+            description: error.localizedDescription,
             image: Images.ErrorConent.error
         )
     }

--- a/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ErrorExtensionTests.swift
+++ b/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/ErrorExtensionTests.swift
@@ -1,0 +1,21 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Foundation
+
+@testable import PrimitivesComponents
+
+struct ErrorExtensionTests {
+
+    @Test
+    func networkErrorDescription() {
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        #expect(error.networkOrNoDataDescription == error.localizedDescription)
+    }
+
+    @Test
+    func nonNetworkErrorDescription() {
+        let error = NSError(domain: "TestDomain", code: 500)
+        #expect(error.networkOrNoDataDescription == "No data available")
+    }
+}


### PR DESCRIPTION
Simplifies error view construction by using StateEmptyView.error(error) directly in ChartScene. Moves network error description logic to StateEmptyView extension and removes redundant description(for:) method from ChartSceneViewModel.

Close: https://github.com/gemwalletcom/gem-ios/issues/1572