### PR TITLE
Fix price alert toast visibility and locale-aware price suggestions

### DIFF
--- a/Features/PriceAlerts/Sources/Types/PriceSuggestion.swift
+++ b/Features/PriceAlerts/Sources/Types/PriceSuggestion.swift
@@ -5,8 +5,10 @@ import PrimitivesComponents
 
 struct PriceSuggestion: SuggestionViewable {
     let title: String
-    let value: String
+    let value: Double
 
-    var inputValue: String { value }
-    var id: String { title + value }
+    var inputValue: String {
+        value.formatted(.number.grouping(.never))
+    }
+    var id: String { "\(title)_\(inputValue)" }
 }

--- a/Features/PriceAlerts/Sources/ViewModels/SetPriceAlertViewModel.swift
+++ b/Features/PriceAlerts/Sources/ViewModels/SetPriceAlertViewModel.swift
@@ -59,7 +59,7 @@ public final class SetPriceAlertViewModel {
         return roundingFormatter.roundedValues(for: currentPrice, byPercent: priceSuggestionPercent).map { value in
             PriceSuggestion(
                 title: currencyFormatter.string(value),
-                value: String(value)
+                value: value
             )
         }
     }

--- a/Features/PriceAlerts/Tests/PriceAlertsTests/PriceSuggestionTests.swift
+++ b/Features/PriceAlerts/Tests/PriceAlertsTests/PriceSuggestionTests.swift
@@ -1,0 +1,14 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+
+@testable import PriceAlerts
+
+struct PriceSuggestionTests {
+
+    @Test
+    func inputValue() {
+        #expect(PriceSuggestion(title: "", value: 67000.0).inputValue == "67000")
+        #expect(PriceSuggestion(title: "", value: 0.3).inputValue == "0.3")
+    }
+}

--- a/Gem/Navigation/Wallet/WalletNavigationStack.swift
+++ b/Gem/Navigation/Wallet/WalletNavigationStack.swift
@@ -230,8 +230,8 @@ struct WalletNavigationStack: View {
                 )
             }
             .safariSheet(url: $model.isPresentingUrl)
-            .toast(message: $model.isPresentingToastMessage)
         }
+        .toast(message: $model.isPresentingToastMessage)
     }
 
     private func onSelectAsset(asset: Asset) {


### PR DESCRIPTION
Move toast modifier outside NavigationStack so it renders above pushed screens. Change PriceSuggestion.value to Double and format inputValue with locale-aware number formatting to avoid wrong decimal separators.

Close: https://github.com/gemwalletcom/gem-ios/issues/1677