### PR TITLE
Add ListItemField and field initializers

### DIFF
--- a/Features/Assets/Sources/Scenes/AssetScene.swift
+++ b/Features/Assets/Sources/Scenes/AssetScene.swift
@@ -165,15 +165,8 @@ public struct AssetScene: View {
 
             if model.showResources {
                 Section(model.resourcesTitle) {
-                    ListItemView(
-                        title: model.energyTitle,
-                        subtitle: model.energyText
-                    )
-
-                    ListItemView(
-                        title: model.bandwidthTitle,
-                        subtitle: model.bandwidthText
-                    )
+                    ListItemView(field: model.energyField)
+                    ListItemView(field: model.bandwidthField)
                 }
             }
 
@@ -208,8 +201,8 @@ public struct AssetScene: View {
 extension AssetScene {
     private var networkView: some View {
         ListItemImageView(
-            title: model.networkTitle,
-            subtitle: model.networkText,
+            title: model.networkField.title.text,
+            subtitle: model.networkField.value.text,
             assetImage: model.networkAssetImage,
             imageSize: .list.image
         )

--- a/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AssetSceneViewModel.swift
@@ -84,14 +84,18 @@ public final class AssetSceneViewModel: Sendable {
     public var title: String { assetModel.name }
 
     var balancesTitle: String { Localized.Asset.balances }
-    var networkTitle: String { Localized.Transfer.network }
 
+    var networkField: ListItemField {
+        ListItemField(title: Localized.Transfer.network, value: assetModel.networkFullName)
+    }
 
     var resourcesTitle: String { Localized.Asset.resources }
-    var energyTitle: String { ResourceViewModel(resource: .energy).title }
-    var bandwidthTitle: String { ResourceViewModel(resource: .bandwidth).title }
-    var energyText: String { feeAssetDataModel.energyText }
-    var bandwidthText: String { feeAssetDataModel.bandwidthText }
+    var energyField: ListItemField {
+        ListItemField(title: ResourceViewModel(resource: .energy).title, value: feeAssetDataModel.energyText)
+    }
+    var bandwidthField: ListItemField {
+        ListItemField(title: ResourceViewModel(resource: .bandwidth).title, value: feeAssetDataModel.bandwidthText)
+    }
 
     var canOpenNetwork: Bool { assetDataModel.asset.type != .native }
 
@@ -126,8 +130,6 @@ public final class AssetSceneViewModel: Sendable {
     }
     
     var reservedBalanceUrl: URL? { assetModel.asset.chain.accountActivationFeeUrl }
-
-    var networkText: String { assetModel.networkFullName }
 
     var showEarnButton: Bool {
         #if DEBUG

--- a/Features/NFT/Sources/Scenes/CollectibleScene.swift
+++ b/Features/NFT/Sources/Scenes/CollectibleScene.swift
@@ -92,22 +92,19 @@ extension CollectibleScene {
 
     private var assetInfoSectionView: some View {
         Section {
-            ListItemView(
-                title: model.collectionTitle,
-                subtitle: model.collectionText
-            )
+            ListItemView(field: model.collectionField)
 
             ListItemImageView(
-                title: model.networkTitle,
-                subtitle: model.networkText,
+                title: model.networkField.title.text,
+                subtitle: model.networkField.value.text,
                 assetImage: model.networkAssetImage
             )
 
-            if let text = model.contractText {
-                ListItemView(title: model.contractTitle, subtitle: text)
+            if let contractField = model.contractField {
+                ListItemView(field: contractField)
                     .contextMenu(model.contractContextMenu)
             }
-            ListItemView(title: model.tokenIdTitle, subtitle: model.tokenIdText)
+            ListItemView(field: model.tokenIdField)
                 .contextMenu(model.tokenIdContextMenu)
         }
     }

--- a/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
+++ b/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
@@ -51,34 +51,37 @@ public final class CollectibleViewModel {
     var title: String { assetData.asset.name }
     var description: String? { assetData.asset.description }
 
-    var collectionTitle: String { Localized.Nft.collection }
-    var collectionText: String { assetData.collection.name }
+    var collectionField: ListItemField {
+        ListItemField(title: Localized.Nft.collection, value: assetData.collection.name)
+    }
 
-    var networkTitle: String { Localized.Transfer.network }
-    var networkText: String { assetData.asset.chain.asset.name }
+    var networkField: ListItemField {
+        ListItemField(title: Localized.Transfer.network, value: assetData.asset.chain.asset.name)
+    }
 
-    var contractTitle: String { Localized.Asset.contract }
     var contractValue: String { assetData.collection.contractAddress }
-    var contractText: String? {
+    var contractField: ListItemField? {
         if contractValue.isEmpty || contractValue == assetData.asset.tokenId {
             return .none
         }
-        return AddressFormatter(address: contractValue, chain: assetData.asset.chain).value()
+        let text = AddressFormatter(address: contractValue, chain: assetData.asset.chain).value()
+        return ListItemField(title: Localized.Asset.contract, value: text)
     }
-    
+
     var contractContextMenu: [ContextMenuItemType] {
         [.copy(value: contractValue, onCopy: { [weak self] value in
             self?.isPresentingToast = .copied(value)
         })]
     }
 
-    var tokenIdTitle: String { Localized.Asset.tokenId }
     var tokenIdValue: String { assetData.asset.tokenId }
-    var tokenIdText: String {
-        if assetData.asset.tokenId.count > 16 {
-            return assetData.asset.tokenId
+    var tokenIdField: ListItemField {
+        let text = if assetData.asset.tokenId.count > 16 {
+            assetData.asset.tokenId
+        } else {
+            "#\(assetData.asset.tokenId)"
         }
-        return "#\(assetData.asset.tokenId)"
+        return ListItemField(title: Localized.Asset.tokenId, value: text)
     }
 
     var attributesTitle: String { Localized.Nft.properties }

--- a/Features/NFT/Tests/NFTTests/CollectibleViewModelTests.swift
+++ b/Features/NFT/Tests/NFTTests/CollectibleViewModelTests.swift
@@ -21,28 +21,28 @@ struct CollectibleViewModelTests {
     }
     
     @Test
-    func tokenIdText() {
+    func tokenIdField() {
         let shortModel = CollectibleViewModel.mock(assetData: .mock(asset: .mock(tokenId: "123")))
         let longModel = CollectibleViewModel.mock(assetData: .mock(asset: .mock(tokenId: "1234567890123456789")))
-        
-        #expect(shortModel.tokenIdText == "#123")
-        #expect(longModel.tokenIdText == "1234567890123456789")
+
+        #expect(shortModel.tokenIdField.value.text == "#123")
+        #expect(longModel.tokenIdField.value.text == "1234567890123456789")
     }
-    
+
     @Test
-    func contractText() {
+    func contractField() {
         #expect(CollectibleViewModel.mock(assetData: .mock(
             collection: .mock(contractAddress: "0x123"),
             asset: .mock(tokenId: "456")
-        )).contractText == "0x123")
+        )).contractField?.value.text == "0x123")
         #expect(CollectibleViewModel.mock(assetData: .mock(
             collection: .mock(contractAddress: "0x12345678910"),
             asset: .mock(tokenId: "")
-        )).contractText == "0x1234...78910")
+        )).contractField?.value.text == "0x1234...78910")
         #expect(CollectibleViewModel.mock(assetData: .mock(
             collection: .mock(contractAddress: ""),
             asset: .mock(tokenId: "456")
-        )).contractText == nil)
+        )).contractField == nil)
     }
     
     @Test

