### PR TITLE
Add warning for custom nodes in AddNodeScene

### DIFF
--- a/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
+++ b/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
@@ -102,6 +102,13 @@ extension AddNodeScene {
                 ListItemView(title: result.latestBlockTitle, subtitle: result.latestBlockValue)
                 ListItemView(title: result.latencyTitle, subtitle: result.latecyValue)
             }
+            warningSection
+        }
+    }
+
+    private var warningSection: some View {
+        Section {
+            ListItemView(model: model.warningModel)
         }
     }
 }
@@ -114,6 +121,7 @@ extension AddNodeScene {
     }
 
     private func onSubmitUrl() {
+        focusedField = nil
         Task {
             await model.fetch()
         }
@@ -122,6 +130,7 @@ extension AddNodeScene {
     private func onSelectPaste() {
         guard let content = UIPasteboard.general.string else { return }
         model.setInput(content.trim())
+        focusedField = nil
     }
 
     private func onSelectImport() {
@@ -135,6 +144,7 @@ extension AddNodeScene {
 
     private func onHandleScan(_ result: String) {
         model.setInput(result)
+        focusedField = nil
     }
 
     private func onSelectScan() {

--- a/Features/Settings/Sources/ChainSettings/ViewModels/AddNodeSceneViewModel.swift
+++ b/Features/Settings/Sources/ChainSettings/ViewModels/AddNodeSceneViewModel.swift
@@ -9,6 +9,7 @@ import ChainService
 import NodeService
 import PrimitivesComponents
 import Validators
+import Style
 
 @MainActor
 @Observable
@@ -37,6 +38,21 @@ public final class AddNodeSceneViewModel {
 
     public var errorTitle: String { Localized.Errors.errorOccured }
     public var chainModel: ChainViewModel { ChainViewModel(chain: chain) }
+
+    public var warningModel: ListItemModel {
+        ListItemModel(
+            title: Localized.Asset.Verification.warningTitle,
+            titleStyle: .headline,
+            titleExtra: Localized.Nodes.ImportNode.warningMessage,
+            titleStyleExtra: .bodySecondary,
+            imageStyle: ListItemImageStyle(
+                assetImage: AssetImage(type: Emoji.WalletAvatar.warning.rawValue),
+                imageSize: .image.semiMedium,
+                alignment: .top,
+                cornerRadiusType: .none
+            )
+        )
+    }
 }
 
 // MARK: - Business Logic

--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -760,6 +760,8 @@ public enum Localized {
       public static let latestBlock = Localized.tr("Localizable", "nodes.import_node.latest_block", fallback: "Latest Block")
       /// Add node
       public static let title = Localized.tr("Localizable", "nodes.import_node.title", fallback: "Add node")
+      /// Custom nodes can be malicious and may expose your transaction data or provide false information.
+      public static let warningMessage = Localized.tr("Localizable", "nodes.import_node.warning_message", fallback: "Custom nodes can be malicious and may expose your transaction data or provide false information.")
     }
   }
   public enum Notifications {
@@ -775,6 +777,10 @@ public enum Localized {
         }
       }
       public enum Rewards {
+        public enum CreateUsername {
+          /// Set up your username to earn rewards
+          public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.create_username.subtitle", fallback: "Set up your username to earn rewards")
+        }
         public enum Disabled {
           /// Your referral code has been deactivated
           public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.disabled.subtitle", fallback: "Your referral code has been deactivated")
@@ -786,6 +792,16 @@ public enum Localized {
           public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.enabled.subtitle", fallback: "Start earning points by inviting friends")
           /// Rewards Enabled
           public static let title = Localized.tr("Localizable", "notifications.inapp.rewards.enabled.title", fallback: "Rewards Enabled")
+        }
+        public enum Invite {
+          /// Invite friends and earn rewards together
+          public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.invite.subtitle", fallback: "Invite friends and earn rewards together")
+        }
+        public enum Redeemed {
+          /// Your rewards have been redeemed successfully
+          public static let subtitle = Localized.tr("Localizable", "notifications.inapp.rewards.redeemed.subtitle", fallback: "Your rewards have been redeemed successfully")
+          /// Rewards Redeemed
+          public static let title = Localized.tr("Localizable", "notifications.inapp.rewards.redeemed.title", fallback: "Rewards Redeemed")
         }
       }
       public enum State {

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "تم تعطيل رمز الإحالة";
 "notifications.inapp.rewards.disabled.subtitle" = "تم تعطيل رمز الإحالة الخاص بك";
 "rewards.nickname" = "كنية";
+"notifications.inapp.rewards.redeemed.title" = "تم استرداد المكافآت";
+"notifications.inapp.rewards.redeemed.subtitle" = "تم استرداد مكافآتك بنجاح";
+"notifications.inapp.rewards.create_username.subtitle" = "قم بإعداد اسم المستخدم الخاص بك لكسب المكافآت";
+"notifications.inapp.rewards.invite.subtitle" = "ادعُ أصدقاءك واربحوا المكافآت معًا";
+"nodes.import_node.warning_message" = "قد تكون العقد المخصصة ضارة وقد تكشف بيانات معاملاتك أو تقدم معلومات خاطئة.";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "রেফারেল কোড বন্ধ করা আছে";
 "notifications.inapp.rewards.disabled.subtitle" = "আপনার রেফারেল কোডটি নিষ্ক্রিয় করা হয়েছে।";
 "rewards.nickname" = "ডাকনাম";
+"notifications.inapp.rewards.redeemed.title" = "পুরস্কার রিডিম করা হয়েছে";
+"notifications.inapp.rewards.redeemed.subtitle" = "আপনার পুরষ্কারগুলি সফলভাবে রিডিম করা হয়েছে।";
+"notifications.inapp.rewards.create_username.subtitle" = "পুরস্কার জিততে আপনার ব্যবহারকারীর নাম সেট আপ করুন";
+"notifications.inapp.rewards.invite.subtitle" = "বন্ধুদের আমন্ত্রণ জানান এবং একসাথে পুরস্কার জিতুন";
+"nodes.import_node.warning_message" = "কাস্টম নোডগুলি ক্ষতিকারক হতে পারে এবং আপনার লেনদেনের ডেটা প্রকাশ করতে পারে বা মিথ্যা তথ্য প্রদান করতে পারে।";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Doporučovací kód deaktivován";
 "notifications.inapp.rewards.disabled.subtitle" = "Váš doporučovací kód byl deaktivován";
 "rewards.nickname" = "Přezdívka";
+"notifications.inapp.rewards.redeemed.title" = "Odměny obdrženy";
+"notifications.inapp.rewards.redeemed.subtitle" = "Vaše odměny byly úspěšně uplatněny";
+"notifications.inapp.rewards.create_username.subtitle" = "Nastavte si uživatelské jméno a získejte odměny";
+"notifications.inapp.rewards.invite.subtitle" = "Pozvěte přátele a společně sbírejte odměny";
+"nodes.import_node.warning_message" = "Vlastní uzly mohou být škodlivé a mohou zveřejnit vaše transakční data nebo poskytovat nepravdivé informace.";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Henvisningskode deaktiveret";
 "notifications.inapp.rewards.disabled.subtitle" = "Din henvisningskode er blevet deaktiveret";
 "rewards.nickname" = "Kælenavn";
+"notifications.inapp.rewards.redeemed.title" = "Indløste belønninger";
+"notifications.inapp.rewards.redeemed.subtitle" = "Dine belønninger er blevet indløst";
+"notifications.inapp.rewards.create_username.subtitle" = "Opret dit brugernavn for at optjene belønninger";
+"notifications.inapp.rewards.invite.subtitle" = "Inviter venner og optjen belønninger sammen";
+"nodes.import_node.warning_message" = "Brugerdefinerede noder kan være skadelige og kan eksponere dine transaktionsdata eller give falske oplysninger.";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Empfehlungscode deaktiviert";
 "notifications.inapp.rewards.disabled.subtitle" = "Ihr Empfehlungscode wurde deaktiviert";
 "rewards.nickname" = "Spitzname";
+"notifications.inapp.rewards.redeemed.title" = "Eingelöste Prämien";
+"notifications.inapp.rewards.redeemed.subtitle" = "Ihre Prämien wurden erfolgreich eingelöst.";
+"notifications.inapp.rewards.create_username.subtitle" = "Richten Sie Ihren Benutzernamen ein, um Prämien zu erhalten.";
+"notifications.inapp.rewards.invite.subtitle" = "Lade Freunde ein und verdient gemeinsam Prämien.";
+"nodes.import_node.warning_message" = "Benutzerdefinierte Knoten können bösartig sein und Ihre Transaktionsdaten offenlegen oder falsche Informationen liefern.";

--- a/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Referral Code Disabled";
 "notifications.inapp.rewards.disabled.subtitle" = "Your referral code has been deactivated";
 "rewards.nickname" = "Nickname";
+"notifications.inapp.rewards.redeemed.title" = "Rewards Redeemed";
+"notifications.inapp.rewards.redeemed.subtitle" = "Your rewards have been redeemed successfully";
+"notifications.inapp.rewards.create_username.subtitle" = "Set up your username to earn rewards";
+"notifications.inapp.rewards.invite.subtitle" = "Invite friends and earn rewards together";
+"nodes.import_node.warning_message" = "Custom nodes can be malicious and may expose your transaction data or provide false information.";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Código de referencia deshabilitado";
 "notifications.inapp.rewards.disabled.subtitle" = "Su código de referencia ha sido desactivado";
 "rewards.nickname" = "Apodo";
+"notifications.inapp.rewards.redeemed.title" = "Recompensas canjeadas";
+"notifications.inapp.rewards.redeemed.subtitle" = "Tus recompensas se han canjeado con éxito";
+"notifications.inapp.rewards.create_username.subtitle" = "Configura tu nombre de usuario para ganar recompensas";
+"notifications.inapp.rewards.invite.subtitle" = "Invita a tus amigos y gana recompensas juntos";
+"nodes.import_node.warning_message" = "Los nodos personalizados pueden ser maliciosos y pueden exponer sus datos de transacciones o proporcionar información falsa.";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "کد ارجاع غیرفعال است";
 "notifications.inapp.rewards.disabled.subtitle" = "کد معرف شما غیرفعال شده است";
 "rewards.nickname" = "نام مستعار";
+"notifications.inapp.rewards.redeemed.title" = "جوایز بازخرید شده";
+"notifications.inapp.rewards.redeemed.subtitle" = "جوایز شما با موفقیت دریافت شد";
+"notifications.inapp.rewards.create_username.subtitle" = "نام کاربری خود را برای کسب جوایز تنظیم کنید";
+"notifications.inapp.rewards.invite.subtitle" = "دوستان را دعوت کنید و با هم پاداش کسب کنید";
+"nodes.import_node.warning_message" = "گره‌های سفارشی می‌توانند مخرب باشند و ممکن است داده‌های تراکنش شما را افشا کنند یا اطلاعات نادرست ارائه دهند.";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Hindi Pinagana ang Referral Code";
 "notifications.inapp.rewards.disabled.subtitle" = "Na-deactivate na ang iyong referral code";
 "rewards.nickname" = "Palayaw";
+"notifications.inapp.rewards.redeemed.title" = "Mga Gantimpala na Natubos";
+"notifications.inapp.rewards.redeemed.subtitle" = "Matagumpay na na-redeem ang iyong mga reward";
+"notifications.inapp.rewards.create_username.subtitle" = "I-set up ang iyong username para makakuha ng mga reward";
+"notifications.inapp.rewards.invite.subtitle" = "Mag-imbita ng mga kaibigan at kumita ng mga gantimpala nang sama-sama";
+"nodes.import_node.warning_message" = "Ang mga custom node ay maaaring maging malisyoso at maaaring maglantad ng iyong data ng transaksyon o magbigay ng maling impormasyon.";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Code de parrainage désactivé";
 "notifications.inapp.rewards.disabled.subtitle" = "Votre code de parrainage a été désactivé.";
 "rewards.nickname" = "Surnom";
+"notifications.inapp.rewards.redeemed.title" = "Récompenses reçues";
+"notifications.inapp.rewards.redeemed.subtitle" = "Vos récompenses ont été utilisées avec succès.";
+"notifications.inapp.rewards.create_username.subtitle" = "Configurez votre nom d'utilisateur pour gagner des récompenses";
+"notifications.inapp.rewards.invite.subtitle" = "Invitez vos amis et gagnez des récompenses ensemble.";
+"nodes.import_node.warning_message" = "Les nœuds personnalisés peuvent être malveillants et exposer vos données de transaction ou fournir de fausses informations.";

--- a/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "An kashe Lambar Tukuitawa";
 "notifications.inapp.rewards.disabled.subtitle" = "An kashe lambar tura ku";
 "rewards.nickname" = "Laƙabi";
+"notifications.inapp.rewards.redeemed.title" = "Lada da aka fanshe";
+"notifications.inapp.rewards.redeemed.subtitle" = "An yi nasarar fansar ladaran ku";
+"notifications.inapp.rewards.create_username.subtitle" = "Saita sunan mai amfani don samun lada";
+"notifications.inapp.rewards.invite.subtitle" = "Gayyaci abokai kuma ku sami lada tare";
+"nodes.import_node.warning_message" = "Maɓallan da aka keɓance na iya zama masu cutarwa kuma suna iya fallasa bayanan ma'amalar ku ko kuma samar da bayanan karya.";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "קוד הפניה מושבת";
 "notifications.inapp.rewards.disabled.subtitle" = "קוד ההפניה שלך הושבת";
 "rewards.nickname" = "כינוי";
+"notifications.inapp.rewards.redeemed.title" = "תגמולים שנפדו";
+"notifications.inapp.rewards.redeemed.subtitle" = "התגמולים שלך מומשו בהצלחה";
+"notifications.inapp.rewards.create_username.subtitle" = "הגדר את שם המשתמש שלך כדי לצבור פרסים";
+"notifications.inapp.rewards.invite.subtitle" = "הזמינו חברים וצברו יחד פרסים";
+"nodes.import_node.warning_message" = "צמתים מותאמים אישית עלולים להיות זדוניים ולחשוף את נתוני העסקאות שלך או לספק מידע כוזב.";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "रेफरल कोड निष्क्रिय";
 "notifications.inapp.rewards.disabled.subtitle" = "आपका रेफरल कोड निष्क्रिय कर दिया गया है।";
 "rewards.nickname" = "उपनाम";
+"notifications.inapp.rewards.redeemed.title" = "भुनाए गए पुरस्कार";
+"notifications.inapp.rewards.redeemed.subtitle" = "आपके पुरस्कार सफलतापूर्वक भुना लिए गए हैं।";
+"notifications.inapp.rewards.create_username.subtitle" = "पुरस्कार अर्जित करने के लिए अपना उपयोगकर्ता नाम सेट करें";
+"notifications.inapp.rewards.invite.subtitle" = "दोस्तों को आमंत्रित करें और साथ मिलकर पुरस्कार जीतें";
+"nodes.import_node.warning_message" = "कस्टम नोड्स दुर्भावनापूर्ण हो सकते हैं और आपके लेनदेन डेटा को उजागर कर सकते हैं या गलत जानकारी प्रदान कर सकते हैं।";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Kode Referensi Dinonaktifkan";
 "notifications.inapp.rewards.disabled.subtitle" = "Kode referensi Anda telah dinonaktifkan";
 "rewards.nickname" = "Nama panggilan";
+"notifications.inapp.rewards.redeemed.title" = "Hadiah Ditukarkan";
+"notifications.inapp.rewards.redeemed.subtitle" = "Hadiah Anda telah berhasil ditukarkan.";
+"notifications.inapp.rewards.create_username.subtitle" = "Buat nama pengguna Anda untuk mendapatkan hadiah.";
+"notifications.inapp.rewards.invite.subtitle" = "Ajak teman dan dapatkan hadiah bersama.";
+"nodes.import_node.warning_message" = "Node kustom dapat bersifat berbahaya dan dapat membocorkan data transaksi Anda atau memberikan informasi palsu.";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Codice di riferimento disabilitato";
 "notifications.inapp.rewards.disabled.subtitle" = "Il tuo codice di riferimento è stato disattivato";
 "rewards.nickname" = "Soprannome";
+"notifications.inapp.rewards.redeemed.title" = "Premi riscattati";
+"notifications.inapp.rewards.redeemed.subtitle" = "I tuoi premi sono stati riscattati con successo";
+"notifications.inapp.rewards.create_username.subtitle" = "Imposta il tuo nome utente per guadagnare premi";
+"notifications.inapp.rewards.invite.subtitle" = "Invita gli amici e guadagnate premi insieme";
+"nodes.import_node.warning_message" = "I nodi personalizzati possono essere dannosi e potrebbero esporre i dati delle transazioni o fornire informazioni false.";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "紹介コードが無効です";
 "notifications.inapp.rewards.disabled.subtitle" = "紹介コードは無効になりました";
 "rewards.nickname" = "ニックネーム";
+"notifications.inapp.rewards.redeemed.title" = "交換された報酬";
+"notifications.inapp.rewards.redeemed.subtitle" = "報酬は正常に引き換えられました";
+"notifications.inapp.rewards.create_username.subtitle" = "ユーザー名を設定して報酬を獲得しましょう";
+"notifications.inapp.rewards.invite.subtitle" = "友達を招待して一緒に報酬を獲得しましょう";
+"nodes.import_node.warning_message" = "カスタム ノードは悪意のあるものである可能性があり、トランザクション データが公開されたり、誤った情報が提供されたりする可能性があります。";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "추천 코드 사용 안 함";
 "notifications.inapp.rewards.disabled.subtitle" = "회원님의 추천 코드가 비활성화되었습니다.";
 "rewards.nickname" = "별명";
+"notifications.inapp.rewards.redeemed.title" = "리워드 수령됨";
+"notifications.inapp.rewards.redeemed.subtitle" = "보상이 성공적으로 사용되었습니다.";
+"notifications.inapp.rewards.create_username.subtitle" = "보상을 받으려면 사용자 이름을 설정하세요.";
+"notifications.inapp.rewards.invite.subtitle" = "친구를 초대하고 함께 보상을 받으세요";
+"nodes.import_node.warning_message" = "사용자 지정 노드는 악의적일 수 있으며 거래 데이터를 노출하거나 허위 정보를 제공할 수 있습니다.";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Kod Rujukan Dilumpuhkan";
 "notifications.inapp.rewards.disabled.subtitle" = "Kod rujukan anda telah dinyahaktifkan";
 "rewards.nickname" = "Nama panggilan";
+"notifications.inapp.rewards.redeemed.title" = "Ganjaran Ditebus";
+"notifications.inapp.rewards.redeemed.subtitle" = "Ganjaran anda telah berjaya ditebus";
+"notifications.inapp.rewards.create_username.subtitle" = "Sediakan nama pengguna anda untuk mendapatkan ganjaran";
+"notifications.inapp.rewards.invite.subtitle" = "Jemput rakan-rakan dan dapatkan ganjaran bersama-sama";
+"nodes.import_node.warning_message" = "Nod tersuai boleh berniat jahat dan mungkin mendedahkan data transaksi anda atau memberikan maklumat palsu.";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Verwijzingscode uitgeschakeld";
 "notifications.inapp.rewards.disabled.subtitle" = "Je verwijzingscode is gedeactiveerd.";
 "rewards.nickname" = "Bijnaam";
+"notifications.inapp.rewards.redeemed.title" = "Ingewisselde beloningen";
+"notifications.inapp.rewards.redeemed.subtitle" = "Uw beloningen zijn succesvol verzilverd.";
+"notifications.inapp.rewards.create_username.subtitle" = "Stel je gebruikersnaam in om beloningen te verdienen.";
+"notifications.inapp.rewards.invite.subtitle" = "Nodig vrienden uit en verdien samen beloningen.";
+"nodes.import_node.warning_message" = "Aangepaste nodes kunnen kwaadaardig zijn en uw transactiegegevens blootleggen of valse informatie verstrekken.";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Kod polecający wyłączony";
 "notifications.inapp.rewards.disabled.subtitle" = "Twój kod polecający został dezaktywowany";
 "rewards.nickname" = "Przydomek";
+"notifications.inapp.rewards.redeemed.title" = "Nagrody zrealizowane";
+"notifications.inapp.rewards.redeemed.subtitle" = "Twoje nagrody zostały pomyślnie odebrane";
+"notifications.inapp.rewards.create_username.subtitle" = "Ustaw swoją nazwę użytkownika, aby zdobywać nagrody";
+"notifications.inapp.rewards.invite.subtitle" = "Zaproś znajomych i zdobywajcie nagrody razem";
+"nodes.import_node.warning_message" = "Węzły niestandardowe mogą mieć charakter złośliwy i ujawniać dane transakcji lub podawać fałszywe informacje.";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Código de indicação desativado";
 "notifications.inapp.rewards.disabled.subtitle" = "Seu código de indicação foi desativado.";
 "rewards.nickname" = "Apelido";
+"notifications.inapp.rewards.redeemed.title" = "Recompensas Resgatadas";
+"notifications.inapp.rewards.redeemed.subtitle" = "Suas recompensas foram resgatadas com sucesso.";
+"notifications.inapp.rewards.create_username.subtitle" = "Configure seu nome de usuário para ganhar recompensas.";
+"notifications.inapp.rewards.invite.subtitle" = "Convide amigos e ganhem recompensas juntos.";
+"nodes.import_node.warning_message" = "Nós personalizados podem ser maliciosos e expor seus dados de transação ou fornecer informações falsas.";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Cod de recomandare dezactivat";
 "notifications.inapp.rewards.disabled.subtitle" = "Codul tău de recomandare a fost dezactivat";
 "rewards.nickname" = "Poreclă";
+"notifications.inapp.rewards.redeemed.title" = "Recompense răscumpărate";
+"notifications.inapp.rewards.redeemed.subtitle" = "Recompensele tale au fost valorificate cu succes";
+"notifications.inapp.rewards.create_username.subtitle" = "Configurați-vă numele de utilizator pentru a câștiga recompense";
+"notifications.inapp.rewards.invite.subtitle" = "Invită-ți prietenii și câștigă recompense împreună";
+"nodes.import_node.warning_message" = "Nodurile personalizate pot fi rău intenționate și pot expune datele tranzacțiilor sau pot furniza informații false.";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Реферальный код отключен";
 "notifications.inapp.rewards.disabled.subtitle" = "Ваш реферальный код деактивирован.";
 "rewards.nickname" = "Никнейм";
+"notifications.inapp.rewards.redeemed.title" = "Награда получена";
+"notifications.inapp.rewards.redeemed.subtitle" = "Награда успешно получена.";
+"notifications.inapp.rewards.create_username.subtitle" = "Зарегистрируйте имя пользователя, чтобы получать награды.";
+"notifications.inapp.rewards.invite.subtitle" = "Приглашайте друзей и зарабатывайте награды вместе.";
+"nodes.import_node.warning_message" = "Пользовательские узлы могут быть вредоносными и способны раскрыть данные ваших транзакций или предоставить ложную информацию.";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Nambari ya Rufaa Imezimwa";
 "notifications.inapp.rewards.disabled.subtitle" = "Nambari yako ya rufaa imezimwa";
 "rewards.nickname" = "Jina la utani";
+"notifications.inapp.rewards.redeemed.title" = "Zawadi Zilizokombolewa";
+"notifications.inapp.rewards.redeemed.subtitle" = "Zawadi zako zimetumika kwa mafanikio";
+"notifications.inapp.rewards.create_username.subtitle" = "Weka jina lako la mtumiaji ili upate zawadi";
+"notifications.inapp.rewards.invite.subtitle" = "Alika marafiki na upate zawadi pamoja";
+"nodes.import_node.warning_message" = "Nodi maalum zinaweza kuwa na nia mbaya na zinaweza kufichua data ya muamala wako au kutoa taarifa za uongo.";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "รหัสอ้างอิงถูกปิดใช้งาน";
 "notifications.inapp.rewards.disabled.subtitle" = "รหัสแนะนำของคุณถูกปิดใช้งานแล้ว";
 "rewards.nickname" = "ชื่อเล่น";
+"notifications.inapp.rewards.redeemed.title" = "รางวัลที่แลกรับ";
+"notifications.inapp.rewards.redeemed.subtitle" = "รางวัลของคุณได้รับการแลกรับเรียบร้อยแล้ว";
+"notifications.inapp.rewards.create_username.subtitle" = "ตั้งชื่อผู้ใช้ของคุณเพื่อรับรางวัล";
+"notifications.inapp.rewards.invite.subtitle" = "ชวนเพื่อนมารับรางวัลด้วยกัน";
+"nodes.import_node.warning_message" = "โหนดที่กำหนดเองอาจเป็นอันตรายและอาจเปิดเผยข้อมูลธุรกรรมของคุณหรือให้ข้อมูลเท็จได้";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Yönlendirme Kodu Devre Dışı Bırakıldı";
 "notifications.inapp.rewards.disabled.subtitle" = "Yönlendirme kodunuz devre dışı bırakıldı.";
 "rewards.nickname" = "Takma ad";
+"notifications.inapp.rewards.redeemed.title" = "Ödüller Alındı";
+"notifications.inapp.rewards.redeemed.subtitle" = "Ödülleriniz başarıyla kullanıldı.";
+"notifications.inapp.rewards.create_username.subtitle" = "Ödüller kazanmak için kullanıcı adınızı oluşturun.";
+"notifications.inapp.rewards.invite.subtitle" = "Arkadaşlarınızı davet edin ve birlikte ödüller kazanın.";
+"nodes.import_node.warning_message" = "Özel düğümler kötü amaçlı olabilir ve işlem verilerinizi ifşa edebilir veya yanlış bilgi sağlayabilir.";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Реферальний код вимкнено";
 "notifications.inapp.rewards.disabled.subtitle" = "Ваш реферальний код деактивовано";
 "rewards.nickname" = "Прізвисько";
+"notifications.inapp.rewards.redeemed.title" = "Винагороду отримано";
+"notifications.inapp.rewards.redeemed.subtitle" = "Ваші винагороди успішно отримано";
+"notifications.inapp.rewards.create_username.subtitle" = "Налаштуйте своє ім'я користувача, щоб отримувати винагороди";
+"notifications.inapp.rewards.invite.subtitle" = "Запрошуйте друзів та отримуйте винагороди разом";
+"nodes.import_node.warning_message" = "Користувацькі вузли можуть бути шкідливими та розкривати дані ваших транзакцій або надавати неправдиву інформацію.";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "ریفرل کوڈ غیر فعال ہے۔";
 "notifications.inapp.rewards.disabled.subtitle" = "آپ کا ریفرل کوڈ غیر فعال کر دیا گیا ہے۔";
 "rewards.nickname" = "عرفی نام";
+"notifications.inapp.rewards.redeemed.title" = "انعامات بھنائے گئے۔";
+"notifications.inapp.rewards.redeemed.subtitle" = "آپ کے انعامات کو کامیابی کے ساتھ بھنایا گیا ہے۔";
+"notifications.inapp.rewards.create_username.subtitle" = "انعامات حاصل کرنے کے لیے اپنا صارف نام ترتیب دیں۔";
+"notifications.inapp.rewards.invite.subtitle" = "دوستوں کو مدعو کریں اور مل کر انعامات کمائیں۔";
+"nodes.import_node.warning_message" = "حسب ضرورت نوڈس بدنیتی پر مبنی ہو سکتے ہیں اور آپ کے لین دین کے ڈیٹا کو بے نقاب کر سکتے ہیں یا غلط معلومات فراہم کر سکتے ہیں۔";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "Mã giới thiệu đã bị vô hiệu hóa";
 "notifications.inapp.rewards.disabled.subtitle" = "Mã giới thiệu của bạn đã bị vô hiệu hóa.";
 "rewards.nickname" = "Biệt danh";
+"notifications.inapp.rewards.redeemed.title" = "Phần thưởng đã quy đổi";
+"notifications.inapp.rewards.redeemed.subtitle" = "Phần thưởng của bạn đã được quy đổi thành công.";
+"notifications.inapp.rewards.create_username.subtitle" = "Thiết lập tên người dùng của bạn để nhận phần thưởng";
+"notifications.inapp.rewards.invite.subtitle" = "Mời bạn bè và cùng nhau nhận phần thưởng.";
+"nodes.import_node.warning_message" = "Các node tùy chỉnh có thể chứa mã độc và có thể làm lộ dữ liệu giao dịch của bạn hoặc cung cấp thông tin sai lệch.";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "推荐码已禁用";
 "notifications.inapp.rewards.disabled.subtitle" = "您的推荐码已停用。";
 "rewards.nickname" = "昵称";
+"notifications.inapp.rewards.redeemed.title" = "已兑换奖励";
+"notifications.inapp.rewards.redeemed.subtitle" = "您的奖励已成功兑换";
+"notifications.inapp.rewards.create_username.subtitle" = "设置您的用户名即可获得奖励";
+"notifications.inapp.rewards.invite.subtitle" = "邀请好友，一起赢取奖励";
+"nodes.import_node.warning_message" = "自定义节点可能存在恶意，可能会泄露您的交易数据或提供虚假信息。";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -561,3 +561,8 @@
 "notifications.inapp.rewards.disabled.title" = "推薦碼已停用";
 "notifications.inapp.rewards.disabled.subtitle" = "您的推薦碼已停用。";
 "rewards.nickname" = "暱稱";
+"notifications.inapp.rewards.redeemed.title" = "已兌換獎勵";
+"notifications.inapp.rewards.redeemed.subtitle" = "您的獎勵已成功兌換";
+"notifications.inapp.rewards.create_username.subtitle" = "設定您的用戶名即可獲得獎勵";
+"notifications.inapp.rewards.invite.subtitle" = "邀請好友，一起贏取獎勵";
+"nodes.import_node.warning_message" = "自訂節點可能存在惡意，可能會洩露您的交易資料或提供虛假資訊。";


### PR DESCRIPTION
Introduced a warning section in AddNodeScene to alert users that custom nodes can be malicious and may expose transaction data or provide false information. Added localized warning messages in all supported languages and updated the AddNodeSceneViewModel to provide the warning model for display.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-20 at 15 54 07" src="https://github.com/user-attachments/assets/068ed640-318c-4fa3-ac5f-a03d50466c64" />


Close: https://github.com/gemwalletcom/gem-ios/issues/1611