### PR TITLE
Refactor WalletAssetSyncService and remove unused protocol

### DIFF
--- a/Packages/FeatureServices/WalletsService/Protocols/DiscoveryAssetsProcessing.swift
+++ b/Packages/FeatureServices/WalletsService/Protocols/DiscoveryAssetsProcessing.swift
@@ -1,9 +1,0 @@
-// Copyright (c). Gem Wallet. All rights reserved.
-
-import Foundation
-import Primitives
-import Preferences
-
-protocol DiscoveryAssetsProcessing: Sendable {
-    func discoverAssets(for walletId: WalletId, preferences: WalletPreferences) async throws
-}

--- a/Packages/FeatureServices/WalletsService/WalletsService.swift
+++ b/Packages/FeatureServices/WalletsService/WalletsService.swift
@@ -87,14 +87,6 @@ public struct WalletsService: Sendable {
     }
 }
 
-// MARK: - DiscoveryAssetsProcessing
-
-extension WalletsService: DiscoveryAssetsProcessing {
-    func discoverAssets(for walletId: WalletId, preferences: WalletPreferences) async throws {
-        try await assetSyncService.discoverAssets(for: walletId, preferences: preferences)
-    }
-}
-
 // MARK: - AssetsEnabler
 
 extension WalletsService: AssetsEnabler {


### PR DESCRIPTION
Simplify asset sync by inlining discovery logic into fetch(), enabling only additional device assets not already present in the local list.