### PR TITLE
Use Grid and GridItemView in CandleTooltipView

### DIFF
--- a/Features/Perpetuals/Sources/Views/CandleTooltipView.swift
+++ b/Features/Perpetuals/Sources/Views/CandleTooltipView.swift
@@ -8,25 +8,25 @@ struct CandleTooltipView: View {
     let model: CandleTooltipViewModel
 
     var body: some View {
-        VStack(spacing: Spacing.small) {
-            VStack(spacing: Spacing.extraSmall) {
-                ListItemView(title: model.openTitle, subtitle: model.openValue)
-                ListItemView(title: model.highTitle, subtitle: model.highValue)
-                ListItemView(title: model.lowTitle, subtitle: model.lowValue)
-                ListItemView(title: model.closeTitle, subtitle: model.closeValue)
-            }
+        Grid(alignment: .leading, horizontalSpacing: Spacing.small, verticalSpacing: Spacing.extraSmall) {
+            GridItemView(title: model.openTitle, value: model.openValue)
+            GridItemView(title: model.highTitle, value: model.highValue)
+            GridItemView(title: model.lowTitle, value: model.lowValue)
+            GridItemView(title: model.closeTitle, value: model.closeValue)
+
             Divider()
-            VStack(spacing: Spacing.extraSmall) {
-                ListItemView(title: model.changeTitle, subtitle: model.changeValue)
-                ListItemView(title: model.volumeTitle, subtitle: model.volumeValue)
-            }
+                .gridCellColumns(2)
+                .padding(.vertical, Spacing.tiny)
+
+            GridItemView(title: model.changeTitle, value: model.changeValue)
+            GridItemView(title: model.volumeTitle, value: model.volumeValue)
         }
         .padding(Spacing.small)
         .background(.thickMaterial)
         .clipShape(RoundedRectangle(cornerRadius: Spacing.small))
         .overlay(
             RoundedRectangle(cornerRadius: Spacing.small)
-                .stroke(Colors.black.opacity(.opacity8), lineWidth: 1)
+                .stroke(Colors.black.opacity(.opacity8), lineWidth: .space1)
         )
         .shadow(color: .black.opacity(.opacity12), radius: Spacing.small, y: Spacing.tiny)
         .fixedSize()

--- a/Packages/Components/Sources/Lists/GridItemView.swift
+++ b/Packages/Components/Sources/Lists/GridItemView.swift
@@ -1,0 +1,30 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Style
+
+public struct GridItemView: View {
+    private let title: TextValue
+    private let value: TextValue
+    private let valueAlignment: HorizontalAlignment
+
+    public init(
+        title: TextValue,
+        value: TextValue,
+        valueAlignment: HorizontalAlignment = .trailing
+    ) {
+        self.title = title
+        self.value = value
+        self.valueAlignment = valueAlignment
+    }
+
+    public var body: some View {
+        GridRow {
+            Text(title.text)
+                .textStyle(title.style)
+            Text(value.text)
+                .textStyle(value.style)
+                .gridColumnAlignment(valueAlignment)
+        }
+    }
+}


### PR DESCRIPTION
Replace stacked ListItemViews with a Grid-based layout in CandleTooltipView and introduce a reusable GridItemView component. The tooltip now uses Grid rows for open/high/low/close and change/volume values, with the Divider spanning both columns and adjusted padding; the border stroke now uses the spacing constant for line width. Adds Packages/Components/Sources/Lists/GridItemView.swift providing a simple title/value GridRow view with configurable alignment.