### PR TITLE
Increase walletBar existence timeout in UI test

### DIFF
--- a/GemUITestsAppTests/Extensions/XCUIApplication+GemUITestsAppTests.swift
+++ b/GemUITestsAppTests/Extensions/XCUIApplication+GemUITestsAppTests.swift
@@ -29,7 +29,7 @@ extension XCUIApplication {
     
     func tapWalletBar() {
         let walletBar = buttons["walletBar"].firstMatch
-        XCTAssertTrue(walletBar.waitForExistence(timeout: 2), "walletBar not found")
+        XCTAssertTrue(walletBar.waitForExistence(timeout: 5), "walletBar not found")
         walletBar.tap()
     }
     


### PR DESCRIPTION
Extended the waitForExistence timeout for the walletBar button from 2 to 5 seconds to improve test reliability in cases where the UI loads more slowly.