--- a/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/AutocloseScene.swift
@@ -25,10 +25,10 @@ public struct AutocloseScene: View {
             }
 
             Section {
-                if let entryPriceText = model.entryPriceText {
-                    ListItemView(title: model.entryPriceTitle, subtitle: entryPriceText)
+                if let entryPriceField = model.entryPriceField {
+                    ListItemView(field: entryPriceField)
                 }
-                ListItemView(title: model.marketPriceTitle, subtitle: model.marketPriceText)
+                ListItemView(field: model.marketPriceField)
             }
 
             AutocloseInputSection(

--- a/Features/Perpetuals/Sources/Scenes/PerpetualPortfolioScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualPortfolioScene.swift
@@ -26,10 +26,10 @@ struct PerpetualPortfolioScene: View {
                 .cleanListRow()
 
                 Section(header: Text(model.infoSectionTitle)) {
-                    ListItemView(title: model.unrealizedPnlTitle, subtitle: model.unrealizedPnlValue.text, subtitleStyle: model.unrealizedPnlValue.style)
+                    ListItemView(field: model.unrealizedPnlField)
                     ListItemView(title: model.accountLeverageTitle, subtitle: model.accountLeverageText)
                     ListItemView(title: model.marginUsageTitle, subtitle: model.marginUsageText)
-                    ListItemView(title: model.allTimePnlTitle, subtitle: model.allTimePnlValue.text, subtitleStyle: model.allTimePnlValue.style)
+                    ListItemView(field: model.allTimePnlField)
                     ListItemView(title: model.volumeTitle, subtitle: model.volumeText)
                 }
             }

--- a/Features/Perpetuals/Sources/Scenes/PerpetualPortfolioScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualPortfolioScene.swift
@@ -27,10 +27,10 @@ struct PerpetualPortfolioScene: View {
 
                 Section(header: Text(model.infoSectionTitle)) {
                     ListItemView(field: model.unrealizedPnlField)
-                    ListItemView(title: model.accountLeverageTitle, subtitle: model.accountLeverageText)
-                    ListItemView(title: model.marginUsageTitle, subtitle: model.marginUsageText)
+                    ListItemView(field: model.accountLeverageField)
+                    ListItemView(field: model.marginUsageField)
                     ListItemView(field: model.allTimePnlField)
-                    ListItemView(title: model.volumeTitle, subtitle: model.volumeText)
+                    ListItemView(field: model.volumeField)
                 }
             }
             .navigationTitle(model.navigationTitle)

--- a/Features/Perpetuals/Sources/Scenes/PerpetualScene.swift
+++ b/Features/Perpetuals/Sources/Scenes/PerpetualScene.swift
@@ -45,12 +45,8 @@ public struct PerpetualScene: View {
                         model: PerpetualPositionItemViewModel(model: position)
                     )
                     
-                    ListItemView(
-                        title: position.pnlTitle,
-                        subtitle: position.pnlWithPercentText,
-                        subtitleStyle: position.pnlTextStyle
-                    )
-                    .numericTransition(for: position.pnlWithPercentText)
+                    ListItemView(field: position.pnlField)
+                        .numericTransition(for: position.pnlWithPercentText)
 
                     NavigationCustomLink(
                         with: ListItemView(
@@ -61,35 +57,21 @@ public struct PerpetualScene: View {
                         ),
                         action: model.onSelectAutoclose
                     )
-                    
-                    ListItemView(
-                        title: position.sizeTitle,
-                        subtitle: position.sizeValueText
-                    )
-                    
-                    ListItemView(
-                        title: position.entryPriceTitle,
-                        subtitle: position.entryPriceText
-                    )
-                    
-                    if let text = position.liquidationPriceText {
+
+                    ListItemView(field: position.sizeField)
+                    ListItemView(field: position.entryPriceField)
+
+                    if let liquidationPriceField = position.liquidationPriceField {
                         ListItemView(
-                            title: position.liquidationPriceTitle,
-                            subtitle: text,
-                            subtitleStyle: position.liquidationPriceTextStyle,
+                            field: liquidationPriceField,
                             infoAction: model.onSelectLiquidationPriceInfo
                         )
                     }
-                    
+
+                    ListItemView(field: position.marginField)
+
                     ListItemView(
-                        title: position.marginTitle,
-                        subtitle: position.marginText
-                    )
-                    
-                    ListItemView(
-                        title: position.fundingPaymentsTitle,
-                        subtitle: position.fundingPaymentsText,
-                        subtitleStyle: position.fundingPaymentsTextStyle,
+                        field: position.fundingPaymentsField,
                         infoAction: model.onSelectFundingPaymentsInfo
                     )
                 } header: {
@@ -122,20 +104,15 @@ public struct PerpetualScene: View {
             }
             
             Section(header: Text(model.infoSectionTitle)) {
+                ListItemView(field: model.perpetualViewModel.volumeField)
+
                 ListItemView(
-                    title: model.perpetualViewModel.volumeTitle,
-                    subtitle: model.perpetualViewModel.volumeText
-                )
-                
-                ListItemView(
-                    title: model.perpetualViewModel.openInterestTitle,
-                    subtitle: model.perpetualViewModel.openInterestText,
+                    field: model.perpetualViewModel.openInterestField,
                     infoAction: model.onSelectOpenInterestInfo
                 )
-                
+
                 ListItemView(
-                    title: model.perpetualViewModel.fundingRateTitle,
-                    subtitle: model.perpetualViewModel.fundingRateText,
+                    field: model.perpetualViewModel.fundingRateField,
                     infoAction: model.onSelectFundingRateInfo
                 )
             }

--- a/Features/Perpetuals/Sources/ViewModels/AutocloseSceneViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/AutocloseSceneViewModel.swift
@@ -33,8 +33,9 @@ public final class AutocloseSceneViewModel {
     }
 
     public var title: String { Localized.Perpetual.autoClose }
-    public var marketPriceTitle: String { Localized.Perpetual.marketPrice }
-    public var marketPriceText: String { currencyFormatter.string(marketPrice) }
+    public var marketPriceField: ListItemField {
+        ListItemField(title: Localized.Perpetual.marketPrice, value: currencyFormatter.string(marketPrice))
+    }
 
     public var takeProfitModel: AutocloseViewModel { autocloseModel(type: .takeProfit, price: takeProfitPrice) }
     public var stopLossModel: AutocloseViewModel { autocloseModel(type: .stopLoss, price: stopLossPrice) }
@@ -46,11 +47,10 @@ public final class AutocloseSceneViewModel {
         }
     }
 
-    public var entryPriceTitle: String { Localized.Perpetual.entryPrice }
-
-    public var entryPriceText: String? {
+    public var entryPriceField: ListItemField? {
         switch type {
-        case let .modify(position, _): currencyFormatter.string(position.position.entryPrice)
+        case let .modify(position, _):
+            ListItemField(title: Localized.Perpetual.entryPrice, value: currencyFormatter.string(position.position.entryPrice))
         case .open: nil
         }
     }

--- a/Features/Perpetuals/Sources/ViewModels/CandleTooltipViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/CandleTooltipViewModel.swift
@@ -20,24 +20,46 @@ public struct CandleTooltipViewModel {
         self.formatter = formatter
     }
 
-    var openTitle: TextValue { TextValue(text: Localized.Charts.Price.open, style: Self.titleStyle, lineLimit: 1) }
-    var openValue: TextValue { TextValue(text: formatter.string(double: candle.open), style: Self.subtitleStyle, lineLimit: 1) }
-
-    var closeTitle: TextValue { TextValue(text: Localized.Charts.Price.close, style: Self.titleStyle, lineLimit: 1) }
-    var closeValue: TextValue { TextValue(text: formatter.string(double: candle.close), style: Self.subtitleStyle, lineLimit: 1) }
-
-    var highTitle: TextValue { TextValue(text: Localized.Charts.Price.high, style: Self.titleStyle, lineLimit: 1) }
-    var highValue: TextValue { TextValue(text: formatter.string(double: candle.high), style: Self.subtitleStyle, lineLimit: 1) }
-
-    var lowTitle: TextValue { TextValue(text: Localized.Charts.Price.low, style: Self.titleStyle, lineLimit: 1) }
-    var lowValue: TextValue { TextValue(text: formatter.string(double: candle.low), style: Self.subtitleStyle, lineLimit: 1) }
-
-    var changeTitle: TextValue { TextValue(text: Localized.Charts.Price.change, style: Self.titleStyle, lineLimit: 1) }
-    var changeValue: TextValue {
-        let change = PriceChangeCalculator.calculate(.percentage(from: candle.open, to: candle.close))
-        return TextValue(text: CurrencyFormatter.percent.string(change), style: TextStyle(font: .caption2.monospacedDigit(), color: PriceChangeColor.color(for: change), fontWeight: .semibold), lineLimit: 1)
+    var openField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Charts.Price.open, style: Self.titleStyle, lineLimit: 1),
+            value: TextValue(text: formatter.string(double: candle.open), style: Self.subtitleStyle, lineLimit: 1)
+        )
     }
 
-    var volumeTitle: TextValue { TextValue(text: Localized.Perpetual.volume, style: Self.titleStyle, lineLimit: 1) }
-    var volumeValue: TextValue { TextValue(text: Self.volumeFormatter.string(candle.volume * candle.close), style: Self.subtitleStyle, lineLimit: 1) }
+    var closeField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Charts.Price.close, style: Self.titleStyle, lineLimit: 1),
+            value: TextValue(text: formatter.string(double: candle.close), style: Self.subtitleStyle, lineLimit: 1)
+        )
+    }
+
+    var highField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Charts.Price.high, style: Self.titleStyle, lineLimit: 1),
+            value: TextValue(text: formatter.string(double: candle.high), style: Self.subtitleStyle, lineLimit: 1)
+        )
+    }
+
+    var lowField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Charts.Price.low, style: Self.titleStyle, lineLimit: 1),
+            value: TextValue(text: formatter.string(double: candle.low), style: Self.subtitleStyle, lineLimit: 1)
+        )
+    }
+
+    var changeField: ListItemField {
+        let change = PriceChangeCalculator.calculate(.percentage(from: candle.open, to: candle.close))
+        return ListItemField(
+            title: TextValue(text: Localized.Charts.Price.change, style: Self.titleStyle, lineLimit: 1),
+            value: TextValue(text: CurrencyFormatter.percent.string(change), style: TextStyle(font: .caption2.monospacedDigit(), color: PriceChangeColor.color(for: change), fontWeight: .semibold), lineLimit: 1)
+        )
+    }
+
+    var volumeField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Perpetual.volume, style: Self.titleStyle, lineLimit: 1),
+            value: TextValue(text: Self.volumeFormatter.string(candle.volume * candle.close), style: Self.subtitleStyle, lineLimit: 1)
+        )
+    }
 }

