### PR TITLE
Update error state views to use dynamic titles

### DIFF
--- a/Features/MarketInsight/Sources/Scenes/ChartScene.swift
+++ b/Features/MarketInsight/Sources/Scenes/ChartScene.swift
@@ -106,7 +106,6 @@ public struct ChartScene: View {
                     model: AssetPriceDetailsViewModel(priceData: priceData)
                 )
             }
-            .presentationDetentsForCurrentDeviceSize(expandable: true)
             .presentationBackground(Colors.grayBackground)
         }
     }

--- a/Features/Perpetuals/Sources/Scenes/PerpetualScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualScene.swift
@@ -26,8 +26,7 @@ public struct PerpetualScene: View {
                         case .data(let data): CandlestickChartView(data: data, period: model.currentPeriod, lineModels: model.chartLineModels)
                         case .error(let error):
                             StateEmptyView(
-                                title: Localized.Errors.errorOccured,
-                                description: error.networkOrNoDataDescription,
+                                title: error.networkOrNoDataDescription,
                                 image: Images.ErrorConent.error
                             )
                         }

--- a/Packages/PrimitivesComponents/Sources/Views/ChartStateView.swift
+++ b/Packages/PrimitivesComponents/Sources/Views/ChartStateView.swift
@@ -34,8 +34,7 @@ public struct ChartStateView: View {
                     ChartView(model: model)
                 case .error(let error):
                     StateEmptyView(
-                        title: Localized.Errors.errorOccured,
-                        description: error.networkOrNoDataDescription,
+                        title: error.networkOrNoDataDescription,
                         image: Images.ErrorConent.error
                     )
                 }


### PR DESCRIPTION
Replaces static error titles with dynamic error descriptions in StateEmptyView for ChartScene, PerpetualScene, and ChartStateView. Also removes an unused presentationDetents modifier in ChartScene.