### PR TITLE
Fix CheckedContinuation double resume crash in WalletConnector

### DIFF
--- a/Features/WalletConnector/Sources/WalletConnector/Types/TransferDataCallback.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Types/TransferDataCallback.swift
@@ -1,6 +1,7 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
+import os
 
 public final class TransferDataCallback<T: Identifiable & Sendable>: Sendable, Identifiable {
     public typealias ConfirmTransferDelegate = @Sendable (Result<String, any Error>) -> Void
@@ -14,8 +15,16 @@ public final class TransferDataCallback<T: Identifiable & Sendable>: Sendable, I
         delegate: @escaping ConfirmTransferDelegate
     ) {
         self.payload = payload
-        self.delegate = delegate
+        let wasCalled = OSAllocatedUnfairLock(initialState: false)
+        self.delegate = { result in
+            let isFirstCall = wasCalled.withLock { wasCalled in
+                defer { wasCalled = true }
+                return !wasCalled
+            }
+            guard isFirstCall else { return }
+            delegate(result)
+        }
     }
-    
+
     public var id: any Hashable { payload.id }
 }

--- a/Features/WalletConnector/Tests/WalletConnectorTests/TransferDataCallbackTests.swift
+++ b/Features/WalletConnector/Tests/WalletConnectorTests/TransferDataCallbackTests.swift
@@ -1,0 +1,26 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Testing
+import Primitives
+import WalletConnectorService
+import WalletConnectorServiceTestKit
+
+@testable import WalletConnector
+
+struct TransferDataCallbackTests {
+
+    typealias DelegateResult = Result<String, any Error>
+
+    @Test
+    func delegateCallsOnce() async {
+        await confirmation(expectedCount: 1) { confirm in
+            let callback = TransferDataCallback(payload: SignMessagePayload.mock()) { result in
+                #expect((try? result.get()) == "first")
+                confirm()
+            }
+            callback.delegate(DelegateResult.success("first"))
+            callback.delegate(DelegateResult.success("second"))
+            callback.delegate(DelegateResult.failure(AnyError("test")))
+        }
+    }
+}

--- a/Packages/ChainServices/WalletConnectorService/TestKit/SignMessagePayload+TestKit.swift
+++ b/Packages/ChainServices/WalletConnectorService/TestKit/SignMessagePayload+TestKit.swift
@@ -1,0 +1,23 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import PrimitivesTestKit
+import WalletConnectorService
+import struct Gemstone.SignMessage
+
+public extension SignMessagePayload {
+    static func mock(
+        chain: Chain = .ethereum,
+        session: WalletConnectionSession = .mock(),
+        wallet: Wallet = .mock(),
+        message: SignMessage = SignMessage(chain: "ethereum", signType: .eip191, data: Data())
+    ) -> SignMessagePayload {
+        SignMessagePayload(
+            chain: chain,
+            session: session,
+            wallet: wallet,
+            message: message
+        )
+    }
+}


### PR DESCRIPTION
Make TransferDataCallback delegate one-shot using OSAllocatedUnfairLock to prevent crash when both success callback and sheet cancellation invoke the continuation.