### PR TITLE
Toggle address display on tap in list item

### DIFF
--- a/Packages/Components/Sources/ViewModifiers/TappableModifier.swift
+++ b/Packages/Components/Sources/ViewModifiers/TappableModifier.swift
@@ -1,0 +1,19 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+
+private struct TappableModifier: ViewModifier {
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .contentShape(Rectangle())
+            .onTapGesture(perform: action)
+    }
+}
+
+public extension View {
+    func onTap(action: @escaping () -> Void) -> some View {
+        modifier(TappableModifier(action: action))
+    }
+}

--- a/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
@@ -23,8 +23,7 @@ public struct AddressListItemView: View {
             assetImageStyle: model.assetImageStyle,
             imageSize: model.assetImageSize
         )
-        .contentShape(Rectangle())
-        .onTapGesture {
+        .onTap {
             if model.canToggleAddress {
                 showAddress.toggle()
             }

--- a/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/AddressListItemView.swift
@@ -8,28 +8,31 @@ import Localization
 
 public struct AddressListItemView: View {
     @State private var isPresentingUrl: URL? = nil
+    @State private var showAddress: Bool = false
     private let model: AddressListItemViewModel
 
-    public init(
-        model: AddressListItemViewModel
-    ) {
+    public init(model: AddressListItemViewModel) {
         self.model = model
     }
 
     public var body: some View {
         ListItemImageView(
             title: model.title,
-            subtitle: model.subtitle,
+            subtitle: showAddress ? model.addressSubtitle : model.subtitle,
             assetImage: model.assetImage,
             assetImageStyle: model.assetImageStyle,
             imageSize: model.assetImageSize
         )
-        .contextMenu(
-            [
-                .copy(value: model.account.address),
-                .url(title: model.addressExplorerText, onOpen: { isPresentingUrl = model.addressExplorerUrl })
-            ]
-        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if model.canToggleAddress {
+                showAddress.toggle()
+            }
+        }
+        .contextMenu([
+            .copy(value: model.account.address),
+            .url(title: model.addressExplorerText, onOpen: { isPresentingUrl = model.addressExplorerUrl })
+        ])
         .safariSheet(url: $isPresentingUrl)
     }
 }

--- a/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
@@ -67,7 +67,10 @@ public struct AddressListItemViewModel {
     }
     
     public var canToggleAddress: Bool {
-        account.name != nil && account.name != account.address
+        guard let name = account.name, name.isNotEmpty else {
+            return false
+        }
+        return name != account.address
     }
 
     public var addressSubtitle: String {

--- a/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/AddressListItemViewModel.swift
@@ -66,6 +66,14 @@ public struct AddressListItemViewModel {
         addressLink.url
     }
     
+    public var canToggleAddress: Bool {
+        account.name != nil && account.name != account.address
+    }
+
+    public var addressSubtitle: String {
+        address(for: .short)
+    }
+
     // MARK: - Private methods
     
     private func auto(for style: AddressFormatter.Style) -> String {


### PR DESCRIPTION
Allow tapping an address list item to toggle showing the (short) address. Adds a showAddress @State and uses it to switch the ListItemImageView subtitle between model.subtitle and model.addressSubtitle. Adds canToggleAddress and addressSubtitle computed properties to the view model to control toggling (only when the account has a name different from the address). Preserves existing context menu and safari sheet behavior; also simplifies the view init formatting.

contact
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-05 at 14 54 12" src="https://github.com/user-attachments/assets/3a405369-f20a-4ae2-8422-3f81e6391aa1" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-05 at 14 54 15" src="https://github.com/user-attachments/assets/eef922fa-d341-4178-aeb8-5536296a62f3" />

plain address
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-05 at 14 54 30" src="https://github.com/user-attachments/assets/6fe4d876-7801-41ad-a611-f523129ebf93" />
