### PR TITLE
Fix pinned asset from search not appearing on wallet screen

### DIFF
--- a/Features/WalletTab/Tests/WalletSearchSceneViewModelTests.swift
+++ b/Features/WalletTab/Tests/WalletSearchSceneViewModelTests.swift
@@ -4,6 +4,8 @@ import Testing
 import Primitives
 import PrimitivesTestKit
 import PreferencesTestKit
+import BalanceServiceTestKit
+import StoreTestKit
 import WalletTabTestKit
 
 @testable import WalletTab
@@ -46,5 +48,19 @@ struct WalletSearchSceneViewModelTests {
 
         model.searchQuery.value = WalletSearchResult(assets: [], perpetuals: (0..<4).map { _ in .mock() })
         #expect(model.hasMorePerpetuals == true)
+    }
+
+    @Test
+    func pinAssetEnablesAsset() async {
+        let db = DB.mockAssets()
+        let enabledAssetIds: [AssetId] = await withCheckedContinuation { continuation in
+            let model = WalletSearchSceneViewModel.mock(
+                assetsEnabler: .mock(onEnableAssets: { _, assetIds, _ in continuation.resume(returning: assetIds) }),
+                balanceService: .mock(balanceStore: .mock(db: db))
+            )
+            model.onSelectPinAsset(.mock(metadata: .mock(isBalanceEnabled: false, isPinned: false)), value: true)
+        }
+
+        #expect(enabledAssetIds == [AssetId.mock()])
     }
 }

--- a/Packages/FeatureServices/BalanceService/TestKit/AssetsEnablerMock.swift
+++ b/Packages/FeatureServices/BalanceService/TestKit/AssetsEnablerMock.swift
@@ -5,14 +5,23 @@ import Primitives
 import BalanceService
 
 public struct AssetsEnablerMock: AssetsEnabler {
-    public init() {}
+    private let onEnableAssets: (@Sendable (Wallet, [AssetId], Bool) async throws -> Void)?
 
-    public func enableAssets(wallet: Wallet, assetIds: [AssetId], enabled: Bool) async throws {}
+    public init(onEnableAssets: (@Sendable (Wallet, [AssetId], Bool) async throws -> Void)? = nil) {
+        self.onEnableAssets = onEnableAssets
+    }
+
+    public func enableAssets(wallet: Wallet, assetIds: [AssetId], enabled: Bool) async throws {
+        try await onEnableAssets?(wallet, assetIds, enabled)
+    }
+
     public func enableAssetId(wallet: Wallet, assetId: AssetId) async throws {}
 }
 
 public extension AssetsEnabler where Self == AssetsEnablerMock {
-    static func mock() -> AssetsEnablerMock {
-        AssetsEnablerMock()
+    static func mock(
+        onEnableAssets: (@Sendable (Wallet, [AssetId], Bool) async throws -> Void)? = nil
+    ) -> AssetsEnablerMock {
+        AssetsEnablerMock(onEnableAssets: onEnableAssets)
     }
 }


### PR DESCRIPTION
Enable asset when pinning from search if it's not already enabled, matching existing behavior in AssetSceneViewModel.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1731