### PR TITLE
Update wallet change handling logic

### DIFF
--- a/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
+++ b/Features/WalletTab/Sources/ViewModels/WalletSceneViewModel.swift
@@ -218,8 +218,12 @@ extension WalletSceneViewModel {
     }
 
     public func onChangeWallet(_ oldWallet: Wallet?, _ newWallet: Wallet?) {
-        if let newWallet, wallet.walletId != newWallet.walletId {
+        guard let newWallet else { return }
+
+        if wallet.walletId != newWallet.walletId {
             refresh(for: newWallet)
+        } else if wallet != newWallet {
+            wallet = newWallet
         }
     }
 

--- a/Features/WalletTab/Tests/WalletSceneViewModelTests.swift
+++ b/Features/WalletTab/Tests/WalletSceneViewModelTests.swift
@@ -38,16 +38,41 @@ struct WalletSceneViewModelTests {
         #expect(model.walletBannersModel.allBanners.first?.state == .alwaysActive)
     }
 
+    @Test
+    func onChangeWalletUpdatesImageUrl() {
+        let wallet = Wallet.mock(id: "1", imageUrl: nil)
+        let model = WalletSceneViewModel.mock(wallet: wallet)
+
+        #expect(model.wallet.imageUrl == nil)
+
+        let updatedWallet = Wallet.mock(id: "1", imageUrl: "avatar.png")
+        model.onChangeWallet(wallet, updatedWallet)
+
+        #expect(model.wallet.imageUrl == "avatar.png")
+    }
+
+    @Test
+    func onChangeWalletSwitchesToDifferentWallet() {
+        let wallet = Wallet.mock(id: "1", name: "Wallet 1")
+        let model = WalletSceneViewModel.mock(wallet: wallet)
+
+        #expect(model.wallet.id == "1")
+
+        let newWallet = Wallet.mock(id: "2", name: "Wallet 2")
+        model.onChangeWallet(wallet, newWallet)
+
+        #expect(model.wallet.id == "2")
+    }
 }
 
 extension WalletSceneViewModel {
-    static func mock() -> WalletSceneViewModel {
+    static func mock(wallet: Wallet = .mock()) -> WalletSceneViewModel {
         WalletSceneViewModel(
             walletsService: .mock(),
             bannerService: .mock(),
             walletService: .mock(),
             observablePreferences: .mock(),
-            wallet: .mock(),
+            wallet: wallet,
             isPresentingSelectedAssetInput: .constant(.none)
         )
     }

--- a/Packages/Primitives/TestKit/Wallet+PrimitivesTestKit.swift
+++ b/Packages/Primitives/TestKit/Wallet+PrimitivesTestKit.swift
@@ -11,6 +11,7 @@ public extension Wallet {
         accounts: [Account] = [],
         index: Int = 0,
         order: Int = 0,
+        imageUrl: String? = nil,
         source: WalletSource = .create
     ) -> Wallet {
         Wallet(
@@ -21,7 +22,7 @@ public extension Wallet {
             accounts: accounts,
             order: order.asInt32,
             isPinned: false,
-            imageUrl: nil,
+            imageUrl: imageUrl,
             source: source
         )
     }


### PR DESCRIPTION
Refactored onChangeWallet to use guard for newWallet and improved logic to refresh or update wallet only when necessary.

- Fix WalletBarView not refreshing when setting an NFT as wallet avatar
- Update onChangeWallet to handle wallet data changes (e.g., imageUrl) for the same wallet, not just wallet switches