### PR TITLE
Resettable timer + RefreshableTimer modifier

### DIFF
--- a/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -162,6 +162,9 @@ public struct AssetScene: View {
             await model.fetch()
         }
         .taskOnce(model.fetchOnce)
+        .onTimer(every: .minutes5) {
+            await model.fetch()
+        }
         .listSectionSpacing(.compact)
         .navigationTitle(model.title)
         .contentMargins([.top], .small, for: .scrollContent)

--- a/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -158,13 +158,10 @@ public struct AssetScene: View {
                 .cleanListRow()
             }
         }
-        .refreshable {
+        .refreshableTimer(every: .minutes(5)) {
             await model.fetch()
         }
         .taskOnce(model.fetchOnce)
-        .onTimer(every: .minutes5) {
-            await model.fetch()
-        }
         .listSectionSpacing(.compact)
         .navigationTitle(model.title)
         .contentMargins([.top], .small, for: .scrollContent)

--- a/Features/Assets/Sources/Scenes/SelectAssetScene.swift
+++ b/Features/Assets/Sources/Scenes/SelectAssetScene.swift
@@ -29,7 +29,7 @@ public struct SelectAssetScene: View {
         .if(model.isNetworkSearchEnabled) {
             $0.debounce(
                 value: $model.searchModel.searchableQuery.wrappedValue,
-                interval: Duration.milliseconds(250),
+                interval: .Debounce.normal,
                 action: model.search(query:)
             )
         }

--- a/Features/FiatConnect/Sources/Scenes/FiatScene.swift
+++ b/Features/FiatConnect/Sources/Scenes/FiatScene.swift
@@ -38,7 +38,7 @@ public struct FiatScene: View {
         .debouncedTask(id: model.fetchTrigger) {
             await model.fetch()
         }
-        .onTimer(every: .minutes5) {
+        .onTimer(every: .minutes(5)) {
             await model.fetch()
         }
         .alertSheet($model.isPresentingAlertMessage)

--- a/Features/FiatConnect/Sources/Scenes/FiatScene.swift
+++ b/Features/FiatConnect/Sources/Scenes/FiatScene.swift
@@ -38,6 +38,9 @@ public struct FiatScene: View {
         .debouncedTask(id: model.fetchTrigger) {
             await model.fetch()
         }
+        .onTimer(every: .minutes5) {
+            await model.fetch()
+        }
         .alertSheet($model.isPresentingAlertMessage)
     }
 }

--- a/Features/MarketInsight/Sources/Scenes/ChartScene.swift
+++ b/Features/MarketInsight/Sources/Scenes/ChartScene.swift
@@ -86,13 +86,10 @@ public struct ChartScene: View {
             }
         }
         .observeQuery(request: $model.priceRequest, value: $model.priceData)
-        .refreshable {
+        .refreshableTimer(every: .minutes(1)) {
             await model.fetch()
         }
         .task {
-            await model.fetch()
-        }
-        .onTimer(every: .minute1) {
             await model.fetch()
         }
         .listSectionSpacing(.compact)

--- a/Features/MarketInsight/Sources/Scenes/ChartScene.swift
+++ b/Features/MarketInsight/Sources/Scenes/ChartScene.swift
@@ -12,7 +12,6 @@ import PrimitivesComponents
 import Localization
 
 public struct ChartScene: View {
-    private let fetchTimer = Timer.publish(every: 60, tolerance: 1, on: .main, in: .common).autoconnect()
     @State private var model: ChartSceneViewModel
 
     public init(model: ChartSceneViewModel) {
@@ -93,10 +92,8 @@ public struct ChartScene: View {
         .task {
             await model.fetch()
         }
-        .onReceive(fetchTimer) { time in
-            Task {
-                await model.fetch()
-            }
+        .onTimer(every: .minute1) {
+            await model.fetch()
         }
         .listSectionSpacing(.compact)
         .navigationTitle(model.title)

--- a/Features/Perpetuals/Sources/Scenes/PerpetualPortfolioScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualPortfolioScene.swift
@@ -7,7 +7,6 @@ import Style
 import PrimitivesComponents
 
 struct PerpetualPortfolioScene: View {
-    private let fetchTimer = Timer.publish(every: 60, tolerance: 1, on: .main, in: .common).autoconnect()
     @State private var model: PerpetualPortfolioSceneViewModel
 
     init(model: PerpetualPortfolioSceneViewModel) {
@@ -57,10 +56,8 @@ struct PerpetualPortfolioScene: View {
             .refreshable {
                 await model.fetch()
             }
-            .onReceive(fetchTimer) { _ in
-                Task {
-                    await model.fetch()
-                }
+            .onTimer(every: .minute1) {
+                await model.fetch()
             }
             .listSectionSpacing(.compact)
         }

--- a/Features/Perpetuals/Sources/Scenes/PerpetualPortfolioScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualPortfolioScene.swift
@@ -53,10 +53,7 @@ struct PerpetualPortfolioScene: View {
             .task {
                 await model.fetch()
             }
-            .refreshable {
-                await model.fetch()
-            }
-            .onTimer(every: .minute1) {
+            .refreshableTimer(every: .minutes(1)) {
                 await model.fetch()
             }
             .listSectionSpacing(.compact)

--- a/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
@@ -50,10 +50,7 @@ struct PerpetualsScene: View {
         .onDisappear {
             Task { await model.onDisappear() }
         }
-        .refreshable {
-            await model.fetch()
-        }
-        .onTimer(every: .minute1) {
+        .refreshableTimer(every: .minutes(1)) {
             await model.fetch()
         }
         .listSectionSpacing(.compact)

--- a/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualsScene.swift
@@ -53,6 +53,9 @@ struct PerpetualsScene: View {
         .refreshable {
             await model.fetch()
         }
+        .onTimer(every: .minute1) {
+            await model.fetch()
+        }
         .listSectionSpacing(.compact)
         .sheet(isPresented: $model.isPresentingRecents) {
             RecentsScene(

--- a/Features/Settings/Sources/ChainSettings/ViewModels/AddNodeSceneViewModel.swift
+++ b/Features/Settings/Sources/ChainSettings/ViewModels/AddNodeSceneViewModel.swift
@@ -23,7 +23,7 @@ final class AddNodeSceneViewModel {
     var state: StateViewType<AddNodeResultViewModel> = .noData
     var isPresentingScanner: Bool = false
     var isPresentingAlertMessage: AlertMessage?
-    var debounceInterval: Duration? = .milliseconds(250)
+    var debounceInterval: Duration? = .Debounce.normal
 
     init(chain: Chain, nodeService: NodeService) {
         self.chain = chain
@@ -59,7 +59,7 @@ final class AddNodeSceneViewModel {
 
 extension AddNodeSceneViewModel {
     func onChangeInput(_ text: String) async {
-        debounceInterval = .milliseconds(250)
+        debounceInterval = .Debounce.normal
 
         guard text.isNotEmpty, urlInputModel.isValid else {
             state = .noData

--- a/Features/Swap/Sources/Scenes/SwapScene.swift
+++ b/Features/Swap/Sources/Scenes/SwapScene.swift
@@ -10,9 +10,6 @@ public struct SwapScene: View {
 
     @State private var model: SwapSceneViewModel
 
-    // Update quote every 30 seconds, needed if you come back from the background.
-    private let updateQuoteTimer = Timer.publish(every: 30, tolerance: 1, on: .main, in: .common).autoconnect()
-
     public init(model: SwapSceneViewModel) {
         _model = State(initialValue: model)
     }
@@ -83,8 +80,8 @@ public struct SwapScene: View {
         .onChange(of: model.amountInputModel.text, model.onChangeFromValue)
         .onChange(of: model.pairSelectorModel, model.onChangePair)
         .onChange(of: model.selectedSwapQuote, model.onChangeSwapQuoute)
-        .onReceive(updateQuoteTimer) { _ in // TODO: - create a view modifier with a timer
-            model.fetch()
+        .onTimer(every: .seconds30) {
+            await model.fetch()
         }
         .onAppear {
             focusedField = true

--- a/Features/Swap/Sources/Scenes/SwapScene.swift
+++ b/Features/Swap/Sources/Scenes/SwapScene.swift
@@ -80,7 +80,7 @@ public struct SwapScene: View {
         .onChange(of: model.amountInputModel.text, model.onChangeFromValue)
         .onChange(of: model.pairSelectorModel, model.onChangePair)
         .onChange(of: model.selectedSwapQuote, model.onChangeSwapQuoute)
-        .onTimer(every: .seconds30) {
+        .onTimer(every: .seconds(30)) {
             await model.fetch()
         }
         .onAppear {

--- a/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
+++ b/Features/Swap/Sources/ViewModels/SwapSceneViewModel.swift
@@ -21,7 +21,7 @@ import Validators
 @Observable
 public final class SwapSceneViewModel {
     static let inputPercentSuggestions = [25, 50, 100].map { PercentageSuggestion(value: $0) }
-    static let quoteTaskDebounceTimeout = Duration.milliseconds(150)
+    static let quoteTaskDebounceTimeout: Duration = .Debounce.fast
 
     public let wallet: Wallet
     public let walletsService: WalletsService

--- a/Features/Transactions/Sources/Scenes/TransactionsScene.swift
+++ b/Features/Transactions/Sources/Scenes/TransactionsScene.swift
@@ -38,5 +38,8 @@ public struct TransactionsScene: View {
             }
         }
         .task { await model.fetch() }
+        .onTimer(every: .minutes5) {
+            await model.fetch()
+        }
     }
 }

--- a/Features/Transactions/Sources/Scenes/TransactionsScene.swift
+++ b/Features/Transactions/Sources/Scenes/TransactionsScene.swift
@@ -28,7 +28,9 @@ public struct TransactionsScene: View {
             }
             .listSectionSpacing(.compact)
             .scrollContentBackground(.hidden)
-            .refreshable(action: model.fetch)
+            .refreshableTimer(every: .minutes(5)) {
+                await model.fetch()
+            }
         }
         .background { Colors.insetGroupedListStyle.ignoresSafeArea() }
         .overlay {
@@ -38,8 +40,5 @@ public struct TransactionsScene: View {
             }
         }
         .task { await model.fetch() }
-        .onTimer(every: .minutes5) {
-            await model.fetch()
-        }
     }
 }

--- a/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
+++ b/Features/WalletTab/Sources/Scenes/WalletSearchScene.swift
@@ -48,7 +48,7 @@ public struct WalletSearchScene: View {
         .autocorrectionDisabled(true)
         .debounce(
             value: $model.searchModel.searchableQuery.wrappedValue,
-            interval: Duration.milliseconds(250),
+            interval: .Debounce.normal,
             action: model.onSearch(query:)
         )
         .onChange(of: model.searchModel.searchableQuery, model.onChangeSearchQuery)

--- a/Packages/Components/Sources/Interval.swift
+++ b/Packages/Components/Sources/Interval.swift
@@ -1,0 +1,36 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+
+public typealias Interval = TimeInterval
+
+public extension Interval {
+    /// 30s
+    static let seconds30: Interval = 30
+    /// 60s
+    static let minute1: Interval = 60
+    /// 300s
+    static let minutes5: Interval = 300
+
+    struct AnimationDuration {
+        /// 0.15s
+        public static let fast: Interval = 0.15
+        /// 0.2s
+        public static let normal: Interval = 0.2
+        /// 0.5s
+        public static let slow: Interval = 0.5
+        /// 1.8s
+        public static let verySlow: Interval = 1.8
+    }
+}
+
+public extension Duration {
+    struct Debounce {
+        /// 150ms
+        public static let fast: Duration = .milliseconds(150)
+        /// 250ms
+        public static let normal: Duration = .milliseconds(250)
+        /// 1s
+        public static let slow: Duration = .seconds(1)
+    }
+}

--- a/Packages/Components/Sources/Interval.swift
+++ b/Packages/Components/Sources/Interval.swift
@@ -5,12 +5,8 @@ import Foundation
 public typealias Interval = TimeInterval
 
 public extension Interval {
-    /// 30s
-    static let seconds30: Interval = 30
-    /// 60s
-    static let minute1: Interval = 60
-    /// 300s
-    static let minutes5: Interval = 300
+    static func seconds(_ value: Int) -> Interval { Interval(value) }
+    static func minutes(_ value: Int) -> Interval { Interval(value) * 60 }
 
     struct AnimationDuration {
         /// 0.15s

--- a/Packages/Components/Sources/TextFields/FloatTextField.swift
+++ b/Packages/Components/Sources/TextFields/FloatTextField.swift
@@ -120,13 +120,13 @@ extension FloatTextField {
             .lineLimit(1)
             .scaleEffect(text.isEmpty ? 1 : style.placeholderScale, anchor: .leading)
             .offset(y: text.isEmpty ? .zero : -.space10)
-            .animation(.smooth(duration: 0.15), value: text.isEmpty)
+            .animation(.smooth(duration: .AnimationDuration.fast), value: text.isEmpty)
     }
 
     private var textField: some View {
         TextField("", text: $text)
             .offset(y: text.isEmpty ? .zero : .space10)
-            .animation(.smooth(duration: 0.15), value: text.isEmpty)
+            .animation(.smooth(duration: .AnimationDuration.fast), value: text.isEmpty)
     }
 
     private var trailingContent: some View {

--- a/Packages/Components/Sources/ViewModifiers/ActivityIndicatorModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/ActivityIndicatorModifier.swift
@@ -46,7 +46,7 @@ private struct ActivityIndicatorOverlay: ViewModifier {
                     }
                 }
             }
-            .animation(.easeInOut(duration: 0.2), value: isLoading)
+            .animation(.easeInOut(duration: .AnimationDuration.normal), value: isLoading)
     }
 }
 

--- a/Packages/Components/Sources/ViewModifiers/DebouncedTaskModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/DebouncedTaskModifier.swift
@@ -22,7 +22,7 @@ struct DebouncedTaskModifier<T: DebouncableTrigger>: ViewModifier {
 public extension View {
     func debouncedTask<T: DebouncableTrigger>(
         id trigger: T,
-        interval: Duration = .milliseconds(250),
+        interval: Duration = .Debounce.normal,
         action: @Sendable @escaping () async -> Void
     ) -> some View {
         modifier(

--- a/Packages/Components/Sources/ViewModifiers/RefreshableTimerModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/RefreshableTimerModifier.swift
@@ -2,13 +2,19 @@
 
 import SwiftUI
 
-private struct TimerModifier: ViewModifier {
+private struct RefreshableTimerModifier: ViewModifier {
     let interval: TimeInterval
     let action: @Sendable () async -> Void
 
+    @State private var trigger = 0
+
     func body(content: Content) -> some View {
         content
-            .task {
+            .refreshable {
+                trigger += 1
+                await action()
+            }
+            .task(id: trigger) {
                 while !Task.isCancelled {
                     try? await Task.sleep(for: .seconds(interval))
                     guard !Task.isCancelled else { break }
@@ -19,7 +25,7 @@ private struct TimerModifier: ViewModifier {
 }
 
 public extension View {
-    func onTimer(every interval: TimeInterval, action: @Sendable @escaping () async -> Void) -> some View {
-        modifier(TimerModifier(interval: interval, action: action))
+    func refreshableTimer(every interval: TimeInterval, action: @Sendable @escaping () async -> Void) -> some View {
+        modifier(RefreshableTimerModifier(interval: interval, action: action))
     }
 }

--- a/Packages/Components/Sources/ViewModifiers/TimerModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/TimerModifier.swift
@@ -1,0 +1,29 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Combine
+import SwiftUI
+
+private struct TimerModifier: ViewModifier {
+    private let timer: Publishers.Autoconnect<Timer.TimerPublisher>
+    private let action: @Sendable () async -> Void
+
+    init(every interval: TimeInterval, tolerance: TimeInterval, action: @Sendable @escaping () async -> Void) {
+        self.timer = Timer.publish(every: interval, tolerance: tolerance, on: .main, in: .common).autoconnect()
+        self.action = action
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .onReceive(timer) { _ in
+                Task {
+                    await action()
+                }
+            }
+    }
+}
+
+public extension View {
+    func onTimer(every interval: TimeInterval, tolerance: TimeInterval = 1, action: @Sendable @escaping () async -> Void) -> some View {
+        modifier(TimerModifier(every: interval, tolerance: tolerance, action: action))
+    }
+}

--- a/Packages/PrimitivesComponents/Sources/Views/ChartView.swift
+++ b/Packages/PrimitivesComponents/Sources/Views/ChartView.swift
@@ -114,7 +114,7 @@ extension ChartView {
                     PulsingDotView(color: model.lineColor)
                         .position(x: origin.x + xPos, y: origin.y + yPos)
                         .opacity(selectedValue == nil ? 1 : 0)
-                        .animation(.easeInOut(duration: 0.2), value: selectedValue == nil)
+                        .animation(.easeInOut(duration: .AnimationDuration.normal), value: selectedValue == nil)
                 }
             }
         }

--- a/Packages/PrimitivesComponents/Sources/Views/NameRecordView.swift
+++ b/Packages/PrimitivesComponents/Sources/Views/NameRecordView.swift
@@ -11,7 +11,7 @@ public struct NameRecordView: View {
 
     @Binding var state: NameRecordState
     @Binding var address: String
-    let debounceTimeout = Duration.seconds(1)
+    let debounceTimeout: Duration = .Debounce.slow
 
     @State var nameResolveTask: Task<NameRecord, any Error>?
 

--- a/Packages/PrimitivesComponents/Sources/Views/PulsingDotView.swift
+++ b/Packages/PrimitivesComponents/Sources/Views/PulsingDotView.swift
@@ -65,7 +65,7 @@ private struct PulseRingView: View {
     let delay: Double
     let isAnimated: Bool
 
-    private let duration: Double = 1.8
+    private let duration: Double = .AnimationDuration.verySlow
 
     var body: some View {
         TimelineView(.animation(paused: !isAnimated)) { timeline in


### PR DESCRIPTION
## Summary
- Modernize `TimerModifier` — replace Combine `Timer.publish`/`onReceive` with `Task.sleep` loop (structured concurrency, auto-cancellation)
- Add `RefreshableTimerModifier` (`.refreshableTimer(every:action:)`) — combines `.refreshable` + resettable timer: pull-to-refresh resets the countdown, preventing redundant fetches
- Replace `Interval` constants (`seconds30`, `minute1`, `minutes5`) with functions (`seconds(_:)`, `minutes(_:)`)
- Migrate 5 scenes from separate `.refreshable` + `.onTimer` → `.refreshableTimer`: AssetScene, ChartScene, PerpetualPortfolioScene, PerpetualsScene, TransactionsScene

Close: https://github.com/gemwalletcom/gem-ios/issues/1666