### PR TITLE
Fix zero balances for discovered assets

### DIFF
--- a/Packages/FeatureServices/WalletsService/AssetsEnablerService.swift
+++ b/Packages/FeatureServices/WalletsService/AssetsEnablerService.swift
@@ -19,14 +19,14 @@ struct AssetsEnablerService: AssetsEnabler {
         self.priceUpdater = priceUpdater
     }
 
-    func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool, shouldRefresh: Bool) async throws {
+    func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool) async throws {
         for assetId in assetIds {
             try assetsService.addBalanceIfMissing(walletId: walletId, assetId: assetId)
         }
 
         try assetsService.updateEnabled(walletId: walletId, assetIds: assetIds, enabled: enabled)
 
-        guard enabled, shouldRefresh else { return }
+        guard enabled else { return }
 
         async let balanceUpdate: () = balanceUpdater.updateBalance(for: walletId, assetIds: assetIds)
         async let priceUpdate: () = priceUpdater.addPrices(assetIds: assetIds)
@@ -35,6 +35,6 @@ struct AssetsEnablerService: AssetsEnabler {
 
     func enableAssetId(walletId: WalletId, assetId: AssetId) async throws {
         let asset = try await assetsService.getOrFetchAsset(for: assetId)
-        try await enableAssets(walletId: walletId, assetIds: [asset.id], enabled: true, shouldRefresh: true)
+        try await enableAssets(walletId: walletId, assetIds: [asset.id], enabled: true)
     }
 }

--- a/Packages/FeatureServices/WalletsService/Protocols/AssetsEnabler.swift
+++ b/Packages/FeatureServices/WalletsService/Protocols/AssetsEnabler.swift
@@ -4,12 +4,6 @@ import Foundation
 import Primitives
 
 public protocol AssetsEnabler: Sendable {
-    func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool, shouldRefresh: Bool) async throws
+    func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool) async throws
     func enableAssetId(walletId: WalletId, assetId: AssetId) async throws
-}
-
-public extension AssetsEnabler {
-    func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool) async throws {
-        try await enableAssets(walletId: walletId, assetIds: assetIds, enabled: enabled, shouldRefresh: true)
-    }
 }

--- a/Packages/FeatureServices/WalletsService/WalletAssetSyncService.swift
+++ b/Packages/FeatureServices/WalletsService/WalletAssetSyncService.swift
@@ -63,12 +63,10 @@ actor WalletAssetSyncService: DiscoveryAssetsProcessing {
 
         if assetIds.isNotEmpty {
             try await assetService.prefetchAssets(assetIds: assetIds)
-            try await addPrices(assetIds: assetIds)
             try await assetsEnabler.enableAssets(
                 walletId: wallet.walletId,
                 assetIds: assetIds,
-                enabled: true,
-                shouldRefresh: false
+                enabled: true
             )
         }
 

--- a/Packages/FeatureServices/WalletsService/WalletsService.swift
+++ b/Packages/FeatureServices/WalletsService/WalletsService.swift
@@ -98,7 +98,9 @@ extension WalletsService: DiscoveryAssetsProcessing {
 // MARK: - AssetsEnabler
 
 extension WalletsService: AssetsEnabler {
-    public func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool, shouldRefresh: Bool) async throws { try await assetsEnabler.enableAssets(walletId: walletId, assetIds: assetIds, enabled: enabled, shouldRefresh: shouldRefresh) }
+    public func enableAssets(walletId: WalletId, assetIds: [AssetId], enabled: Bool) async throws {
+        try await assetsEnabler.enableAssets(walletId: walletId, assetIds: assetIds, enabled: enabled)
+    }
 
     public func enableAssetId(walletId: WalletId, assetId: AssetId) async throws { try await assetsEnabler.enableAssetId(walletId: walletId, assetId: assetId) }
 }


### PR DESCRIPTION
Remove shouldRefresh parameter from AssetsEnabler - always refresh balances and prices when enabling assets. The parameter was introduced to avoid duplicate addPrices calls, but it also skipped balance updates for newly discovered assets (osmosis, ton, injective, etc.).

Changes:
- Remove shouldRefresh from AssetsEnabler protocol and extension
- AssetsEnablerService.enableAssets always updates balances/prices when enabled
- WalletAssetSyncService.discoverAssets uses default enableAssets behavior
- Remove redundant addPrices call before enableAssets

Fix: https://github.com/gemwalletcom/gem-ios/issues/1706