--- a/Features/Perpetuals/Sources/ViewModels/PerpetualItemViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/PerpetualItemViewModel.swift
@@ -42,7 +42,7 @@ struct PerpetualItemViewModel: ListAssetItemViewable {
     var rightView: ListAssetItemRightView {
         .balance(
             balance: TextValue(
-                text: model.volumeText,
+                text: model.volumeField.value.text,
                 style: TextStyle(font: .body, color: .primary, fontWeight: .semibold)
             ),
             totalFiat: TextValue(

--- a/Features/Perpetuals/Sources/ViewModels/PerpetualPortfolioSceneViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/PerpetualPortfolioSceneViewModel.swift
@@ -90,16 +90,12 @@ extension PerpetualPortfolioSceneViewModel {
         )
     }
 
-    var accountLeverageTitle: String { Localized.Perpetual.accountLeverage }
-    var accountLeverageText: String { portfolio?.accountSummary.map { String(format: "%.2fx", $0.accountLeverage) } ?? "-" }
+    var accountLeverageField: ListItemField {
+        ListItemField(title: Localized.Perpetual.accountLeverage, value: accountLeverageText)
+    }
 
-    var marginUsageTitle: String { Localized.Perpetual.marginUsage }
-    var marginUsageText: String {
-        portfolio?.accountSummary.map {
-            let marginValue = currencyFormatter.string($0.accountValue * $0.marginUsage)
-            let marginPercent = CurrencyFormatter.percentSignLess.string($0.marginUsage * 100)
-            return "\(marginValue) (\(marginPercent))"
-        } ?? "-"
+    var marginUsageField: ListItemField {
+        ListItemField(title: Localized.Perpetual.marginUsage, value: marginUsageText)
     }
 
     var allTimePnlField: ListItemField {
@@ -109,8 +105,9 @@ extension PerpetualPortfolioSceneViewModel {
         )
     }
 
-    var volumeTitle: String { Localized.Perpetual.volume }
-    var volumeText: String { portfolio.map { currencyFormatter.string($0.allTime?.volume ?? 0) } ?? "-" }
+    var volumeField: ListItemField {
+        ListItemField(title: Localized.Perpetual.volume, value: volumeText)
+    }
 }
 
 // MARK: - Private
@@ -118,6 +115,16 @@ extension PerpetualPortfolioSceneViewModel {
 extension PerpetualPortfolioSceneViewModel {
     private var unrealizedPnlModel: PriceChangeViewModel { priceChangeModel(value: portfolio?.accountSummary?.unrealizedPnl) }
     private var allTimePnlModel: PriceChangeViewModel { priceChangeModel(value: portfolio?.allTime?.pnlHistory.last?.value) }
+
+    private var accountLeverageText: String { portfolio?.accountSummary.map { String(format: "%.2fx", $0.accountLeverage) } ?? "-" }
+    private var marginUsageText: String {
+        portfolio?.accountSummary.map {
+            let marginValue = currencyFormatter.string($0.accountValue * $0.marginUsage)
+            let marginPercent = CurrencyFormatter.percentSignLess.string($0.marginUsage * 100)
+            return "\(marginValue) (\(marginPercent))"
+        } ?? "-"
+    }
+    private var volumeText: String { portfolio.map { currencyFormatter.string($0.allTime?.volume ?? 0) } ?? "-" }
 
     private func priceChangeModel(value: Double?) -> PriceChangeViewModel {
         PriceChangeViewModel(value: value, currencyFormatter: currencyFormatter)

--- a/Features/Perpetuals/Sources/ViewModels/PerpetualPortfolioSceneViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/PerpetualPortfolioSceneViewModel.swift
@@ -83,8 +83,12 @@ final class PerpetualPortfolioSceneViewModel {
 // MARK: - Stats
 
 extension PerpetualPortfolioSceneViewModel {
-    var unrealizedPnlTitle: String { Localized.Perpetual.unrealizedPnl }
-    var unrealizedPnlValue: TextValue { TextValue(text: unrealizedPnlModel.text ?? "-", style: unrealizedPnlModel.textStyle) }
+    var unrealizedPnlField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Perpetual.unrealizedPnl, style: ListItemModel.StyleDefaults.titleStyle),
+            value: TextValue(text: unrealizedPnlModel.text ?? "-", style: unrealizedPnlModel.textStyle)
+        )
+    }
 
     var accountLeverageTitle: String { Localized.Perpetual.accountLeverage }
     var accountLeverageText: String { portfolio?.accountSummary.map { String(format: "%.2fx", $0.accountLeverage) } ?? "-" }
@@ -98,8 +102,12 @@ extension PerpetualPortfolioSceneViewModel {
         } ?? "-"
     }
 
-    var allTimePnlTitle: String { Localized.Perpetual.allTimePnl }
-    var allTimePnlValue: TextValue { TextValue(text: allTimePnlModel.text ?? "-", style: allTimePnlModel.textStyle) }
+    var allTimePnlField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Perpetual.allTimePnl, style: ListItemModel.StyleDefaults.titleStyle),
+            value: TextValue(text: allTimePnlModel.text ?? "-", style: allTimePnlModel.textStyle)
+        )
+    }
 
     var volumeTitle: String { Localized.Perpetual.volume }
     var volumeText: String { portfolio.map { currencyFormatter.string($0.allTime?.volume ?? 0) } ?? "-" }

--- a/Features/Perpetuals/Sources/ViewModels/PerpetualPositionViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/PerpetualPositionViewModel.swift
@@ -61,13 +61,16 @@ public struct PerpetualPositionViewModel {
             percentFormatter: percentFormatter
         )
     }
-    public var pnlTitle: String { pnlViewModel.title }
+    public var pnlField: ListItemField {
+        ListItemField(
+            title: TextValue(text: pnlViewModel.title, style: .body),
+            value: TextValue(text: pnlViewModel.text ?? "", style: pnlViewModel.textStyle)
+        )
+    }
     public var pnlColor: Color { pnlViewModel.color }
