### PR TITLE
Refactor swap min amount: move action to main button

### DIFF
--- a/Features/Swap/Sources/Scenes/SwapScene.swift
+++ b/Features/Swap/Sources/Scenes/SwapScene.swift
@@ -29,10 +29,6 @@ public struct SwapScene: View {
                         error: error.asAnyError(asset: model.fromAsset?.asset),
                         infoAction: model.errorInfoAction
                     )
-                    if let title = model.errorInfoActionButtonTitle, let action = model.errorInfoAction {
-                        Button(title, action: action)
-                            .foregroundStyle(Colors.blue)
-                    }
                 }
             }
         }

--- a/Features/Swap/Sources/ViewModels/SwapButtonViewModel.swift
+++ b/Features/Swap/Sources/ViewModels/SwapButtonViewModel.swift
@@ -8,11 +8,13 @@ import Primitives
 import SwiftUI
 import PrimitivesComponents
 import struct Gemstone.SwapperQuote
+import enum Gemstone.SwapperError
 
 enum SwapButtonAction: Equatable {
     case retryQuotes
     case retrySwap
     case insufficientBalance(asset: Asset)
+    case useMinAmount(amount: String, asset: Asset)
     case swap
 }
 
@@ -39,11 +41,13 @@ struct SwapButtonViewModel: StateButtonViewable {
         switch buttonAction {
         case .retryQuotes, .retrySwap: Localized.Common.tryAgain
         case .insufficientBalance(let asset): Localized.Transfer.insufficientBalance(asset.symbol)
+        case .useMinAmount: Localized.Swap.useMinimumAmount
         case .swap: Localized.Wallet.swap
         }
     }
 
     var buttonAction: SwapButtonAction {
+        if let useMinAmount { return useMinAmount }
         if canRetryQuotes { return .retryQuotes }
         if canRetrySwap { return .retrySwap }
         if !isAmountValid, let fromAsset { return .insufficientBalance(asset: fromAsset.asset) }
@@ -55,6 +59,7 @@ struct SwapButtonViewModel: StateButtonViewable {
         switch buttonAction {
         case .retryQuotes: swapState.quotes.isLoading ? .primary(swapState.quotes) : .primary(.normal)
         case .insufficientBalance: .primary(.disabled)
+        case .useMinAmount: .primary(.normal)
         case .retrySwap: swapState.swapTransferData.isLoading ? .primary(swapState.swapTransferData) : .primary(.normal)
         case .swap: swapState.swapTransferData.isLoading ? .primary(swapState.swapTransferData) : .primary(swapState.quotes)
         }
@@ -67,6 +72,14 @@ struct SwapButtonViewModel: StateButtonViewable {
 // MARK: - Private
 
 extension SwapButtonViewModel {
+    private var useMinAmount: SwapButtonAction? {
+        guard case .error(let error) = swapState.quotes,
+              case .InputAmountError(let amount) = error as? SwapperError,
+              let amount,
+              let fromAsset else { return nil }
+        return .useMinAmount(amount: amount, asset: fromAsset.asset)
+    }
+
     private var canRetryQuotes: Bool {
         guard case .error(let error) = swapState.quotes,
               let retryableError = error as? RetryableError else { return false }

--- a/Features/Swap/Tests/SwapTests/SwapSceneViewModelTests.swift
+++ b/Features/Swap/Tests/SwapTests/SwapSceneViewModelTests.swift
@@ -47,6 +47,9 @@ struct SwapSceneViewModelTests {
         model.swapState.quotes = .error(TestError())
         #expect(model.buttonViewModel.buttonAction == SwapButtonAction.retryQuotes)
 
+        model.swapState.quotes = .error(SwapperError.InputAmountError(minAmount: "1000"))
+        #expect(model.buttonViewModel.buttonAction == SwapButtonAction.useMinAmount(amount: "1000", asset: .mockEthereum()))
+
         model.swapState.quotes = .data([])
         model.swapState.swapTransferData = .error(TestError())
         #expect(model.buttonViewModel.buttonAction == SwapButtonAction.retrySwap)
@@ -121,7 +124,7 @@ struct SwapSceneViewModelTests {
 
         model.fetchTrigger = nil
         model.swapState.quotes = .error(SwapperError.InputAmountError(minAmount: "1000000000000000000"))
-        model.errorInfoAction?()
+        model.buttonViewModel.action()
 
         #expect(model.fetchTrigger?.isImmediate == true)
     }


### PR DESCRIPTION
  - Add useMinAmount case to SwapButtonAction
  - Main button shows "Use Minimum Amount" and becomes active on InputAmountError
  - Remove separate button from error section
  - Update errorInfoAction to only handle NoQuoteAvailable
  
  
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-02-17 at 01 07 29" src="https://github.com/user-attachments/assets/6cd0952a-884b-4299-bf2c-7af414176b27" />
