### PR TITLE
Show asset info in SetPriceAlertScene

### DIFF
--- a/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
+++ b/Features/PriceAlerts/Sources/Scenes/SetPriceAlertScene.swift
@@ -43,6 +43,10 @@ public struct SetPriceAlertScene: View {
                 }
             }
             .cleanListRow()
+
+            Section {
+                ListAssetItemView(model: model.assetItemViewModel(for: assetData))
+            }
         }
         .safeAreaView {
             StateButton(

--- a/Features/PriceAlerts/Sources/ViewModels/SetPriceAlertViewModel.swift
+++ b/Features/PriceAlerts/Sources/ViewModels/SetPriceAlertViewModel.swift
@@ -9,6 +9,7 @@ import PriceAlertService
 import Style
 import Localization
 import Formatters
+import PrimitivesComponents
 
 @MainActor
 @Observable
@@ -80,6 +81,18 @@ public final class SetPriceAlertViewModel {
             assetData: assetData,
             formatter: currencyFormatter,
             onTapActionButton: toggleAlertDirection
+        )
+    }
+
+    func assetItemViewModel(for assetData: AssetData) -> ListAssetItemViewModel {
+        ListAssetItemViewModel(
+            showBalancePrivacy: .constant(false),
+            assetDataModel: AssetDataViewModel(
+                assetData: assetData,
+                formatter: .abbreviated,
+                currencyCode: currencyFormatter.currencyCode
+            ),
+            type: .price
         )
     }
     


### PR DESCRIPTION
Added a section to SetPriceAlertScene displaying asset details using ListAssetItemView. Exposed currencyCode in SetPriceAlertViewModel to support this feature.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-19 at 12 02 48" src="https://github.com/user-attachments/assets/15bd1329-0f78-4f61-b75a-e5021ab18222" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-19 at 12 02 51" src="https://github.com/user-attachments/assets/cf8f6c7d-fef7-4d46-a79f-b098e00d00d6" />


Close: https://github.com/gemwalletcom/gem-ios/issues/1598