### PR TITLE
Update wallet sync logic and add onboarding tests

### DIFF
--- a/Features/Onboarding/Package.swift
+++ b/Features/Onboarding/Package.swift
@@ -53,6 +53,7 @@ let package = Package(
             name: "OnboardingTest",
             dependencies: [
                 "Onboarding",
+                .product(name: "PrimitivesTestKit", package: "Primitives"),
                 .product(name: "WalletServiceTestKit", package: "FeatureServices"),
                 .product(name: "KeystoreTestKit", package: "Keystore"),
                 .product(name: "NameServiceTestKit", package: "ChainServices"),

--- a/Features/Onboarding/Package.swift
+++ b/Features/Onboarding/Package.swift
@@ -54,6 +54,9 @@ let package = Package(
             dependencies: [
                 "Onboarding",
                 .product(name: "WalletServiceTestKit", package: "FeatureServices"),
+                .product(name: "KeystoreTestKit", package: "Keystore"),
+                .product(name: "NameServiceTestKit", package: "ChainServices"),
+                .product(name: "StoreTestKit", package: "Store"),
             ],
             path: "Tests"
         )

--- a/Features/Onboarding/Sources/ViewModels/CreateWalletModel.swift
+++ b/Features/Onboarding/Sources/ViewModels/CreateWalletModel.swift
@@ -53,6 +53,7 @@ extension CreateWalletModel {
             source: .create
         )
         walletService.acceptTerms()
+        WalletPreferences(walletId: wallet.walletId).completeInitialSynchronization()
         return wallet
     }
 

--- a/Features/Onboarding/Sources/ViewModels/ImportWalletViewModel.swift
+++ b/Features/Onboarding/Sources/ViewModels/ImportWalletViewModel.swift
@@ -6,7 +6,6 @@ import Primitives
 import WalletService
 import AvatarService
 import PrimitivesComponents
-import Preferences
 import enum Keystore.KeystoreImportType
 
 @Observable
@@ -51,7 +50,6 @@ extension ImportWalletViewModel {
     func importWallet(data: WalletImportData) async throws -> Wallet {
         let wallet = try await walletService.loadOrCreateWallet(name: data.name, type: data.keystoreType, source: .import)
         walletService.acceptTerms()
-        WalletPreferences(walletId: wallet.walletId).completeInitialSynchronization()
         try await walletService.setCurrent(wallet: wallet)
         return wallet
     }

--- a/Features/Onboarding/Tests/CreateWalletModelTests.swift
+++ b/Features/Onboarding/Tests/CreateWalletModelTests.swift
@@ -26,5 +26,7 @@ struct CreateWalletModelTests {
 
         #expect(preferences.completeInitialAddressStatus)
         #expect(preferences.completeInitialLoadAssets)
+
+        preferences.clear()
     }
 }

--- a/Features/Onboarding/Tests/CreateWalletModelTests.swift
+++ b/Features/Onboarding/Tests/CreateWalletModelTests.swift
@@ -1,0 +1,30 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Testing
+import Preferences
+import Keystore
+import KeystoreTestKit
+import StoreTestKit
+import WalletServiceTestKit
+
+@testable import Onboarding
+
+@MainActor
+struct CreateWalletModelTests {
+
+    @Test
+    func createWalletSetsAddressStatus() async throws {
+        let model = CreateWalletModel(
+            walletService: .mock(keystore: KeystoreMock()),
+            avatarService: .init(store: .mock()),
+            onComplete: nil
+        )
+
+        let wallet = try await model.createWallet(words: LocalKeystore.words)
+        let preferences = WalletPreferences(walletId: wallet.walletId)
+
+        #expect(preferences.completeInitialAddressStatus)
+        #expect(preferences.completeInitialLoadAssets)
+    }
+}

--- a/Features/Onboarding/Tests/ImportWalletViewModelTests.swift
+++ b/Features/Onboarding/Tests/ImportWalletViewModelTests.swift
@@ -2,9 +2,11 @@
 
 import Foundation
 import Testing
+import Primitives
 import Preferences
 import Keystore
 import KeystoreTestKit
+import PrimitivesTestKit
 import NameServiceTestKit
 import StoreTestKit
 import WalletServiceTestKit
@@ -16,18 +18,21 @@ struct ImportWalletViewModelTests {
 
     @Test
     func importWalletDoesNotSetAddressStatus() async throws {
+        let keystore = KeystoreMock()
+        let preferences = WalletPreferences(walletId: Wallet.mock().walletId)
+        preferences.clear()
+
         let model = ImportWalletViewModel(
-            walletService: .mock(keystore: KeystoreMock()),
+            walletService: .mock(keystore: keystore),
             avatarService: .init(store: .mock()),
             nameService: .mock(),
             onComplete: nil
         )
 
-        let wallet = try await model.importWallet(data: WalletImportData(
+        _ = try await model.importWallet(data: WalletImportData(
             name: "Test",
             keystoreType: .phrase(words: LocalKeystore.words, chains: [.tron])
         ))
-        let preferences = WalletPreferences(walletId: wallet.walletId)
 
         #expect(preferences.completeInitialAddressStatus == false)
         #expect(preferences.completeInitialLoadAssets == false)

--- a/Features/Onboarding/Tests/ImportWalletViewModelTests.swift
+++ b/Features/Onboarding/Tests/ImportWalletViewModelTests.swift
@@ -1,0 +1,35 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Testing
+import Preferences
+import Keystore
+import KeystoreTestKit
+import NameServiceTestKit
+import StoreTestKit
+import WalletServiceTestKit
+
+@testable import Onboarding
+
+@MainActor
+struct ImportWalletViewModelTests {
+
+    @Test
+    func importWalletDoesNotSetAddressStatus() async throws {
+        let model = ImportWalletViewModel(
+            walletService: .mock(keystore: KeystoreMock()),
+            avatarService: .init(store: .mock()),
+            nameService: .mock(),
+            onComplete: nil
+        )
+
+        let wallet = try await model.importWallet(data: WalletImportData(
+            name: "Test",
+            keystoreType: .phrase(words: LocalKeystore.words, chains: [.tron])
+        ))
+        let preferences = WalletPreferences(walletId: wallet.walletId)
+
+        #expect(preferences.completeInitialAddressStatus == false)
+        #expect(preferences.completeInitialLoadAssets == false)
+    }
+}

--- a/Features/WalletTab/Tests/WalletSceneViewModelTests.swift
+++ b/Features/WalletTab/Tests/WalletSceneViewModelTests.swift
@@ -16,9 +16,12 @@ import PreferencesTestKit
 struct WalletSceneViewModelTests {
     @Test
     func isLoading() {
+        let preferences = WalletPreferences(walletId: Wallet.mock().walletId)
+        preferences.clear()
+
         let model = WalletSceneViewModel.mock()
         #expect(model.isLoadingAssets == false)
-        
+
         model.shouldStartLoadingAssets()
         #expect(model.isLoadingAssets)
         

--- a/Packages/Preferences/Sources/WalletPreferences.swift
+++ b/Packages/Preferences/Sources/WalletPreferences.swift
@@ -44,10 +44,6 @@ public final class WalletPreferences: @unchecked Sendable {
         get { defaults.bool(forKey: Keys.completeInitialAddressStatus) }
     }
     
-    public var isCompleteInitialSynchronization: Bool {
-        completeInitialAddressStatus && completeInitialLoadAssets
-    }
-    
     public func completeInitialSynchronization() {
         completeInitialAddressStatus = true
         completeInitialLoadAssets = true


### PR DESCRIPTION
Moved initial synchronization completion to CreateWalletModel and removed it from ImportWalletViewModel. Added unit tests for both CreateWalletModel and ImportWalletViewModel to verify address status and asset loading preferences. Updated test dependencies in Package.swift.