### PR TITLE
Add dismantleUIView to clean up WKWebView handlers

### DIFF
--- a/Features/Support/Sources/Views/ChatwootWebView.swift
+++ b/Features/Support/Sources/Views/ChatwootWebView.swift
@@ -22,4 +22,8 @@ struct ChatwootWebView: UIViewRepresentable {
     func updateUIView(_ webView: WKWebView, context: Context) {
         webView.loadHTMLString(model.htmlContent, baseURL: model.baseUrl)
     }
+    
+    static func dismantleUIView(_ webView: WKWebView, coordinator: ()) {
+        webView.configuration.userContentController.removeAllScriptMessageHandlers()
+    }
 }


### PR DESCRIPTION
Implements the static dismantleUIView method in ChatwootWebView to remove all script message handlers from the WKWebView's userContentController, ensuring proper cleanup when the view is dismantled.