### PR TITLE
Harden payload.message.chain == payload.chain

### DIFF
--- a/Features/WalletConnector/Sources/WalletConnector/ViewModels/SignMessageSceneViewModel.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/ViewModels/SignMessageSceneViewModel.swift
@@ -76,6 +76,10 @@ public final class SignMessageSceneViewModel {
     }
 
     public func signMessage() async throws {
+        guard payload.message.chain == payload.chain.rawValue else {
+            throw WalletConnectorServiceError.wrongSignParameters
+        }
+
         var privateKey = try await keystore.getPrivateKey(wallet: payload.wallet, chain: payload.chain)
         defer { privateKey.zeroize() }
 

--- a/Features/WalletConnector/Tests/WalletConnectorTests/SignMessageSceneViewModelTests.swift
+++ b/Features/WalletConnector/Tests/WalletConnectorTests/SignMessageSceneViewModelTests.swift
@@ -1,5 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import Foundation
 import Testing
 import Primitives
 import PrimitivesTestKit
@@ -51,6 +52,27 @@ struct SignMessageSceneViewModelTests {
 
         #expect(viewModel.connectionViewModel.connection.wallet.id == "specific-wallet-id")
         #expect(viewModel.connectionViewModel.connection.wallet.name == "Test Wallet")
+    }
+
+    @Test
+    @MainActor
+    func signMessageRejectsChainMismatch() async {
+        let payload = SignMessagePayload(
+            chain: .ethereum,
+            session: .mock(),
+            wallet: .mock(),
+            message: SignMessage(chain: "solana", signType: .eip191, data: Data())
+        )
+
+        let viewModel = SignMessageSceneViewModel(
+            keystore: KeystoreMock(),
+            payload: payload,
+            confirmTransferDelegate: { _ in }
+        )
+
+        await #expect(throws: WalletConnectorServiceError.wrongSignParameters) {
+            try await viewModel.signMessage()
+        }
     }
 
     @Test


### PR DESCRIPTION
SignMessage.chain is set from the WalletConnect request chain in core (decode_sign_message), and EIP‑712/SIWE validation checks the chain ID against the request chain. So payload.message.chain and payload.chain should always match.

Add this UI guarding just in case