### PR TITLE
Show infinity symbol for unlimited max supply

### DIFF
--- a/Features/MarketInsight/Sources/ViewModels/AssetMarketViewModel.swift
+++ b/Features/MarketInsight/Sources/ViewModels/AssetMarketViewModel.swift
@@ -74,7 +74,7 @@ struct AssetMarketViewModel {
     var maxSupply: MarketValueViewModel {
         MarketValueViewModel(
             title: Localized.Info.MaxSupply.title,
-            subtitle: formatSupply(market.maxSupply),
+            subtitle: market.maxSupply == 0 ? "∞ \(assetSymbol)" : formatSupply(market.maxSupply),
             infoSheetType: .maxSupply
         )
     }


### PR DESCRIPTION
Display ∞ symbol instead of 0 when maxSupply is zero, indicating unlimited token supply.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-28 at 23 08 39" src="https://github.com/user-attachments/assets/8a77ff55-533f-4ee1-9361-da05666e9bea" />
