### PR TITLE
Add ChainServiceFactorable protocol and mock for tests

### DIFF
--- a/Features/Transfer/Sources/Services/ConfirmServiceFactory.swift
+++ b/Features/Transfer/Sources/Services/ConfirmServiceFactory.swift
@@ -18,7 +18,7 @@ import EventPresenterService
 public struct ConfirmServiceFactory {
     public static func create(
         keystore: any Keystore,
-        chainServiceFactory: ChainServiceFactory,
+        chainServiceFactory: any ChainServiceFactorable,
         walletsService: WalletsService,
         scanService: ScanService,
         balanceService: BalanceService,

--- a/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
+++ b/Features/Transfer/Tests/ViewModels/ConfirmTransferSceneViewModelTests.swift
@@ -16,6 +16,7 @@ import TransactionStateServiceTestKit
 import NodeServiceTestKit
 import NodeService
 import ChainService
+import ChainServiceTestKit
 import Localization
 import AddressNameService
 import AddressNameServiceTestKit
@@ -338,7 +339,7 @@ private extension ConfirmTransferSceneViewModel {
             data: data,
             confirmService: ConfirmServiceFactory.create(
                 keystore: KeystoreMock(),
-                chainServiceFactory: ChainServiceFactory(nodeProvider: NodeService.mock()),
+                chainServiceFactory: ChainServiceFactoryMock(),
                 walletsService: .mock(),
                 scanService: .mock(),
                 balanceService: .mock(),

--- a/Packages/ChainServices/ChainService/AddTokenService.swift
+++ b/Packages/ChainServices/ChainService/AddTokenService.swift
@@ -4,10 +4,10 @@ import Foundation
 import Primitives
 
 public struct AddTokenService: Sendable {
-    private let chainServiceFactory: ChainServiceFactory
+    private let chainServiceFactory: any ChainServiceFactorable
     
     public init(
-        chainServiceFactory: ChainServiceFactory
+        chainServiceFactory: any ChainServiceFactorable
     ) {
         self.chainServiceFactory = chainServiceFactory
     }

--- a/Packages/ChainServices/ChainService/AddressStatusService.swift
+++ b/Packages/ChainServices/ChainService/AddressStatusService.swift
@@ -6,11 +6,11 @@ import Blockchain
 
 public struct AddressStatusService: Sendable {
     
-    private let chainServiceFactory: ChainServiceFactory
+    private let chainServiceFactory: any ChainServiceFactorable
     private let chains: [Chain] = [.tron]
 
     public init(
-        chainServiceFactory: ChainServiceFactory
+        chainServiceFactory: any ChainServiceFactorable
     ) {
         self.chainServiceFactory = chainServiceFactory 
     }

--- a/Packages/ChainServices/ChainService/ChainServiceFactory.swift
+++ b/Packages/ChainServices/ChainService/ChainServiceFactory.swift
@@ -4,7 +4,12 @@ import Foundation
 import Primitives
 import Blockchain
 
-public final class ChainServiceFactory: Sendable {
+public protocol ChainServiceFactorable: Sendable {
+    var requestInterceptor: any RequestInterceptable { get }
+    func service(for chain: Chain) -> any ChainServiceable
+}
+
+public final class ChainServiceFactory: ChainServiceFactorable, Sendable {
 
     private let nodeProvider: any NodeURLFetchable
 

--- a/Packages/ChainServices/ChainService/TestKit/AddressStatusService+TestKit.swift
+++ b/Packages/ChainServices/ChainService/TestKit/AddressStatusService+TestKit.swift
@@ -5,7 +5,7 @@ import ChainService
 
 public extension AddressStatusService {
     static func mock(
-        chainServiceFactory: ChainServiceFactory = .mock()
+        chainServiceFactory: any ChainServiceFactorable = ChainServiceFactoryMock()
     ) -> AddressStatusService {
         AddressStatusService(chainServiceFactory: chainServiceFactory)
     }

--- a/Packages/ChainServices/ChainService/TestKit/ChainServiceFactoryMock.swift
+++ b/Packages/ChainServices/ChainService/TestKit/ChainServiceFactoryMock.swift
@@ -1,0 +1,24 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import ChainService
+import Primitives
+import Blockchain
+import BlockchainTestKit
+
+public final class ChainServiceFactoryMock: ChainServiceFactorable, Sendable {
+
+    private let chainService: any ChainServiceable
+
+    public var requestInterceptor: any RequestInterceptable {
+        EmptyRequestInterceptor()
+    }
+
+    public init(chainService: any ChainServiceable = ChainServiceMock()) {
+        self.chainService = chainService
+    }
+
+    public func service(for chain: Chain) -> any ChainServiceable {
+        chainService
+    }
+}

--- a/Packages/ChainServices/Package.swift
+++ b/Packages/ChainServices/Package.swift
@@ -165,6 +165,7 @@ let package = Package(
                 "Primitives",
                 .product(name: "PrimitivesTestKit", package: "Primitives"),
                 "Blockchain",
+                .product(name: "BlockchainTestKit", package: "Blockchain"),
             ],
             path: "ChainService/TestKit"
         ),

--- a/Packages/ChainServices/StakeService/StakeService.swift
+++ b/Packages/ChainServices/StakeService/StakeService.swift
@@ -10,13 +10,13 @@ import Blockchain
 public struct StakeService: StakeServiceable {
     private let store: StakeStore
     private let addressStore: AddressStore
-    private let chainServiceFactory: ChainServiceFactory
+    private let chainServiceFactory: any ChainServiceFactorable
     private let assetsService: GemAPIStaticService
     
     public init(
         store: StakeStore,
         addressStore: AddressStore,
-        chainServiceFactory: ChainServiceFactory,
+        chainServiceFactory: any ChainServiceFactorable,
         assetsService: GemAPIStaticService = GemAPIStaticService()
     ) {
         self.store = store

--- a/Packages/ChainServices/StakeService/TestKit/StakeService+TestKit.swift
+++ b/Packages/ChainServices/StakeService/TestKit/StakeService+TestKit.swift
@@ -12,7 +12,7 @@ public extension StakeService {
     static func mock(
         store: StakeStore = .mock(),
         addressStore: AddressStore = .mock(),
-        chainServiceFactory: ChainServiceFactory = .mock(),
+        chainServiceFactory: any ChainServiceFactorable = ChainServiceFactoryMock(),
         assetsService: GemAPIStaticService = GemAPIStaticService()
     ) -> Self {
         StakeService(

--- a/Packages/FeatureServices/AssetsService/AssetsService.swift
+++ b/Packages/FeatureServices/AssetsService/AssetsService.swift
@@ -9,12 +9,12 @@ public final class AssetsService: Sendable {
     public let assetStore: AssetStore
     let balanceStore: BalanceStore
     let assetsProvider: any GemAPIAssetsService
-    let chainServiceFactory: ChainServiceFactory
+    let chainServiceFactory: any ChainServiceFactorable
 
     public init(
         assetStore: AssetStore,
         balanceStore: BalanceStore,
-        chainServiceFactory: ChainServiceFactory,
+        chainServiceFactory: any ChainServiceFactorable,
         assetsProvider: any GemAPIAssetsService = GemAPIService.shared
     ) {
         self.assetStore = assetStore

--- a/Packages/FeatureServices/AssetsService/TestKit/AssetsService+TestKit.swift
+++ b/Packages/FeatureServices/AssetsService/TestKit/AssetsService+TestKit.swift
@@ -14,7 +14,7 @@ extension AssetsService {
     public static func mock(
         assetStore: AssetStore = .mock(),
         balanceStore: BalanceStore = .mock(),
-        chainServiceFactory: ChainServiceFactory = .mock(),
+        chainServiceFactory: any ChainServiceFactorable = ChainServiceFactoryMock(),
         assetsProvider: any GemAPIAssetsService = GemAPIAssetsServiceMock()
     ) -> AssetsService {
         AssetsService(

--- a/Packages/FeatureServices/BalanceService/BalanceFetcher.swift
+++ b/Packages/FeatureServices/BalanceService/BalanceFetcher.swift
@@ -5,9 +5,9 @@ import ChainService
 import Primitives
 
 struct BalanceFetcher: Sendable {
-    private let chainServiceFactory: ChainServiceFactory
+    private let chainServiceFactory: any ChainServiceFactorable
     
-    init(chainServiceFactory: ChainServiceFactory) {
+    init(chainServiceFactory: any ChainServiceFactorable) {
         self.chainServiceFactory = chainServiceFactory
     }
     

--- a/Packages/FeatureServices/BalanceService/BalanceService.swift
+++ b/Packages/FeatureServices/BalanceService/BalanceService.swift
@@ -16,7 +16,7 @@ public struct BalanceService: BalancerUpdater, Sendable {
     public init(
         balanceStore: BalanceStore,
         assetsService: AssetsService,
-        chainServiceFactory: ChainServiceFactory
+        chainServiceFactory: any ChainServiceFactorable
     ) {
         self.balanceStore = balanceStore
         self.assetsService = assetsService

--- a/Packages/FeatureServices/BalanceService/TestKit/BalanceService+TestKit.swift
+++ b/Packages/FeatureServices/BalanceService/TestKit/BalanceService+TestKit.swift
@@ -13,7 +13,7 @@ public extension BalanceService {
     static func mock(
         balanceStore: BalanceStore = .mock(),
         assetsService: AssetsService = .mock(),
-        chainServiceFactory: ChainServiceFactory = .mock()
+        chainServiceFactory: any ChainServiceFactorable = ChainServiceFactoryMock()
     ) -> BalanceService {
         BalanceService(
             balanceStore: balanceStore,

--- a/Packages/FeatureServices/PriceService/PriceObserverService.swift
+++ b/Packages/FeatureServices/PriceService/PriceObserverService.swift
@@ -32,6 +32,18 @@ public actor PriceObserverService: Sendable {
         self.webSocket = WebSocketConnection(configuration: configuration)
     }
 
+    public init(
+        priceService: PriceService,
+        preferences: Preferences,
+        securePreferences: SecurePreferences = SecurePreferences(),
+        webSocket: any WebSocketConnectable
+    ) {
+        self.priceService = priceService
+        self.preferences = preferences
+        self.securePreferences = securePreferences
+        self.webSocket = webSocket
+    }
+
     deinit {
         observeTask?.cancel()
     }

--- a/Packages/FeatureServices/PriceService/TestKit/PriceObserverService+TestKit.swift
+++ b/Packages/FeatureServices/PriceService/TestKit/PriceObserverService+TestKit.swift
@@ -4,16 +4,19 @@ import Foundation
 import PriceService
 import Preferences
 import PreferencesTestKit
+import WebSocketClient
 import WebSocketClientTestKit
 
 public extension PriceObserverService {
     static func mock(
         priceService: PriceService = .mock(),
-        preferences: Preferences = .mock()
+        preferences: Preferences = .mock(),
+        webSocket: any WebSocketConnectable = WebSocketConnectionMock()
     ) -> PriceObserverService {
         PriceObserverService(
             priceService: priceService,
-            preferences: preferences
+            preferences: preferences,
+            webSocket: webSocket
         )
     }
 }

--- a/Packages/FeatureServices/TransactionStateService/TestKit/TransactionStateService+TestKit.swift
+++ b/Packages/FeatureServices/TransactionStateService/TestKit/TransactionStateService+TestKit.swift
@@ -18,7 +18,7 @@ public extension TransactionStateService {
         transactionStore: TransactionStore = .mock(),
         stakeService: StakeService = .mock(),
         nftService: NFTService = .mock(),
-        chainServiceFactory: ChainServiceFactory = .mock()
+        chainServiceFactory: any ChainServiceFactorable = ChainServiceFactoryMock()
     ) -> TransactionStateService {
         TransactionStateService(
             transactionStore: transactionStore,

--- a/Packages/FeatureServices/TransactionStateService/TransactionStateProvider.swift
+++ b/Packages/FeatureServices/TransactionStateService/TransactionStateProvider.swift
@@ -8,11 +8,11 @@ import Blockchain
 
 struct TransactionStateProvider: Sendable {
     private let transactionStore: TransactionStore
-    private let chainServiceFactory: ChainServiceFactory
+    private let chainServiceFactory: any ChainServiceFactorable
 
     init(
         transactionStore: TransactionStore,
-        chainServiceFactory: ChainServiceFactory
+        chainServiceFactory: any ChainServiceFactorable
     ) {
         self.transactionStore = transactionStore
         self.chainServiceFactory = chainServiceFactory

--- a/Packages/FeatureServices/TransactionStateService/TransactionStateService.swift
+++ b/Packages/FeatureServices/TransactionStateService/TransactionStateService.swift
@@ -18,7 +18,7 @@ public struct TransactionStateService: Sendable {
         transactionStore: TransactionStore,
         stakeService: StakeService,
         nftService: NFTService,
-        chainServiceFactory: ChainServiceFactory,
+        chainServiceFactory: any ChainServiceFactorable,
         balanceUpdater: any BalancerUpdater
     ) {
         self.transactionStore = transactionStore


### PR DESCRIPTION
- Extract ChainServiceFactorable protocol from ChainServiceFactory
- Add ChainServiceFactoryMock using ChainServiceMock to prevent network requests in tests
- Update all TestKit mocks to use ChainServiceFactoryMock
- Add WebSocket dependency injection to PriceObserverService