### PR TITLE
Use recommended validator set; add TestKit mock

### DIFF
--- a/Features/Stake/Package.swift
+++ b/Features/Stake/Package.swift
@@ -55,6 +55,7 @@ let package = Package(
             dependencies: [
                 "Stake",
                 .product(name: "PrimitivesTestKit", package: "Primitives"),
+                .product(name: "StakeServiceTestKit", package: "ChainServices"),
             ],
             path: "TestKit"
         ),

--- a/Features/Stake/Sources/ViewModels/StakeSceneViewModel.swift
+++ b/Features/Stake/Sources/ViewModels/StakeSceneViewModel.swift
@@ -107,8 +107,8 @@ public final class StakeSceneViewModel {
     }
     
     var recommendedCurrentValidator: DelegationValidator? {
-        guard let validatorId = recommendedValidators.randomValidatorId(chain: chain.chain) else { return .none }
-        return try? stakeService.getValidator(assetId: asset.id, validatorId: validatorId)
+        let ids = recommendedValidators.validatorsSet(chain: chain.chain)
+        return validators.first { ids.contains($0.id) }
     }
 
     var emptyContentModel: EmptyContentTypeViewModel {

--- a/Features/Stake/TestKit/StakeSceneViewModel+TestKit.swift
+++ b/Features/Stake/TestKit/StakeSceneViewModel+TestKit.swift
@@ -1,0 +1,22 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Primitives
+import PrimitivesTestKit
+import StakeService
+import StakeServiceTestKit
+@testable import Stake
+
+public extension StakeSceneViewModel {
+    static func mock(
+        wallet: Wallet = .mock(),
+        chain: StakeChain = .tron,
+        stakeService: any StakeServiceable = MockStakeService(stakeApr: 13.5)
+    ) -> StakeSceneViewModel {
+        StakeSceneViewModel(
+            wallet: wallet,
+            chain: chain,
+            currencyCode: "USD",
+            stakeService: stakeService
+        )
+    }
+}

--- a/Features/Stake/Tests/ViewModels/StakeSceneViewModelTests.swift
+++ b/Features/Stake/Tests/ViewModels/StakeSceneViewModelTests.swift
@@ -2,12 +2,13 @@
 
 import Foundation
 import Testing
-import Store
 import StakeService
 import StakeServiceTestKit
+import StakeTestKit
 import PrimitivesTestKit
 import Primitives
 
+@testable import Store
 @testable import Stake
 
 @MainActor
@@ -35,20 +36,14 @@ struct StakeSceneViewModelTests {
         #expect(StakeSceneViewModel.mock(wallet: .mock(type: .multicoin)).showManage == true)
         #expect(StakeSceneViewModel.mock(wallet: .mock(type: .view)).showManage == false)
     }
-}
 
-//TODO: Move to staking test kit
-extension StakeSceneViewModel {
-    static func mock(
-        wallet: Wallet = .mock(),
-        chain: StakeChain = .tron,
-        stakeService: any StakeServiceable = MockStakeService(stakeApr: 13.5)
-    ) -> StakeSceneViewModel {
-        StakeSceneViewModel(
-            wallet: wallet,
-            chain: chain,
-            currencyCode: "USD",
-            stakeService: stakeService
-        )
+    @Test
+    func recommendedCurrentValidator() {
+        let model = StakeSceneViewModel.mock(chain: .cosmos)
+        let recommendedId = StakeRecommendedValidators().validatorsSet(chain: .cosmos).first!
+
+        model.validatorsQuery.value = [.mock(.cosmos, id: "other"), .mock(.cosmos, id: recommendedId)]
+
+        #expect(model.recommendedCurrentValidator?.id == recommendedId)
     }
 }

--- a/Features/Stake/Tests/ViewModels/StakeSceneViewModelTests.swift
+++ b/Features/Stake/Tests/ViewModels/StakeSceneViewModelTests.swift
@@ -2,12 +2,13 @@
 
 import Foundation
 import Testing
-import Store
 import StakeService
 import StakeServiceTestKit
+import StakeTestKit
 import PrimitivesTestKit
 import Primitives
 
+@testable import Store
 @testable import Stake
 
 @MainActor
@@ -35,20 +36,14 @@ struct StakeSceneViewModelTests {
         #expect(StakeSceneViewModel.mock(wallet: .mock(type: .multicoin)).showManage == true)
         #expect(StakeSceneViewModel.mock(wallet: .mock(type: .view)).showManage == false)
     }
-}
 
-//TODO: Move to staking test kit
-extension StakeSceneViewModel {
-    static func mock(
-        wallet: Wallet = .mock(),
-        chain: StakeChain = .tron,
-        stakeService: any StakeServiceable = MockStakeService(stakeApr: 13.5)
-    ) -> StakeSceneViewModel {
-        StakeSceneViewModel(
-            wallet: wallet,
-            chain: chain,
-            currencyCode: "USD",
-            stakeService: stakeService
-        )
+    @Test
+    func recommendedCurrentValidator() throws {
+        let model = StakeSceneViewModel.mock(chain: .cosmos)
+        let recommendedId = try #require(StakeRecommendedValidators().validatorsSet(chain: .cosmos).first)
+
+        model.validatorsQuery.value = [.mock(.cosmos, id: "other"), .mock(.cosmos, id: recommendedId)]
+
+        #expect(model.recommendedCurrentValidator?.id == recommendedId)
     }
 }


### PR DESCRIPTION
Replace random selection in recommendedCurrentValidator with a deterministic lookup using recommendedValidators.validatorsSet. Add a new StakeSceneViewModel+TestKit.swift providing a mock factory for tests. Update StakeSceneViewModelTests to use the TestKit, adjust imports, remove the inline mock/TODO, and add a unit test for recommendedCurrentValidator to assert the correct validator is returned.

Fix: https://github.com/gemwalletcom/gem-ios/issues/1763