-    public var pnlTextStyle: TextStyle { pnlViewModel.textStyle }
     public var pnlPercent: Double { pnlViewModel.percent }
     public var pnlWithPercentText: String { pnlViewModel.text ?? "" }
 
-    public var marginTitle: String { Localized.Perpetual.margin }
     public var marginAmountText: String {
         currencyFormatter.string(data.position.marginAmount)
     }
@@ -80,55 +83,45 @@ public struct PerpetualPositionViewModel {
         )
     }
 
-    public var marginText: String {
+    public var marginField: ListItemField {
         let marginAmount = currencyFormatter.string(data.position.marginAmount)
-        return "\(marginAmount) (\(data.position.marginType.displayText))"
+        return ListItemField(title: Localized.Perpetual.margin, value: "\(marginAmount) (\(data.position.marginType.displayText))")
     }
-    
-    public var fundingPaymentsTitle: String { Localized.Info.FundingPayments.title }
+
+    public var fundingPaymentsField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Info.FundingPayments.title, style: .body),
+            value: TextValue(text: fundingPaymentsModel.text ?? "-", style: fundingPaymentsModel.textStyle)
+        )
+    }
+    public var fundingPaymentsColor: Color { fundingPaymentsModel.color }
+
+    public var sizeField: ListItemField {
+        ListItemField(title: Localized.Perpetual.size, value: currencyFormatter.string(data.position.sizeValue))
+    }
+
+    public var entryPriceField: ListItemField {
+        ListItemField(title: Localized.Perpetual.entryPrice, value: currencyFormatter.string(data.position.entryPrice))
+    }
+
+    public var liquidationPriceField: ListItemField? {
+        guard let price = data.position.liquidationPrice, price > 0 else { return .none }
+        return ListItemField(
+            title: TextValue(text: Localized.Info.LiquidationPrice.title, style: .body),
+            value: TextValue(text: currencyFormatter.string(price), style: liquidationPriceTextStyle)
+        )
+    }
+}
+
+// MARK: - Private
+
+extension PerpetualPositionViewModel {
     private var fundingPaymentsModel: PriceChangeViewModel {
         PriceChangeViewModel(value: data.position.funding.map { Double($0) }, currencyFormatter: currencyFormatter)
     }
-    public var fundingPaymentsText: String { fundingPaymentsModel.text ?? "-" }
-    public var fundingPaymentsColor: Color { fundingPaymentsModel.color }
-    public var fundingPaymentsTextStyle: TextStyle { fundingPaymentsModel.textStyle }
-    
-    public var sizeTitle: String { Localized.Perpetual.size }
-    public var sizeValueText: String {
-        currencyFormatter.string(data.position.sizeValue)
-    }
-    
-    public var entryPriceTitle: String { Localized.Perpetual.entryPrice }
-    public var entryPriceText: String { currencyFormatter.string(data.position.entryPrice) }
 
-    public var liquidationPriceTitle: String { Localized.Info.LiquidationPrice.title }
-    public var liquidationPriceText: String? {
-        guard let price = data.position.liquidationPrice, price > 0 else { return .none }
-        return currencyFormatter.string(price)
-    }
-    
-    public var liquidationPriceColor: Color {
-//        guard let entryPrice = data.position.entryPrice,
-//              let liquidationPrice = data.position.liquidationPrice,
-//              let currentPrice = data.position.currencyPrice,
-//              entryPrice > 0, liquidationPrice > 0, currentPrice > 0 else {
-//            return Colors.secondaryText
-//        }
-//        
-//        let priceRange = abs(entryPrice - liquidationPrice)
-//        let distance = abs(currentPrice - entryPrice)
-//        let progress = distance / priceRange
-//        
-//        return switch progress {
-//        case 0.8...: Colors.red
-//        case 0.5..<0.8: Colors.orange
-//        default: Colors.secondaryText
-//        }
-        Colors.secondaryText
-    }
-    
-    public var liquidationPriceTextStyle: TextStyle {
-        TextStyle(font: .callout, color: liquidationPriceColor)
+    private var liquidationPriceTextStyle: TextStyle {
+        TextStyle(font: .callout, color: Colors.secondaryText)
     }
 }
 

--- a/Features/Perpetuals/Sources/ViewModels/PerpetualViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/PerpetualViewModel.swift
@@ -34,22 +34,22 @@ public struct PerpetualViewModel {
         AssetIdViewModel(assetId: perpetual.assetId).assetImage
     }
     
-    public var volumeTitle: String { Localized.Markets.dailyVolume }
-    public var volumeText: String {
-        currencyFormatter.string(perpetual.volume24h)
+    public var volumeField: ListItemField {
+        ListItemField(title: Localized.Markets.dailyVolume, value: currencyFormatter.string(perpetual.volume24h))
     }
-    
-    public var openInterestTitle: String { Localized.Info.OpenInterest.title }
-    public var openInterestText: String {
-        currencyFormatter.string(perpetual.openInterest)
+
+    public var openInterestField: ListItemField {
+        ListItemField(title: Localized.Info.OpenInterest.title, value: currencyFormatter.string(perpetual.openInterest))
     }
-    
-    public var fundingRateTitle: String { Localized.Info.FundingRate.title }
-    public var fundingRateText: String {
+
+    public var fundingRateField: ListItemField {
+        let text: String
         if let formattedNumber = fundingRateFormatter.string(from: NSNumber(value: perpetual.funding)) {
-            return "\(formattedNumber)%"
+            text = "\(formattedNumber)%"
+        } else {
+            text = percentFormatter.string(perpetual.funding)
         }
-        return percentFormatter.string(perpetual.funding)
+        return ListItemField(title: Localized.Info.FundingRate.title, value: text)
     }
     
     public var priceText: String {

--- a/Features/Perpetuals/Sources/Views/CandleTooltipView.swift
+++ b/Features/Perpetuals/Sources/Views/CandleTooltipView.swift
@@ -9,17 +9,17 @@ struct CandleTooltipView: View {
 
     var body: some View {
         Grid(alignment: .leading, horizontalSpacing: Spacing.small, verticalSpacing: Spacing.extraSmall) {
-            GridItemView(title: model.openTitle, value: model.openValue)
-            GridItemView(title: model.highTitle, value: model.highValue)
-            GridItemView(title: model.lowTitle, value: model.lowValue)
-            GridItemView(title: model.closeTitle, value: model.closeValue)
+            GridItemView(field: model.openField)
+            GridItemView(field: model.highField)
+            GridItemView(field: model.lowField)
+            GridItemView(field: model.closeField)
 
             Divider()
                 .gridCellColumns(2)
                 .padding(.vertical, Spacing.tiny)
 
-            GridItemView(title: model.changeTitle, value: model.changeValue)
-            GridItemView(title: model.volumeTitle, value: model.volumeValue)
+            GridItemView(field: model.changeField)
+            GridItemView(field: model.volumeField)
         }
         .padding(Spacing.small)
         .background(.thickMaterial)

--- a/Features/Perpetuals/Tests/CandleTooltipViewModelTests.swift
+++ b/Features/Perpetuals/Tests/CandleTooltipViewModelTests.swift
@@ -14,29 +14,29 @@ struct CandleTooltipViewModelTests {
     func tooltipContent() {
         let model = CandleTooltipViewModel.mock(candle: .mock(open: 67_715, high: 68_181, low: 67_714, close: 68_087, volume: 500))
 
-        #expect(model.openTitle.text == Localized.Charts.Price.open)
-        #expect(model.openValue.text == "67,715.00")
+        #expect(model.openField.title.text == Localized.Charts.Price.open)
+        #expect(model.openField.value.text == "67,715.00")
 
-        #expect(model.highTitle.text == Localized.Charts.Price.high)
-        #expect(model.highValue.text == "68,181.00")
+        #expect(model.highField.title.text == Localized.Charts.Price.high)
+        #expect(model.highField.value.text == "68,181.00")
 
-        #expect(model.lowTitle.text == Localized.Charts.Price.low)
-        #expect(model.lowValue.text == "67,714.00")
+        #expect(model.lowField.title.text == Localized.Charts.Price.low)
+        #expect(model.lowField.value.text == "67,714.00")
 
-        #expect(model.closeTitle.text == Localized.Charts.Price.close)
-        #expect(model.closeValue.text == "68,087.00")
+        #expect(model.closeField.title.text == Localized.Charts.Price.close)
+        #expect(model.closeField.value.text == "68,087.00")
 
-        #expect(model.changeTitle.text == Localized.Charts.Price.change)
-        #expect(model.changeValue.text == "+0.55%")
+        #expect(model.changeField.title.text == Localized.Charts.Price.change)
+        #expect(model.changeField.value.text == "+0.55%")
 
-        #expect(model.volumeTitle.text == Localized.Perpetual.volume)
-        #expect(model.volumeValue.text == "$34.04M")
+        #expect(model.volumeField.title.text == Localized.Perpetual.volume)
+        #expect(model.volumeField.value.text == "$34.04M")
     }
 
     @Test
     func changeSign() {
-        #expect(CandleTooltipViewModel.mock(candle: .mock(open: 100, close: 105)).changeValue.text == "+5.00%")
-        #expect(CandleTooltipViewModel.mock(candle: .mock(open: 100, close: 95)).changeValue.text == "-5.00%")
-        #expect(CandleTooltipViewModel.mock(candle: .mock(open: 100, close: 100)).changeValue.text == "+0.00%")
+        #expect(CandleTooltipViewModel.mock(candle: .mock(open: 100, close: 105)).changeField.value.text == "+5.00%")
+        #expect(CandleTooltipViewModel.mock(candle: .mock(open: 100, close: 95)).changeField.value.text == "-5.00%")
+        #expect(CandleTooltipViewModel.mock(candle: .mock(open: 100, close: 100)).changeField.value.text == "+0.00%")
     }
 }

--- a/Features/Perpetuals/Tests/PerpetualPortfolioSceneViewModelTests.swift
+++ b/Features/Perpetuals/Tests/PerpetualPortfolioSceneViewModelTests.swift
@@ -80,16 +80,16 @@ struct PerpetualPortfolioSceneViewModelTests {
 
     @Test
     @MainActor
-    func marginUsageText() {
+    func marginUsageField() {
         let model = PerpetualPortfolioSceneViewModel.mock()
 
-        #expect(model.marginUsageText == "-")
+        #expect(model.marginUsageField.value.text == "-")
 
         model.state = .data(.mock(accountSummary: .mock(accountValue: 100, marginUsage: 0.168)))
-        #expect(model.marginUsageText == "$16.80 (16.80%)")
+        #expect(model.marginUsageField.value.text == "$16.80 (16.80%)")
 
         model.state = .data(.mock(accountSummary: .mock(accountValue: 0, marginUsage: 0)))
-        #expect(model.marginUsageText == "$0.00 (0.00%)")
+        #expect(model.marginUsageField.value.text == "$0.00 (0.00%)")
     }
 
     @Test

--- a/Features/Perpetuals/Tests/PerpetualPositionViewModelTests.swift
+++ b/Features/Perpetuals/Tests/PerpetualPositionViewModelTests.swift
@@ -3,6 +3,7 @@
 import Testing
 import Primitives
 import Style
+import Components
 import PerpetualsTestKit
 @testable import Perpetuals
 
@@ -25,31 +26,31 @@ struct PerpetualPositionViewModelTests {
     }
     
     @Test
-    func marginText() {
-        #expect(createPositionViewModel(.mock(marginAmount: 1000)).marginText == "$1,000.00 (isolated)")
+    func marginField() {
+        #expect(createPositionViewModel(.mock(marginAmount: 1000)).marginField.value.text == "$1,000.00 (isolated)")
     }
-    
+
     @Test
-    func pnlWithPercentText() {
-        #expect(createPositionViewModel(.mock(marginAmount: 1000, pnl: 500)).pnlWithPercentText == "+$500.00 (+50.00%)")
-        #expect(createPositionViewModel(.mock(marginAmount: 1000, pnl: -200)).pnlWithPercentText == "-$200.00 (-20.00%)")
+    func pnlField() {
+        #expect(createPositionViewModel(.mock(marginAmount: 1000, pnl: 500)).pnlField.value.text == "+$500.00 (+50.00%)")
+        #expect(createPositionViewModel(.mock(marginAmount: 1000, pnl: -200)).pnlField.value.text == "-$200.00 (-20.00%)")
     }
 
     @Test
     func pnlPercent() {
         #expect(createPositionViewModel(.mock(marginAmount: 1000, pnl: 100)).pnlPercent == 10.0)
     }
-    
+
     @Test
-    func entryPriceText() {
-        #expect(createPositionViewModel(.mock(entryPrice: 42000)).entryPriceText == "$42,000.00")
+    func entryPriceField() {
+        #expect(createPositionViewModel(.mock(entryPrice: 42000)).entryPriceField.value.text == "$42,000.00")
     }
-    
+
     @Test
-    func liquidationPriceText() {
-        #expect(createPositionViewModel(.mock(liquidationPrice: 35000)).liquidationPriceText == "$35,000.00")
-        #expect(createPositionViewModel(.mock(liquidationPrice: 0)).liquidationPriceText == nil)
-        #expect(createPositionViewModel(.mock(liquidationPrice: nil)).liquidationPriceText == nil)
+    func liquidationPriceField() {
+        #expect(createPositionViewModel(.mock(liquidationPrice: 35000)).liquidationPriceField?.value.text == "$35,000.00")
+        #expect(createPositionViewModel(.mock(liquidationPrice: 0)).liquidationPriceField == nil)
+        #expect(createPositionViewModel(.mock(liquidationPrice: nil)).liquidationPriceField == nil)
     }
     
     @Test

--- a/Features/Perpetuals/Tests/PerpetualViewModelTests.swift
+++ b/Features/Perpetuals/Tests/PerpetualViewModelTests.swift
@@ -14,18 +14,18 @@ struct PerpetualViewModelTests {
     }
     
     @Test
-    func volumeText() {
-        #expect(PerpetualViewModel(perpetual: .mock(volume24h: 1_500_000)).volumeText == "$1.5M")
+    func volumeField() {
+        #expect(PerpetualViewModel(perpetual: .mock(volume24h: 1_500_000)).volumeField.value.text == "$1.5M")
     }
-    
+
     @Test
-    func openInterestText() {
-        #expect(PerpetualViewModel(perpetual: .mock(openInterest: 5_250_000)).openInterestText == "$5.25M")
+    func openInterestField() {
+        #expect(PerpetualViewModel(perpetual: .mock(openInterest: 5_250_000)).openInterestField.value.text == "$5.25M")
     }
-    
+
     @Test
-    func fundingRateText() {
-        #expect(PerpetualViewModel(perpetual: .mock(funding: 0.0001)).fundingRateText.contains("%"))
+    func fundingRateField() {
+        #expect(PerpetualViewModel(perpetual: .mock(funding: 0.0001)).fundingRateField.value.text.contains("%"))
     }
     
     @Test

--- a/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
+++ b/Features/Settings/Sources/ChainSettings/Scenes/AddNodeScene.swift
@@ -96,10 +96,10 @@ extension AddNodeScene {
             EmptyView()
         case let .data(result):
             Section {
-                ListItemView(title: result.chainIdTitle, subtitle: result.chainIdValue)
-                ListItemView(title: result.inSyncTitle, subtitle: result.inSyncValue)
-                ListItemView(title: result.latestBlockTitle, subtitle: result.latestBlockValue)
-                ListItemView(title: result.latencyTitle, subtitle: result.latecyValue)
+                ListItemView(field: result.chainIdField)
+                ListItemView(field: result.inSyncField)
+                ListItemView(field: result.latestBlockField)
+                ListItemView(field: result.latencyField)
             }
             warningSection
         }

--- a/Features/Settings/Sources/ChainSettings/ViewModels/AddNodeResultViewModel.swift
+++ b/Features/Settings/Sources/ChainSettings/ViewModels/AddNodeResultViewModel.swift
@@ -5,6 +5,7 @@ import Primitives
 import Style
 import Localization
 import Formatters
+import Components
 
 struct AddNodeResultViewModel: Sendable {
     static let valueFormatter = ValueFormatter.full_US
@@ -14,23 +15,24 @@ struct AddNodeResultViewModel: Sendable {
     init(addNodeResult: AddNodeResult) {
         self.addNodeResult = addNodeResult
     }
-    
+
     var url: URL { addNodeResult.url }
 
-    var chainIdTitle: String { Localized.Nodes.ImportNode.chainId }
-    var chainIdValue: String { addNodeResult.chainID }
-
     var isInSync: Bool { addNodeResult.isInSync }
-    var inSyncTitle: String { Localized.Nodes.ImportNode.inSync }
-    var inSyncValue: String? { isInSync ? Emoji.checkmark : Emoji.reject }
 
-    var latestBlockTitle: String { Localized.Nodes.ImportNode.latestBlock }
-    var latestBlockValue: String? {
-        Self.valueFormatter.string(addNodeResult.blockNumber, decimals: 0)
+    var chainIdField: ListItemField {
+        ListItemField(title: Localized.Nodes.ImportNode.chainId, value: addNodeResult.chainID)
     }
 
-    var latencyTitle: String { Localized.Nodes.ImportNode.latency }
-    var latecyValue: String? {
-        LatencyViewModel(latency: addNodeResult.latency).title
+    var inSyncField: ListItemField {
+        ListItemField(title: Localized.Nodes.ImportNode.inSync, value: isInSync ? Emoji.checkmark : Emoji.reject)
+    }
+
+    var latestBlockField: ListItemField {
+        ListItemField(title: Localized.Nodes.ImportNode.latestBlock, value: Self.valueFormatter.string(addNodeResult.blockNumber, decimals: 0))
+    }
+
+    var latencyField: ListItemField {
+        ListItemField(title: Localized.Nodes.ImportNode.latency, value: LatencyViewModel(latency: addNodeResult.latency).title)
     }
 }

--- a/Features/Stake/Sources/Scenes/DelegationScene.swift
+++ b/Features/Stake/Sources/Scenes/DelegationScene.swift
@@ -28,10 +28,10 @@ public struct DelegationScene: View {
             Section {
                 if let url = model.providerUrl {
                     SafariNavigationLink(url: url) {
-                        ListItemView(title: model.providerTitle, subtitle: model.providerText)
+                        ListItemView(field: model.providerField)
                     }
                 } else {
-                    ListItemView(title: model.providerTitle, subtitle: model.providerText)
+                    ListItemView(field: model.providerField)
                 }
 
                 if model.aprModel.showApr {
@@ -40,8 +40,8 @@ public struct DelegationScene: View {
 
                 ListItemView(title: model.stateTitle, subtitle: model.stateModel.title, subtitleStyle: model.stateModel.textStyle)
 
-                if let title = model.completionDateTitle, let subtitle = model.completionDateText {
-                    ListItemView(title: title, subtitle: subtitle)
+                if let completionDateField = model.completionDateField {
+                    ListItemView(field: completionDateField)
                 }
             }
 

--- a/Features/Stake/Sources/Scenes/StakeScene.swift
+++ b/Features/Stake/Sources/Scenes/StakeScene.swift
@@ -104,28 +104,19 @@ extension StakeScene {
                 infoAction: model.onAprInfo
             )
             ListItemView(
-                title: model.lockTimeTitle,
-                subtitle: model.lockTimeValue,
+                field: model.lockTimeField,
                 infoAction: model.onLockTimeInfo
             )
-            if let minAmountValue = model.minAmountValue {
-                ListItemView(title: model.minAmountTitle, subtitle: minAmountValue)
+            if let minAmountField = model.minAmountField {
+                ListItemView(field: minAmountField)
             }
         }
     }
 
     private var resourcesSection: some View {
         Section(model.resourcesTitle) {
-            ListItemView(
-                title: model.energyTitle,
-                subtitle: model.energyText
-            )
-
-            ListItemView(
-                title: model.bandwidthTitle,
-                subtitle: model.bandwidthText
-            )
+            ListItemView(field: model.energyField)
+            ListItemView(field: model.bandwidthField)
         }
-        
     }
 }

--- a/Features/Stake/Sources/ViewModels/DelegationSceneViewModel.swift
+++ b/Features/Stake/Sources/ViewModels/DelegationSceneViewModel.swift
@@ -41,14 +41,13 @@ public struct DelegationSceneViewModel {
         }
     }
 
-    public var providerTitle: String {
-        switch providerType {
+    public var providerField: ListItemField {
+        let title: String = switch providerType {
         case .stake: Localized.Stake.validator
         case .earn: Localized.Common.provider
         }
+        return ListItemField(title: title, value: model.validatorText)
     }
-
-    public var providerText: String { model.validatorText }
     public var aprModel: AprViewModel {
         AprViewModel(apr: model.delegation.validator.apr)
     }
@@ -67,8 +66,8 @@ public struct DelegationSceneViewModel {
         }
     }
 
-    public var completionDateTitle: String? {
-        switch providerType {
+    public var completionDateField: ListItemField? {
+        let title: String? = switch providerType {
         case .stake:
             switch model.state {
             case .pending, .deactivating: Localized.Stake.availableIn
@@ -77,13 +76,12 @@ public struct DelegationSceneViewModel {
             }
         case .earn: .none
         }
-    }
-
-    public var completionDateText: String? {
-        switch providerType {
+        let text: String? = switch providerType {
         case .stake: model.completionDateText
         case .earn: .none
         }
+        guard let title, let text else { return nil }
+        return ListItemField(title: title, value: text)
     }
 
     public var assetImageStyle: ListItemImageStyle? {
@@ -167,6 +165,8 @@ extension DelegationSceneViewModel {
             value: model.delegation.base.balanceValue
         )
     }
+
+    private var providerText: String { model.validatorText }
 
     private var providerType: StakeProviderType {
         model.delegation.validator.providerType

--- a/Features/Stake/Sources/ViewModels/StakeSceneViewModel.swift
+++ b/Features/Stake/Sources/ViewModels/StakeSceneViewModel.swift
@@ -69,20 +69,22 @@ public final class StakeSceneViewModel {
 
     var resourcesTitle: String { Localized.Asset.resources }
 
-    var energyTitle: String { ResourceViewModel(resource: .energy).title }
-    var energyText: String { balanceModel.energyText }
+    var energyField: ListItemField {
+        ListItemField(title: ResourceViewModel(resource: .energy).title, value: balanceModel.energyText)
+    }
 
-    var bandwidthTitle: String { ResourceViewModel(resource: .bandwidth).title }
-    var bandwidthText: String { balanceModel.bandwidthText }
+    var bandwidthField: ListItemField {
+        ListItemField(title: ResourceViewModel(resource: .bandwidth).title, value: balanceModel.bandwidthText)
+    }
 
     var freezeTitle: String { Localized.Transfer.Freeze.title }
     var unfreezeTitle: String { Localized.Transfer.Unfreeze.title }
 
-    var lockTimeTitle: String { Localized.Stake.lockTime }
-    var lockTimeValue: String {
+    var lockTimeField: ListItemField {
         let now = Date.now
         let date = now.addingTimeInterval(chain.lockTime)
-        return Self.lockTimeFormatter.string(from: now, to: date) ?? .empty
+        let value = Self.lockTimeFormatter.string(from: now, to: date) ?? .empty
+        return ListItemField(title: Localized.Stake.lockTime, value: value)
     }
     var lockTimeInfoSheet: InfoSheetType {
         InfoSheetType.stakeLockTime(assetModel.assetImage.placeholder)
@@ -92,10 +94,10 @@ public final class StakeSceneViewModel {
         InfoSheetType.stakeApr(assetModel.assetImage.placeholder)
     }
 
-    var minAmountTitle: String { Localized.Stake.minimumAmount }
-    var minAmountValue: String? {
+    var minAmountField: ListItemField? {
         guard chain.minAmount != 0 else { return .none }
-        return formatter.string(chain.minAmount, decimals: Int(asset.decimals), currency: asset.symbol)
+        let value = formatter.string(chain.minAmount, decimals: Int(asset.decimals), currency: asset.symbol)
+        return ListItemField(title: Localized.Stake.minimumAmount, value: value)
     }
 
     var delegationsErrorTitle: String { Localized.Errors.errorOccured }

--- a/Features/Stake/Tests/ViewModels/StakeSceneViewModelTests.swift
+++ b/Features/Stake/Tests/ViewModels/StakeSceneViewModelTests.swift
@@ -22,13 +22,13 @@ struct StakeSceneViewModelTests {
     }
     
     @Test
-    func testLockTimeValue() throws {
-        #expect(StakeSceneViewModel.mock(chain: .tron).lockTimeValue == "14 days")
+    func testLockTimeField() throws {
+        #expect(StakeSceneViewModel.mock(chain: .tron).lockTimeField.value.text == "14 days")
     }
-    
+
     @Test
     func minimumStakeAmount() throws {
-        #expect(StakeSceneViewModel.mock(chain: .tron).minAmountValue == "1.00 TRX")
+        #expect(StakeSceneViewModel.mock(chain: .tron).minAmountField?.value.text == "1.00 TRX")
     }
     
     @Test

--- a/Features/Swap/Sources/ViewModels/SwapDetailsViewModel.swift
+++ b/Features/Swap/Sources/ViewModels/SwapDetailsViewModel.swift
@@ -71,15 +71,14 @@ public final class SwapDetailsViewModel {
     }
     
     // MARK: - Estimation
-    var swapEstimationTitle: String { Localized.Swap.EstimatedTime.title }
-    var swapEstimationText: String? {
+    var swapEstimationField: ListItemField? {
         guard
             let estimation = selectedQuote.etaInSeconds, estimation > 60,
             let estimationTime = Self.timeFormatter.string(from: TimeInterval(estimation))
         else {
             return nil
         }
-        return String(format: "%@ %@", "≈", estimationTime)
+        return ListItemField(title: Localized.Swap.EstimatedTime.title, value: String(format: "%@ %@", "≈", estimationTime))
     }
     
     // MARK: - Rate
@@ -117,14 +116,17 @@ public final class SwapDetailsViewModel {
     }
     
     // MARK: - Slippage
-    var slippageTitle: String { Localized.Swap.slippage }
     var slippageValue: UInt32 { selectedQuote.slippageBps / 100 }
-    var slippageText: String { percentSignLessFormatter.string(Double(slippageValue).rounded(toPlaces: 2)) }
-    
+    var slippageField: ListItemField {
+        ListItemField(title: Localized.Swap.slippage, value: percentSignLessFormatter.string(Double(slippageValue).rounded(toPlaces: 2)))
+    }
+
     // MARK: - Min receive
-    var minReceiveTitle: String { Localized.Swap.minReceive }
-    var minReceiveText: String {
-        valueFormatter.string(selectedQuote.toValueBigInt.decrease(byPercent: Int(slippageValue)), asset: toAssetPrice.asset)
+    var minReceiveField: ListItemField {
+        ListItemField(
+            title: Localized.Swap.minReceive,
+            value: valueFormatter.string(selectedQuote.toValueBigInt.decrease(byPercent: Int(slippageValue)), asset: toAssetPrice.asset)
+        )
     }
 
     var fromAsset: Asset { fromAssetPrice.asset }

--- a/Features/Swap/Sources/Views/SwapDetailsView.swift
+++ b/Features/Swap/Sources/Views/SwapDetailsView.swift
@@ -74,23 +74,19 @@ public struct SwapDetailsView: View {
                     )
                 }
 
-                if let swapEstimation = model.swapEstimationText {
-                    ListItemView(title: model.swapEstimationTitle, subtitle: swapEstimation)
+                if let swapEstimationField = model.swapEstimationField {
+                    ListItemView(field: swapEstimationField)
                 }
-                
+
                 PriceImpactView(
                     model: model.priceImpactModel,
                     infoAction: model.onSelectPriceImpactInfoSheet
                 )
-                
-                ListItemView(
-                    title: model.minReceiveTitle,
-                    subtitle: model.minReceiveText
-                )
+
+                ListItemView(field: model.minReceiveField)
 
                 ListItemView(
-                    title: model.slippageTitle,
-                    subtitle: model.slippageText,
+                    field: model.slippageField,
                     infoAction: model.onSelectSlippageInfoSheet
                 )
             }

--- a/Features/Swap/Tests/SwapTests/SwapDetailsViewModelTests.swift
+++ b/Features/Swap/Tests/SwapTests/SwapDetailsViewModelTests.swift
@@ -15,13 +15,13 @@ import struct Gemstone.SwapperQuote
 @MainActor
 struct SwapDetailsViewModelTests {
     @Test
-    func swapEstimationText() throws {
+    func swapEstimationField() throws {
         #expect(
             SwapDetailsViewModel
-                .mock(selectedQuote: try SwapperQuote.mock(etaInSeconds: nil).map()).swapEstimationText == nil
+                .mock(selectedQuote: try SwapperQuote.mock(etaInSeconds: nil).map()).swapEstimationField == nil
         )
-        #expect(SwapDetailsViewModel.mock(selectedQuote: try SwapperQuote.mock(etaInSeconds: 30).map()).swapEstimationText == nil)
-        #expect(SwapDetailsViewModel.mock(selectedQuote: try SwapperQuote.mock(etaInSeconds: 180).map()).swapEstimationText == "≈ 3 min")
+        #expect(SwapDetailsViewModel.mock(selectedQuote: try SwapperQuote.mock(etaInSeconds: 30).map()).swapEstimationField == nil)
+        #expect(SwapDetailsViewModel.mock(selectedQuote: try SwapperQuote.mock(etaInSeconds: 180).map()).swapEstimationField?.value.text == "≈ 3 min")
     }
 
     @Test

--- a/Packages/Components/Sources/Lists/GridItemView.swift
+++ b/Packages/Components/Sources/Lists/GridItemView.swift
@@ -18,6 +18,10 @@ public struct GridItemView: View {
         self.valueAlignment = valueAlignment
     }
 
+    public init(field: ListItemField, valueAlignment: HorizontalAlignment = .trailing) {
+        self.init(title: field.title, value: field.value, valueAlignment: valueAlignment)
+    }
+
     public var body: some View {
         GridRow {
             Text(title.text)

--- a/Packages/Components/Sources/Lists/ListItemView.swift
+++ b/Packages/Components/Sources/Lists/ListItemView.swift
@@ -44,8 +44,8 @@ public struct ListItemView: View {
         ))
     }
     
-    public init(field: ListItemField) {
-        self.init(title: field.title, subtitle: field.value)
+    public init(field: ListItemField, infoAction: (() -> Void)? = nil) {
+        self.init(title: field.title, subtitle: field.value, infoAction: infoAction)
     }
 
     public init(

--- a/Packages/Components/Sources/Lists/ListItemView.swift
+++ b/Packages/Components/Sources/Lists/ListItemView.swift
@@ -44,6 +44,10 @@ public struct ListItemView: View {
         ))
     }
     
+    public init(field: ListItemField) {
+        self.init(title: field.title, subtitle: field.value)
+    }
+
     public init(
         title: TextValue? = nil,
         titleExtra: TextValue? = nil,

--- a/Packages/Components/Sources/Types/ListItemField.swift
+++ b/Packages/Components/Sources/Types/ListItemField.swift
@@ -1,0 +1,13 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Style
+
+public struct ListItemField {
+    public let title: TextValue
+    public let value: TextValue
+
+    public init(title: TextValue, value: TextValue) {
+        self.title = title
+        self.value = value
+    }
+}

--- a/Packages/Components/Sources/Types/ListItemField.swift
+++ b/Packages/Components/Sources/Types/ListItemField.swift
@@ -10,4 +10,11 @@ public struct ListItemField {
         self.title = title
         self.value = value
     }
+
+    public init(title: String, value: String) {
+        self.init(
+            title: TextValue(text: title, style: .body),
+            value: TextValue(text: value, style: .calloutSecondary)
+        )
+    }
 }

--- a/Packages/PrimitivesComponents/Sources/ViewModels/PerpetualDetailsViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/PerpetualDetailsViewModel.swift
@@ -56,11 +56,13 @@ public struct PerpetualDetailsViewModel: Sendable, Identifiable {
         )
     }
 
-    var positionTitle: String { Localized.Perpetual.position }
-    var positionText: String { "\(directionViewModel.title) \(leverageText)" }
-    var positionTextStyle: TextStyle {
-        TextStyle(font: .callout, color: directionViewModel.color)
+    var positionField: ListItemField {
+        ListItemField(
+            title: TextValue(text: Localized.Perpetual.position, style: .body),
+            value: TextValue(text: positionText, style: TextStyle(font: .callout, color: directionViewModel.color))
+        )
     }
+    var positionText: String { "\(directionViewModel.title) \(leverageText)" }
 
     var directionViewModel: PerpetualDirectionViewModel {
         let direction = switch type {
@@ -73,16 +75,17 @@ public struct PerpetualDetailsViewModel: Sendable, Identifiable {
     var leverageTitle: String { Localized.Perpetual.leverage}
     var leverageText: String { "\(data.leverage)x" }
 
-    var slippageTitle: String { Localized.Swap.slippage }
-    var slippageText: String { percentSignLessFormatter.string(data.slippage) }
+    var slippageField: ListItemField {
+        ListItemField(title: Localized.Swap.slippage, value: percentSignLessFormatter.string(data.slippage))
+    }
 
-    var marketPriceTitle: String { Localized.PriceAlerts.SetAlert.currentPrice }
-    var marketPriceText: String { currencyFormatter.string(data.marketPrice) }
+    var marketPriceField: ListItemField {
+        ListItemField(title: Localized.PriceAlerts.SetAlert.currentPrice, value: currencyFormatter.string(data.marketPrice))
+    }
 
-    var entryPriceTitle: String { Localized.Perpetual.entryPrice }
-    var entryPriceText: String? {
+    var entryPriceField: ListItemField? {
         guard let price = data.entryPrice else { return nil }
-        return currencyFormatter.string(price)
+        return ListItemField(title: Localized.Perpetual.entryPrice, value: currencyFormatter.string(price))
     }
 
     var pnlViewModel: PnLViewModel {
@@ -93,15 +96,23 @@ public struct PerpetualDetailsViewModel: Sendable, Identifiable {
             percentFormatter: percentFormatter
         )
     }
-    var pnlTitle: String { pnlViewModel.title }
+    var pnlField: ListItemField? {
+        guard let text = pnlViewModel.text else { return nil }
+        return ListItemField(
+            title: TextValue(text: pnlViewModel.title, style: .body),
+            value: TextValue(text: text, style: pnlViewModel.textStyle)
+        )
+    }
     var pnlText: String? { pnlViewModel.text }
     var pnlTextStyle: TextStyle { pnlViewModel.textStyle }
 
-    var marginTitle: String { Localized.Perpetual.margin }
-    var marginText: String { currencyFormatter.string(data.marginAmount) }
+    var marginField: ListItemField {
+        ListItemField(title: Localized.Perpetual.margin, value: currencyFormatter.string(data.marginAmount))
+    }
 
-    var sizeTitle: String { Localized.Perpetual.size }
-    var sizeText: String { currencyFormatter.string(data.fiatValue) }
+    var sizeField: ListItemField {
+        ListItemField(title: Localized.Perpetual.size, value: currencyFormatter.string(data.fiatValue))
+    }
 
     var autocloseTitle: String { Localized.Perpetual.autoClose }
     var autocloseText: (subtitle: String, subtitleExtra: String?) {

--- a/Packages/PrimitivesComponents/Sources/Views/PerpetualDetailsView.swift
+++ b/Packages/PrimitivesComponents/Sources/Views/PerpetualDetailsView.swift
@@ -16,31 +16,16 @@ public struct PerpetualDetailsView: View {
     public var body: some View {
         List {
             Section {
-                ListItemView(
-                    title: model.positionTitle,
-                    subtitle: model.positionText,
-                    subtitleStyle: model.positionTextStyle
-                )
+                ListItemView(field: model.positionField)
 
-                if let pnlText = model.pnlText {
-                    ListItemView(
-                        title: model.pnlTitle,
-                        subtitle: pnlText,
-                        subtitleStyle: model.pnlTextStyle
-                    )
+                if let pnlField = model.pnlField {
+                    ListItemView(field: pnlField)
                 }
             }
 
             Section {
-                ListItemView(
-                    title: model.marginTitle,
-                    subtitle: model.marginText
-                )
-
-                ListItemView(
-                    title: model.sizeTitle,
-                    subtitle: model.sizeText
-                )
+                ListItemView(field: model.marginField)
+                ListItemView(field: model.sizeField)
             }
 
             if model.showAutoclose {
@@ -54,22 +39,13 @@ public struct PerpetualDetailsView: View {
             }
 
             Section {
-                ListItemView(
-                    title: model.marketPriceTitle,
-                    subtitle: model.marketPriceText
-                )
+                ListItemView(field: model.marketPriceField)
 
-                if let entryPriceText = model.entryPriceText {
-                    ListItemView(
-                        title: model.entryPriceTitle,
-                        subtitle: entryPriceText
-                    )
+                if let entryPriceField = model.entryPriceField {
+                    ListItemView(field: entryPriceField)
                 }
 
-                ListItemView(
-                    title: model.slippageTitle,
-                    subtitle: model.slippageText
-                )
+                ListItemView(field: model.slippageField)
             }
         }
         .toolbarDismissItem(type: .close, placement: .topBarLeading)

--- a/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/PerpetualDetailsViewModelTests.swift
+++ b/Packages/PrimitivesComponents/Tests/PrimitivesComponentsTests/PerpetualDetailsViewModelTests.swift
@@ -14,24 +14,24 @@ struct PerpetualDetailsViewModelTests {
     }
 
     @Test
-    func slippageText() {
-        #expect(PerpetualDetailsViewModel.mock(.open(.mock(slippage: 2.0))).slippageText == "2.00%")
+    func slippageField() {
+        #expect(PerpetualDetailsViewModel.mock(.open(.mock(slippage: 2.0))).slippageField.value.text == "2.00%")
     }
 
     @Test
-    func entryPriceText() {
-        #expect(PerpetualDetailsViewModel.mock(.open(.mock(entryPrice: 48000.0))).entryPriceText == "$48,000.00")
-        #expect(PerpetualDetailsViewModel.mock(.open(.mock(entryPrice: nil))).entryPriceText == nil)
+    func entryPriceField() {
+        #expect(PerpetualDetailsViewModel.mock(.open(.mock(entryPrice: 48000.0))).entryPriceField?.value.text == "$48,000.00")
+        #expect(PerpetualDetailsViewModel.mock(.open(.mock(entryPrice: nil))).entryPriceField == nil)
     }
 
     @Test
-    func marginText() {
-        #expect(PerpetualDetailsViewModel.mock(.open(.mock(marginAmount: 1000.0))).marginText == "$1,000.00")
+    func marginField() {
+        #expect(PerpetualDetailsViewModel.mock(.open(.mock(marginAmount: 1000.0))).marginField.value.text == "$1,000.00")
     }
 
     @Test
-    func sizeText() {
-        #expect(PerpetualDetailsViewModel.mock(.open(.mock(fiatValue: 5000.0))).sizeText == "$5,000.00")
+    func sizeField() {
+        #expect(PerpetualDetailsViewModel.mock(.open(.mock(fiatValue: 5000.0))).sizeField.value.text == "$5,000.00")
     }
 
     @Test


### PR DESCRIPTION
Introduce a new ListItemField type in Components to encapsulate a title and value TextValue. Add convenience initializers ListItemView.init(field:) and GridItemView.init(field:) to accept the new type. Refactor Perpetuals code to use field-based APIs: PerpetualPortfolioScene, PerpetualPortfolioSceneViewModel (unrealizedPnlField, allTimePnlField), CandleTooltipViewModel (openField, closeField, highField, lowField, changeField, volumeField) and CandleTooltipView to use the new fields for cleaner wiring and consistent styling. No functional behavior changes intended.


Close: https://github.com/gemwalletcom/gem-ios/issues/1732
Close: https://github.com/gemwalletcom/gem-ios/issues/1735