### PR TITLE
Fix concurrentImportAndDelete test

### DIFF
--- a/Packages/Keystore/Tests/LocalKeystoreTests.swift
+++ b/Packages/Keystore/Tests/LocalKeystoreTests.swift
@@ -269,8 +269,25 @@ struct LocalKeystoreTests {
     }
 
     @Test
+    func passwordCreatedOnFirstImport() async throws {
+        let mockPassword = MockKeystorePassword()
+        let keystore = LocalKeystore.mock(keystorePassword: mockPassword)
+
+        #expect(try mockPassword.getPassword().isEmpty)
+
+        let _ = try await keystore.importWallet(
+            name: "First Wallet",
+            type: .phrase(words: LocalKeystore.words, chains: [.ethereum]),
+            isWalletsEmpty: true,
+            source: .import
+        )
+
+        #expect(try mockPassword.getPassword().count == 64)
+    }
+
+    @Test
     func concurrentImportAndDelete() async throws {
-        let keystore = LocalKeystore.mock()
+        let keystore = LocalKeystore.mock(keystorePassword: MockKeystorePassword(memoryPassword: "test-password"))
 
         let wallets = try await withThrowingTaskGroup(of: Primitives.Wallet.self) { group in
             for index in 0 ..< 5 {
@@ -278,7 +295,7 @@ struct LocalKeystoreTests {
                     try await keystore.importWallet(
                         name: "Wallet \(index)",
                         type: .phrase(words: LocalKeystore.words, chains: [.ethereum]),
-                        isWalletsEmpty: index == 0 ? true : false,
+                        isWalletsEmpty: false,
                         source: .import
                     )
                 }


### PR DESCRIPTION
Add passwordCreatedOnFirstImport test that verifies a keystore password is initialized on the first wallet import (asserts empty before import and 64-char password after). Also modify concurrentImportAndDelete test to pass an explicit MockKeystorePassword (memoryPassword) when creating the mock keystore and set isWalletsEmpty to false for imports to make the concurrent test deterministic.