### PR TITLE
Use TimeInterval for toast duration parameters

### DIFF
--- a/Packages/Components/Sources/AlertToast/AlertToast.swift
+++ b/Packages/Components/Sources/AlertToast/AlertToast.swift
@@ -57,7 +57,7 @@ public struct AlertToastModifier: ViewModifier {
 
     @Binding var isPresenting: Bool
 
-    var duration: Double = 2
+    var duration: TimeInterval = 2
     var tapToDismiss: Bool = true
     var offsetY: CGFloat = 0
 
@@ -95,7 +95,7 @@ public struct AlertToastModifier: ViewModifier {
                 .animation(.spring(), value: isPresenting)
             )
             .task(id: isPresenting) {
-                if isPresenting && duration > 0 {
+                if isPresenting && duration > 0 && duration.isFinite {
                     try? await Task.sleep(for: .seconds(duration))
                     withAnimation(.spring()) {
                         isPresenting = false
@@ -108,7 +108,7 @@ public struct AlertToastModifier: ViewModifier {
 public extension View {
     func toast(
         isPresenting: Binding<Bool>,
-        duration: Double = 2,
+        duration: TimeInterval = 2,
         tapToDismiss: Bool = true,
         offsetY: CGFloat = 0,
         alert: @escaping () -> AlertToast,

--- a/Packages/Components/Sources/ViewModifiers/ToastModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/ToastModifier.swift
@@ -8,14 +8,14 @@ struct ToastModifier: ViewModifier {
     private var isPresenting: Binding<Bool>
 
     private let message: ToastMessage
-    private let duration: Double
+    private let duration: TimeInterval
     private let tapToDismiss: Bool
     private let offsetY: CGFloat
 
     init(
         isPresenting: Binding<Bool>,
         message: ToastMessage,
-        duration: Double,
+        duration: TimeInterval,
         tapToDismiss: Bool,
         offsetY: CGFloat
     ) {
@@ -40,11 +40,11 @@ struct ToastModifier: ViewModifier {
 
 private struct OptionalMessageToastModifier: ViewModifier {
     @Binding var message: ToastMessage?
-    private let duration: Double
+    private let duration: TimeInterval
     private let tapToDismiss: Bool
     private let offsetY: CGFloat
 
-    init(message: Binding<ToastMessage?>, duration: Double, tapToDismiss: Bool, offsetY: CGFloat) {
+    init(message: Binding<ToastMessage?>, duration: TimeInterval, tapToDismiss: Bool, offsetY: CGFloat) {
         _message = message
         self.duration = duration
         self.tapToDismiss = tapToDismiss
@@ -77,7 +77,7 @@ public extension View {
     func toast(
         isPresenting: Binding<Bool>,
         message: ToastMessage,
-        duration: Double = Self.toastDuration,
+        duration: TimeInterval = Self.toastDuration,
         tapToDismiss: Bool = true,
         offsetY: CGFloat = 0
     ) -> some View {
@@ -92,7 +92,7 @@ public extension View {
 
     func toast(
         message: Binding<ToastMessage?>,
-        duration: Double = Self.toastDuration,
+        duration: TimeInterval = Self.toastDuration,
         tapToDismiss: Bool = true,
         offsetY: CGFloat = 0
     ) -> some View {


### PR DESCRIPTION
Replaces Double with TimeInterval for toast duration parameters in AlertToast and ToastModifier. This improves code clarity and ensures type correctness for time-based values.