### PR TITLE
Add new rewards notification types and localizations

### DIFF
--- a/Features/InAppNotifications/Sources/ViewModels/InAppNotificationListItemViewModel.swift
+++ b/Features/InAppNotifications/Sources/ViewModels/InAppNotificationListItemViewModel.swift
@@ -33,6 +33,9 @@ public struct InAppNotificationListItemViewModel: Identifiable, Sendable {
         case .referralJoined: Localized.Notifications.Inapp.Referral.Joined.title
         case .rewardsEnabled: Localized.Notifications.Inapp.Rewards.Enabled.title
         case .rewardsCodeDisabled: Localized.Notifications.Inapp.Rewards.Disabled.title
+        case .rewardsRedeemed: Localized.Notifications.Inapp.Rewards.Redeemed.title
+        case .rewardsCreateUsername: Localized.Rewards.CreateReferralCode.title
+        case .rewardsInvite: Localized.Rewards.InviteFriends.title
         }
     }
 
@@ -41,6 +44,9 @@ public struct InAppNotificationListItemViewModel: Identifiable, Sendable {
         case .referralJoined: metadata.map { Localized.Notifications.Inapp.Referral.Joined.subtitle($0.username) }
         case .rewardsEnabled: Localized.Notifications.Inapp.Rewards.Enabled.subtitle
         case .rewardsCodeDisabled: Localized.Notifications.Inapp.Rewards.Disabled.subtitle
+        case .rewardsRedeemed: Localized.Notifications.Inapp.Rewards.Redeemed.subtitle
+        case .rewardsCreateUsername: Localized.Notifications.Inapp.Rewards.CreateUsername.subtitle
+        case .rewardsInvite: Localized.Notifications.Inapp.Rewards.Invite.subtitle
         }
     }
 
@@ -58,6 +64,9 @@ public struct InAppNotificationListItemViewModel: Identifiable, Sendable {
         case .referralJoined: Emoji.party
         case .rewardsEnabled: Emoji.WalletAvatar.gift.rawValue
         case .rewardsCodeDisabled: Emoji.WalletAvatar.warning.rawValue
+        case .rewardsRedeemed: Emoji.WalletAvatar.check.rawValue
+        case .rewardsCreateUsername: Emoji.WalletAvatar.star.rawValue
+        case .rewardsInvite: Emoji.WalletAvatar.magic.rawValue
         }
         return AssetImage(type: emoji)
     }

