### PR TITLE
AssetPriceAlertsScene minor fixes

### DIFF
--- a/Features/PriceAlerts/Sources/Scenes/AssetPriceAlertsScene.swift
+++ b/Features/PriceAlerts/Sources/Scenes/AssetPriceAlertsScene.swift
@@ -36,8 +36,8 @@ public struct AssetPriceAlertsScene: View {
             }
         }
         .overlay {
-            if let emptyContentModel = model.emptyContentModel {
-                EmptyContentView(model: emptyContentModel)
+            if model.showEmptyState {
+                EmptyContentView(model: model.emptyContentModel)
             }
         }
         .observeQuery(request: $model.request, value: $model.priceAlerts)

--- a/Features/PriceAlerts/Sources/ViewModels/AssetPriceAlertsViewModel.swift
+++ b/Features/PriceAlerts/Sources/ViewModels/AssetPriceAlertsViewModel.swift
@@ -54,9 +54,12 @@ public final class AssetPriceAlertsViewModel: Sendable {
             .map { PriceAlertItemViewModel(data: $0) }
     }
     
-    var emptyContentModel: EmptyContentTypeViewModel? {
-        guard alertsModel.isEmpty, autoAlertModel == nil else { return nil }
-        return EmptyContentTypeViewModel(type: .priceAlerts)
+    var showEmptyState: Bool {
+        alertsModel.isEmpty && autoAlertModel == nil
+    }
+
+    var emptyContentModel: EmptyContentTypeViewModel {
+        EmptyContentTypeViewModel(type: .priceAlerts)
     }
 }
 

--- a/Features/PriceAlerts/Tests/PriceAlertsTests/AssetPriceAlertsViewModelTests.swift
+++ b/Features/PriceAlerts/Tests/PriceAlertsTests/AssetPriceAlertsViewModelTests.swift
@@ -26,14 +26,14 @@ struct AssetPriceAlertsViewModelTests {
     }
     
     @Test
-    func emptyContentModel() {
+    func showEmptyState() {
         let model = AssetPriceAlertsViewModel.mock()
-        
-        #expect(model.emptyContentModel != nil)
-        
+
+        #expect(model.showEmptyState == true)
+
         model.priceAlerts = [PriceAlertData.mock()]
-        
-        #expect(model.emptyContentModel == nil)
+
+        #expect(model.showEmptyState == false)
     }
 }
 


### PR DESCRIPTION
AssetPriceAlertsScene already has empty state, can't repro

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-02 at 20 57 56" src="https://github.com/user-attachments/assets/8412edde-0403-4afb-92c7-77c131ec3454" />


Close: https://github.com/gemwalletcom/gem-ios/issues/1631