--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -775,6 +775,10 @@ public enum Localized {
         }
       }
       public enum Rewards {
+        public enum CreateUsername {
+          /// Set up your username to earn rewards
+          public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.create_username.subtitle", fallback: "Set up your username to earn rewards")
+        }
         public enum Disabled {
           /// Your referral code has been deactivated
           public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.disabled.subtitle", fallback: "Your referral code has been deactivated")
@@ -786,6 +790,16 @@ public enum Localized {
           public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.enabled.subtitle", fallback: "Start earning points by inviting friends")
           /// Rewards Enabled
           public static let title = Localized.tr("Localizable", "notifications.inapp.rewards.enabled.title", fallback: "Rewards Enabled")
+        }
+        public enum Invite {
+          /// Invite friends and earn rewards together
+          public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.invite.subtitle", fallback: "Invite friends and earn rewards together")
+        }
+        public enum Redeemed {
+          /// Your rewards have been redeemed successfully
+          public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.redeemed.subtitle", fallback: "Your rewards have been redeemed successfully")
+          /// Rewards Redeemed
+          public static let title = Localized.tr("Localizable", "notifications.inapp.rewards.redeemed.title", fallback: "Rewards Redeemed")
         }
       }
       public enum State {

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "تم تعطيل رمز الإحالة";
 "notifications.inapp.rewards.disabled.subtitle" = "تم تعطيل رمز الإحالة الخاص بك";
 "rewards.nickname" = "كنية";
+"notifications.inapp.rewards.redeemed.title" = "تم استرداد المكافآت";
+"notifications.inapp.rewards.redeemed.subtitle" = "تم استرداد مكافآتك بنجاح";
+"notifications.inapp.rewards.create_username.subtitle" = "قم بإعداد اسم المستخدم الخاص بك لكسب المكافآت";
+"notifications.inapp.rewards.invite.subtitle" = "ادعُ أصدقاءك واربحوا المكافآت معًا";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "রেফারেল কোড বন্ধ করা আছে";
 "notifications.inapp.rewards.disabled.subtitle" = "আপনার রেফারেল কোডটি নিষ্ক্রিয় করা হয়েছে।";
 "rewards.nickname" = "ডাকনাম";
+"notifications.inapp.rewards.redeemed.title" = "পুরস্কার রিডিম করা হয়েছে";
+"notifications.inapp.rewards.redeemed.subtitle" = "আপনার পুরষ্কারগুলি সফলভাবে রিডিম করা হয়েছে।";
+"notifications.inapp.rewards.create_username.subtitle" = "পুরস্কার জিততে আপনার ব্যবহারকারীর নাম সেট আপ করুন";
+"notifications.inapp.rewards.invite.subtitle" = "বন্ধুদের আমন্ত্রণ জানান এবং একসাথে পুরস্কার জিতুন";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Doporučovací kód deaktivován";
 "notifications.inapp.rewards.disabled.subtitle" = "Váš doporučovací kód byl deaktivován";
 "rewards.nickname" = "Přezdívka";
+"notifications.inapp.rewards.redeemed.title" = "Odměny obdrženy";
+"notifications.inapp.rewards.redeemed.subtitle" = "Vaše odměny byly úspěšně uplatněny";
+"notifications.inapp.rewards.create_username.subtitle" = "Nastavte si uživatelské jméno a získejte odměny";
+"notifications.inapp.rewards.invite.subtitle" = "Pozvěte přátele a společně sbírejte odměny";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Henvisningskode deaktiveret";
 "notifications.inapp.rewards.disabled.subtitle" = "Din henvisningskode er blevet deaktiveret";
 "rewards.nickname" = "Kælenavn";
+"notifications.inapp.rewards.redeemed.title" = "Indløste belønninger";
+"notifications.inapp.rewards.redeemed.subtitle" = "Dine belønninger er blevet indløst";
+"notifications.inapp.rewards.create_username.subtitle" = "Opret dit brugernavn for at optjene belønninger";
+"notifications.inapp.rewards.invite.subtitle" = "Inviter venner og optjen belønninger sammen";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Empfehlungscode deaktiviert";
 "notifications.inapp.rewards.disabled.subtitle" = "Ihr Empfehlungscode wurde deaktiviert";
 "rewards.nickname" = "Spitzname";
+"notifications.inapp.rewards.redeemed.title" = "Eingelöste Prämien";
+"notifications.inapp.rewards.redeemed.subtitle" = "Ihre Prämien wurden erfolgreich eingelöst.";
+"notifications.inapp.rewards.create_username.subtitle" = "Richten Sie Ihren Benutzernamen ein, um Prämien zu erhalten.";
+"notifications.inapp.rewards.invite.subtitle" = "Lade Freunde ein und verdient gemeinsam Prämien.";

--- a/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Referral Code Disabled";
 "notifications.inapp.rewards.disabled.subtitle" = "Your referral code has been deactivated";
 "rewards.nickname" = "Nickname";
+"notifications.inapp.rewards.redeemed.title" = "Rewards Redeemed";
+"notifications.inapp.rewards.redeemed.subtitle" = "Your rewards have been redeemed successfully";
+"notifications.inapp.rewards.create_username.subtitle" = "Set up your username to earn rewards";
+"notifications.inapp.rewards.invite.subtitle" = "Invite friends and earn rewards together";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Código de referencia deshabilitado";
 "notifications.inapp.rewards.disabled.subtitle" = "Su código de referencia ha sido desactivado";
 "rewards.nickname" = "Apodo";
+"notifications.inapp.rewards.redeemed.title" = "Recompensas canjeadas";
+"notifications.inapp.rewards.redeemed.subtitle" = "Tus recompensas se han canjeado con éxito";
+"notifications.inapp.rewards.create_username.subtitle" = "Configura tu nombre de usuario para ganar recompensas";
+"notifications.inapp.rewards.invite.subtitle" = "Invita a tus amigos y gana recompensas juntos";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "کد ارجاع غیرفعال است";
 "notifications.inapp.rewards.disabled.subtitle" = "کد معرف شما غیرفعال شده است";
 "rewards.nickname" = "نام مستعار";
+"notifications.inapp.rewards.redeemed.title" = "جوایز بازخرید شده";
+"notifications.inapp.rewards.redeemed.subtitle" = "جوایز شما با موفقیت دریافت شد";
+"notifications.inapp.rewards.create_username.subtitle" = "نام کاربری خود را برای کسب جوایز تنظیم کنید";
+"notifications.inapp.rewards.invite.subtitle" = "دوستان را دعوت کنید و با هم پاداش کسب کنید";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Hindi Pinagana ang Referral Code";
 "notifications.inapp.rewards.disabled.subtitle" = "Na-deactivate na ang iyong referral code";
 "rewards.nickname" = "Palayaw";
+"notifications.inapp.rewards.redeemed.title" = "Mga Gantimpala na Natubos";
+"notifications.inapp.rewards.redeemed.subtitle" = "Matagumpay na na-redeem ang iyong mga reward";
+"notifications.inapp.rewards.create_username.subtitle" = "I-set up ang iyong username para makakuha ng mga reward";
+"notifications.inapp.rewards.invite.subtitle" = "Mag-imbita ng mga kaibigan at kumita ng mga gantimpala nang sama-sama";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Code de parrainage désactivé";
 "notifications.inapp.rewards.disabled.subtitle" = "Votre code de parrainage a été désactivé.";
 "rewards.nickname" = "Surnom";
+"notifications.inapp.rewards.redeemed.title" = "Récompenses reçues";
+"notifications.inapp.rewards.redeemed.subtitle" = "Vos récompenses ont été utilisées avec succès.";
+"notifications.inapp.rewards.create_username.subtitle" = "Configurez votre nom d'utilisateur pour gagner des récompenses";
+"notifications.inapp.rewards.invite.subtitle" = "Invitez vos amis et gagnez des récompenses ensemble.";

--- a/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "An kashe Lambar Tukuitawa";
 "notifications.inapp.rewards.disabled.subtitle" = "An kashe lambar tura ku";
 "rewards.nickname" = "Laƙabi";
+"notifications.inapp.rewards.redeemed.title" = "Lada da aka fanshe";
+"notifications.inapp.rewards.redeemed.subtitle" = "An yi nasarar fansar ladaran ku";
+"notifications.inapp.rewards.create_username.subtitle" = "Saita sunan mai amfani don samun lada";
+"notifications.inapp.rewards.invite.subtitle" = "Gayyaci abokai kuma ku sami lada tare";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "קוד הפניה מושבת";
 "notifications.inapp.rewards.disabled.subtitle" = "קוד ההפניה שלך הושבת";
 "rewards.nickname" = "כינוי";
+"notifications.inapp.rewards.redeemed.title" = "תגמולים שנפדו";
+"notifications.inapp.rewards.redeemed.subtitle" = "התגמולים שלך מומשו בהצלחה";
+"notifications.inapp.rewards.create_username.subtitle" = "הגדר את שם המשתמש שלך כדי לצבור פרסים";
+"notifications.inapp.rewards.invite.subtitle" = "הזמינו חברים וצברו יחד פרסים";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "रेफरल कोड निष्क्रिय";
 "notifications.inapp.rewards.disabled.subtitle" = "आपका रेफरल कोड निष्क्रिय कर दिया गया है।";
 "rewards.nickname" = "उपनाम";
+"notifications.inapp.rewards.redeemed.title" = "भुनाए गए पुरस्कार";
+"notifications.inapp.rewards.redeemed.subtitle" = "आपके पुरस्कार सफलतापूर्वक भुना लिए गए हैं।";
+"notifications.inapp.rewards.create_username.subtitle" = "पुरस्कार अर्जित करने के लिए अपना उपयोगकर्ता नाम सेट करें";
+"notifications.inapp.rewards.invite.subtitle" = "दोस्तों को आमंत्रित करें और साथ मिलकर पुरस्कार जीतें";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Kode Referensi Dinonaktifkan";
 "notifications.inapp.rewards.disabled.subtitle" = "Kode referensi Anda telah dinonaktifkan";
 "rewards.nickname" = "Nama panggilan";
+"notifications.inapp.rewards.redeemed.title" = "Hadiah Ditukarkan";
+"notifications.inapp.rewards.redeemed.subtitle" = "Hadiah Anda telah berhasil ditukarkan.";
+"notifications.inapp.rewards.create_username.subtitle" = "Buat nama pengguna Anda untuk mendapatkan hadiah.";
+"notifications.inapp.rewards.invite.subtitle" = "Ajak teman dan dapatkan hadiah bersama.";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Codice di riferimento disabilitato";
 "notifications.inapp.rewards.disabled.subtitle" = "Il tuo codice di riferimento è stato disattivato";
 "rewards.nickname" = "Soprannome";
+"notifications.inapp.rewards.redeemed.title" = "Premi riscattati";
+"notifications.inapp.rewards.redeemed.subtitle" = "I tuoi premi sono stati riscattati con successo";
+"notifications.inapp.rewards.create_username.subtitle" = "Imposta il tuo nome utente per guadagnare premi";
+"notifications.inapp.rewards.invite.subtitle" = "Invita gli amici e guadagnate premi insieme";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "紹介コードが無効です";
 "notifications.inapp.rewards.disabled.subtitle" = "紹介コードは無効になりました";
 "rewards.nickname" = "ニックネーム";
+"notifications.inapp.rewards.redeemed.title" = "交換された報酬";
+"notifications.inapp.rewards.redeemed.subtitle" = "報酬は正常に引き換えられました";
+"notifications.inapp.rewards.create_username.subtitle" = "ユーザー名を設定して報酬を獲得しましょう";
+"notifications.inapp.rewards.invite.subtitle" = "友達を招待して一緒に報酬を獲得しましょう";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "추천 코드 사용 안 함";
 "notifications.inapp.rewards.disabled.subtitle" = "회원님의 추천 코드가 비활성화되었습니다.";
 "rewards.nickname" = "별명";
+"notifications.inapp.rewards.redeemed.title" = "리워드 수령됨";
+"notifications.inapp.rewards.redeemed.subtitle" = "보상이 성공적으로 사용되었습니다.";
+"notifications.inapp.rewards.create_username.subtitle" = "보상을 받으려면 사용자 이름을 설정하세요.";
+"notifications.inapp.rewards.invite.subtitle" = "친구를 초대하고 함께 보상을 받으세요";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Kod Rujukan Dilumpuhkan";
 "notifications.inapp.rewards.disabled.subtitle" = "Kod rujukan anda telah dinyahaktifkan";
 "rewards.nickname" = "Nama panggilan";
+"notifications.inapp.rewards.redeemed.title" = "Ganjaran Ditebus";
+"notifications.inapp.rewards.redeemed.subtitle" = "Ganjaran anda telah berjaya ditebus";
+"notifications.inapp.rewards.create_username.subtitle" = "Sediakan nama pengguna anda untuk mendapatkan ganjaran";
+"notifications.inapp.rewards.invite.subtitle" = "Jemput rakan-rakan dan dapatkan ganjaran bersama-sama";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Verwijzingscode uitgeschakeld";
 "notifications.inapp.rewards.disabled.subtitle" = "Je verwijzingscode is gedeactiveerd.";
 "rewards.nickname" = "Bijnaam";
+"notifications.inapp.rewards.redeemed.title" = "Ingewisselde beloningen";
+"notifications.inapp.rewards.redeemed.subtitle" = "Uw beloningen zijn succesvol verzilverd.";
+"notifications.inapp.rewards.create_username.subtitle" = "Stel je gebruikersnaam in om beloningen te verdienen.";
+"notifications.inapp.rewards.invite.subtitle" = "Nodig vrienden uit en verdien samen beloningen.";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Kod polecający wyłączony";
 "notifications.inapp.rewards.disabled.subtitle" = "Twój kod polecający został dezaktywowany";
 "rewards.nickname" = "Przydomek";
+"notifications.inapp.rewards.redeemed.title" = "Nagrody zrealizowane";
+"notifications.inapp.rewards.redeemed.subtitle" = "Twoje nagrody zostały pomyślnie odebrane";
+"notifications.inapp.rewards.create_username.subtitle" = "Ustaw swoją nazwę użytkownika, aby zdobywać nagrody";
+"notifications.inapp.rewards.invite.subtitle" = "Zaproś znajomych i zdobywajcie nagrody razem";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Código de indicação desativado";
 "notifications.inapp.rewards.disabled.subtitle" = "Seu código de indicação foi desativado.";
 "rewards.nickname" = "Apelido";
+"notifications.inapp.rewards.redeemed.title" = "Recompensas Resgatadas";
+"notifications.inapp.rewards.redeemed.subtitle" = "Suas recompensas foram resgatadas com sucesso.";
+"notifications.inapp.rewards.create_username.subtitle" = "Configure seu nome de usuário para ganhar recompensas.";
+"notifications.inapp.rewards.invite.subtitle" = "Convide amigos e ganhem recompensas juntos.";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Cod de recomandare dezactivat";
 "notifications.inapp.rewards.disabled.subtitle" = "Codul tău de recomandare a fost dezactivat";
 "rewards.nickname" = "Poreclă";
+"notifications.inapp.rewards.redeemed.title" = "Recompense răscumpărate";
+"notifications.inapp.rewards.redeemed.subtitle" = "Recompensele tale au fost valorificate cu succes";
+"notifications.inapp.rewards.create_username.subtitle" = "Configurați-vă numele de utilizator pentru a câștiga recompense";
+"notifications.inapp.rewards.invite.subtitle" = "Invită-ți prietenii și câștigă recompense împreună";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Реферальный код отключен";
 "notifications.inapp.rewards.disabled.subtitle" = "Ваш реферальный код деактивирован.";
 "rewards.nickname" = "Никнейм";
+"notifications.inapp.rewards.redeemed.title" = "Награда получена";
+"notifications.inapp.rewards.redeemed.subtitle" = "Награда успешно получена.";
+"notifications.inapp.rewards.create_username.subtitle" = "Зарегистрируйте имя пользователя, чтобы получать награды.";
+"notifications.inapp.rewards.invite.subtitle" = "Приглашайте друзей и зарабатывайте награды вместе.";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Nambari ya Rufaa Imezimwa";
 "notifications.inapp.rewards.disabled.subtitle" = "Nambari yako ya rufaa imezimwa";
 "rewards.nickname" = "Jina la utani";
+"notifications.inapp.rewards.redeemed.title" = "Zawadi Zilizokombolewa";
+"notifications.inapp.rewards.redeemed.subtitle" = "Zawadi zako zimetumika kwa mafanikio";
+"notifications.inapp.rewards.create_username.subtitle" = "Weka jina lako la mtumiaji ili upate zawadi";
+"notifications.inapp.rewards.invite.subtitle" = "Alika marafiki na upate zawadi pamoja";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "รหัสอ้างอิงถูกปิดใช้งาน";
 "notifications.inapp.rewards.disabled.subtitle" = "รหัสแนะนำของคุณถูกปิดใช้งานแล้ว";
 "rewards.nickname" = "ชื่อเล่น";
+"notifications.inapp.rewards.redeemed.title" = "รางวัลที่แลกรับ";
+"notifications.inapp.rewards.redeemed.subtitle" = "รางวัลของคุณได้รับการแลกรับเรียบร้อยแล้ว";
+"notifications.inapp.rewards.create_username.subtitle" = "ตั้งชื่อผู้ใช้ของคุณเพื่อรับรางวัล";
+"notifications.inapp.rewards.invite.subtitle" = "ชวนเพื่อนมารับรางวัลด้วยกัน";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Yönlendirme Kodu Devre Dışı Bırakıldı";
 "notifications.inapp.rewards.disabled.subtitle" = "Yönlendirme kodunuz devre dışı bırakıldı.";
 "rewards.nickname" = "Takma ad";
+"notifications.inapp.rewards.redeemed.title" = "Ödüller Alındı";
+"notifications.inapp.rewards.redeemed.subtitle" = "Ödülleriniz başarıyla kullanıldı.";
+"notifications.inapp.rewards.create_username.subtitle" = "Ödüller kazanmak için kullanıcı adınızı oluşturun.";
+"notifications.inapp.rewards.invite.subtitle" = "Arkadaşlarınızı davet edin ve birlikte ödüller kazanın.";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Реферальний код вимкнено";
 "notifications.inapp.rewards.disabled.subtitle" = "Ваш реферальний код деактивовано";
 "rewards.nickname" = "Прізвисько";
+"notifications.inapp.rewards.redeemed.title" = "Винагороду отримано";
+"notifications.inapp.rewards.redeemed.subtitle" = "Ваші винагороди успішно отримано";
+"notifications.inapp.rewards.create_username.subtitle" = "Налаштуйте своє ім'я користувача, щоб отримувати винагороди";
+"notifications.inapp.rewards.invite.subtitle" = "Запрошуйте друзів та отримуйте винагороди разом";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "ریفرل کوڈ غیر فعال ہے۔";
 "notifications.inapp.rewards.disabled.subtitle" = "آپ کا ریفرل کوڈ غیر فعال کر دیا گیا ہے۔";
 "rewards.nickname" = "عرفی نام";
+"notifications.inapp.rewards.redeemed.title" = "انعامات بھنائے گئے۔";
+"notifications.inapp.rewards.redeemed.subtitle" = "آپ کے انعامات کو کامیابی کے ساتھ بھنایا گیا ہے۔";
+"notifications.inapp.rewards.create_username.subtitle" = "انعامات حاصل کرنے کے لیے اپنا صارف نام ترتیب دیں۔";
+"notifications.inapp.rewards.invite.subtitle" = "دوستوں کو مدعو کریں اور مل کر انعامات کمائیں۔";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "Mã giới thiệu đã bị vô hiệu hóa";
 "notifications.inapp.rewards.disabled.subtitle" = "Mã giới thiệu của bạn đã bị vô hiệu hóa.";
 "rewards.nickname" = "Biệt danh";
+"notifications.inapp.rewards.redeemed.title" = "Phần thưởng đã quy đổi";
+"notifications.inapp.rewards.redeemed.subtitle" = "Phần thưởng của bạn đã được quy đổi thành công.";
+"notifications.inapp.rewards.create_username.subtitle" = "Thiết lập tên người dùng của bạn để nhận phần thưởng";
+"notifications.inapp.rewards.invite.subtitle" = "Mời bạn bè và cùng nhau nhận phần thưởng.";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "推荐码已禁用";
 "notifications.inapp.rewards.disabled.subtitle" = "您的推荐码已停用。";
 "rewards.nickname" = "昵称";
+"notifications.inapp.rewards.redeemed.title" = "已兑换奖励";
+"notifications.inapp.rewards.redeemed.subtitle" = "您的奖励已成功兑换";
+"notifications.inapp.rewards.create_username.subtitle" = "设置您的用户名即可获得奖励";
+"notifications.inapp.rewards.invite.subtitle" = "邀请好友，一起赢取奖励";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -561,3 +561,7 @@
 "notifications.inapp.rewards.disabled.title" = "推薦碼已停用";
 "notifications.inapp.rewards.disabled.subtitle" = "您的推薦碼已停用。";
 "rewards.nickname" = "暱稱";
+"notifications.inapp.rewards.redeemed.title" = "已兌換獎勵";
+"notifications.inapp.rewards.redeemed.subtitle" = "您的獎勵已成功兌換";
+"notifications.inapp.rewards.create_username.subtitle" = "設定您的用戶名即可獲得獎勵";
+"notifications.inapp.rewards.invite.subtitle" = "邀請好友，一起贏取獎勵";

--- a/Packages/Primitives/Sources/NotificationType.swift
+++ b/Packages/Primitives/Sources/NotificationType.swift
@@ -8,4 +8,7 @@ public enum NotificationType: String, Codable, Equatable, Sendable {
 	case referralJoined
 	case rewardsEnabled
 	case rewardsCodeDisabled
+	case rewardsRedeemed
+	case rewardsCreateUsername
+	case rewardsInvite
 }

--- a/Packages/Primitives/Sources/Rewards.swift
+++ b/Packages/Primitives/Sources/Rewards.swift
@@ -149,6 +149,7 @@ public enum RewardEventType: String, Codable, CaseIterable, Equatable, Hashable,
 	case inviteExisting
 	case joined
 	case disabled
+	case redeemed
 }
 
 public struct RewardEvent: Codable, Equatable, Hashable, Sendable {


### PR DESCRIPTION
Introduces new notification types for rewards: redeemed, create username, and invite. Updates view models, localization keys, and translations in all supported languages to support these new notification events.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-20 at 12 43 28" src="https://github.com/user-attachments/assets/614856fc-13bc-485d-a364-b7fa376bf9ed" />
