### PR TITLE
Add asset FK

### DIFF
--- a/Features/WalletConnector/Tests/WalletConnectorTests/WalletConnectorSignerTests.swift
+++ b/Features/WalletConnector/Tests/WalletConnectorTests/WalletConnectorSignerTests.swift
@@ -91,7 +91,7 @@ struct WalletConnectorSignerTests {
 
     @Test
     func validateChainPresent() async throws {
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
         let connectionsStore = ConnectionsStore(db: db)
 
@@ -117,7 +117,7 @@ struct WalletConnectorSignerTests {
 
     @Test
     func validateChainEmptyChains() async throws {
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
         let connectionsStore = ConnectionsStore(db: db)
 
@@ -143,7 +143,7 @@ struct WalletConnectorSignerTests {
 
     @Test
     func sessionBindsToConnectedWallet() throws {
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
         let connectionsStore = ConnectionsStore(db: db)
 
@@ -194,7 +194,8 @@ extension WalletConnectorSigner {
     }
     
     static func mock(wallets: [Wallet]) throws -> WalletConnectorSigner {
-        let db = DB.mock()
+        let chains = wallets.flatMap { $0.accounts.map(\.chain) }.asSet()
+        let db = DB.mockWithChains(chains.asArray())
         let walletStore = WalletStore(db: db)
         for wallet in wallets {
             try walletStore.addWallet(wallet)

--- a/Packages/ChainServices/NodeService/Tests/NodeServiceTests.swift
+++ b/Packages/ChainServices/NodeService/Tests/NodeServiceTests.swift
@@ -17,7 +17,7 @@ struct NodeServiceTests {
 
     @Test
     func setNodeSelectedPersistsNode() throws {
-        let service = NodeService.mock()
+        let service = NodeService.mock(nodeStore: .mock(db: .mockWithChains([.ethereum])))
 
         try service.setNodeSelected(chain: .ethereum, node: Chain.ethereum.asiaChainNode.node)
 
@@ -26,7 +26,7 @@ struct NodeServiceTests {
 
     @Test
     func switchNode() throws {
-        let service = NodeService.mock()
+        let service = NodeService.mock(nodeStore: .mock(db: .mockWithChains([.ethereum])))
 
         try service.setNodeSelected(chain: .ethereum, node: Chain.ethereum.asiaChainNode.node)
         #expect(service.getNodeSelected(chain: .ethereum).node.url == Chain.ethereum.asiaChainNode.node.url)
@@ -37,7 +37,7 @@ struct NodeServiceTests {
 
     @Test
     func nodeURLFetchableReturnsSelectedUrl() throws {
-        let service = NodeService.mock()
+        let service = NodeService.mock(nodeStore: .mock(db: .mockWithChains([.ethereum])))
 
         try service.setNodeSelected(chain: .ethereum, node: Chain.ethereum.asiaChainNode.node)
 

--- a/Packages/FeatureServices/WalletService/Tests/WalletServiceTests.swift
+++ b/Packages/FeatureServices/WalletService/Tests/WalletServiceTests.swift
@@ -15,7 +15,7 @@ struct WalletServiceTests {
 
     @Test
     func importSecretPhraseDuplicateSameChain() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.ethereum, .aptos])))
 
         let wallet1 = try await service.loadOrCreateWallet(
             name: "First Wallet",
@@ -38,7 +38,7 @@ struct WalletServiceTests {
 
     @Test
     func importSecretPhraseNoDuplicateDifferentWords() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.ethereum])))
 
         let wallet1 = try await service.loadOrCreateWallet(
             name: "First Wallet",
@@ -60,7 +60,7 @@ struct WalletServiceTests {
 
     @Test
     func importSingleDuplicateSameChain() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.bitcoin])))
 
         let wallet1 = try await service.loadOrCreateWallet(
             name: "First Single",
@@ -83,7 +83,7 @@ struct WalletServiceTests {
 
     @Test
     func importSingleNoDuplicateDifferentChain() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.bitcoin, .litecoin])))
 
         let wallet1 = try await service.loadOrCreateWallet(
             name: "BTC Single",
@@ -104,7 +104,7 @@ struct WalletServiceTests {
 
     @Test
     func importPrivateKeyDuplicateSameChain() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.ethereum])))
 
         let wallet1 = try await service.loadOrCreateWallet(
             name: "First Wallet",
@@ -127,7 +127,7 @@ struct WalletServiceTests {
 
     @Test
     func importPrivateKeyNoDuplicateDifferentChain() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.ethereum, .smartChain])))
 
         let wallet1 = try await service.loadOrCreateWallet(
             name: "ETH Wallet",
@@ -148,7 +148,7 @@ struct WalletServiceTests {
 
     @Test
     func importViewOnlyDuplicateSameChain() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.ethereum])))
 
         let wallet1 = try await service.loadOrCreateWallet(
             name: "First View",
@@ -171,7 +171,7 @@ struct WalletServiceTests {
 
     @Test
     func importViewOnlyNoDuplicateDifferentChain() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.ethereum, .polygon])))
 
         let wallet1 = try await service.loadOrCreateWallet(
             name: "ETH View",
@@ -192,7 +192,7 @@ struct WalletServiceTests {
 
     @Test
     func importTypeMatchingExact() async throws {
-        let service = WalletService.mock()
+        let service = WalletService.mock(walletStore: .mock(db: .mockWithChains([.ethereum, .aptos])))
 
         let mnemonicWallet = try await service.loadOrCreateWallet(
             name: "Mnemonic",

--- a/Packages/Store/Sources/Migrations.swift
+++ b/Packages/Store/Sources/Migrations.swift
@@ -26,8 +26,8 @@ struct Migrations {
         migrator.registerMigration("Create all start table") { db in
             // wallet
             try WalletRecord.create(db: db)
-            try AccountRecord.create(db: db)
             try AssetRecord.create(db: db)
+            try AccountRecord.create(db: db)
             try BalanceRecord.create(db: db)
 
             // asset

--- a/Packages/Store/Sources/Models/AccountRecord.swift
+++ b/Packages/Store/Sources/Models/AccountRecord.swift
@@ -34,6 +34,7 @@ extension AccountRecord: CreateTable {
                 .references(WalletRecord.databaseTableName, onDelete: .cascade, onUpdate: .cascade)
             $0.column(Columns.chain.name, .text)
                 .notNull()
+                .references(AssetRecord.databaseTableName, onDelete: .cascade, onUpdate: .cascade)
             $0.column(Columns.address.name, .text)
                 .notNull()
             $0.column(Columns.extendedPublicKey.name, .text)

--- a/Packages/Store/Sources/Models/NodeRecord.swift
+++ b/Packages/Store/Sources/Models/NodeRecord.swift
@@ -31,6 +31,7 @@ extension NodeRecord: CreateTable {
             $0.column(Columns.chain.name, .text)
                 .notNull()
                 .indexed()
+                .references(AssetRecord.databaseTableName, onDelete: .cascade, onUpdate: .cascade)
             $0.column(Columns.status.name, .text)
             $0.column(Columns.priority.name, .integer)
         }

--- a/Packages/Store/Sources/Models/NodeSelectedRecord.swift
+++ b/Packages/Store/Sources/Models/NodeSelectedRecord.swift
@@ -21,6 +21,7 @@ extension NodeSelectedRecord: CreateTable {
     static func create(db: Database) throws {
         try db.create(table: Self.databaseTableName, ifNotExists: true) {
             $0.column(Columns.chain.name, .text).primaryKey()
+                .references(AssetRecord.databaseTableName, onDelete: .cascade, onUpdate: .cascade)
             $0.column(Columns.nodeUrl.name, .text).notNull()
         }
     }

--- a/Packages/Store/TestKit/DB+StoreTestKit.swift
+++ b/Packages/Store/TestKit/DB+StoreTestKit.swift
@@ -9,14 +9,26 @@ public extension DB {
     static func mock() -> DB {
         DB(fileName: "\(UUID().uuidString).sqlite")
     }
-    
+
+    static func mockWithChains(_ chains: [Chain] = [.bitcoin]) -> DB {
+        let db = Self.mock()
+        let assetStore = AssetStore(db: db)
+        try? assetStore.add(assets: chains.map { .mock(asset: .mock(id: $0.assetId)) })
+        return db
+    }
+
     static func mockAssets(assets: [AssetBasic] = .mock()) -> DB {
         let db = Self.mock()
         let assetStore = AssetStore(db: db)
         let balanceStore = BalanceStore(db: db)
         let walletStore = WalletStore(db: db)
 
-        try? assetStore.add(assets: assets)
+        let existingChainIds = assets.filter { $0.asset.type == .native }.map(\.asset.chain).asSet()
+        let allChains = assets.map(\.asset.chain).asSet()
+        let missingChains = allChains.subtracting(existingChainIds)
+        let chainAssets: [AssetBasic] = missingChains.map { .mock(asset: .mock(id: $0.assetId)) }
+
+        try? assetStore.add(assets: assets + chainAssets)
         try? walletStore.addWallet(.mock(accounts: assets.map { Account.mock(chain: $0.asset.chain) }))
         try? balanceStore.addBalance(assets.map { AddBalance(assetId: $0.asset.id, isEnabled: true) }, for: .mock())
         try? balanceStore.updateBalances(.mock(assets: assets), for: .mock())

--- a/Packages/Store/Tests/StoreTests/ConnectionsStoreTests.swift
+++ b/Packages/Store/Tests/StoreTests/ConnectionsStoreTests.swift
@@ -10,7 +10,7 @@ struct ConnectionsStoreTests {
 
     @Test
     func getConnectionReturnsBoundWallet() throws {
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
         let connectionsStore = ConnectionsStore(db: db)
 

--- a/Packages/Store/Tests/StoreTests/WalletIdMigrationTests.swift
+++ b/Packages/Store/Tests/StoreTests/WalletIdMigrationTests.swift
@@ -25,7 +25,7 @@ struct WalletIdMigrationTests {
     @Test
     func migrateMulticoinWallet() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum, .bitcoin])
         let walletStore = WalletStore(db: db)
 
         let oldId = "uuid-multicoin-1"
@@ -50,7 +50,7 @@ struct WalletIdMigrationTests {
     @Test
     func migrateViewWallet() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let oldId = "uuid-view-1"
@@ -75,7 +75,7 @@ struct WalletIdMigrationTests {
     @Test
     func migrateSingleWallet() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.bitcoin])
         let walletStore = WalletStore(db: db)
 
         let oldId = "uuid-single-1"
@@ -100,7 +100,7 @@ struct WalletIdMigrationTests {
     @Test
     func migratePrivateKeyWallet() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let oldId = "uuid-pk-1"
@@ -125,7 +125,7 @@ struct WalletIdMigrationTests {
     @Test
     func removeDuplicateMulticoinWallets() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let ethAddress = "0xsameaddress"
@@ -166,7 +166,7 @@ struct WalletIdMigrationTests {
     @Test
     func mixedWalletTypes() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum, .bitcoin, .solana])
         let walletStore = WalletStore(db: db)
 
         let multicoin = Wallet.mock(
@@ -208,7 +208,7 @@ struct WalletIdMigrationTests {
     @Test
     func updateChildTableReferences() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
         let balanceStore = BalanceStore(db: db)
         let assetStore = AssetStore(db: db)
@@ -243,7 +243,7 @@ struct WalletIdMigrationTests {
     @Test
     func multipleDuplicateGroups() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let address1 = "0xaddress1"
@@ -280,7 +280,7 @@ struct WalletIdMigrationTests {
     @Test
     func duplicateViewWallets() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let address = "0xviewaddr"
@@ -302,7 +302,7 @@ struct WalletIdMigrationTests {
     @Test
     func duplicateSingleWallets() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.bitcoin])
         let walletStore = WalletStore(db: db)
 
         let address = "bc1qsingle"
@@ -326,7 +326,7 @@ struct WalletIdMigrationTests {
     @Test
     func keepWalletWithLowestOrder() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let address = "0xordertest"
@@ -353,7 +353,7 @@ struct WalletIdMigrationTests {
     @Test
     func accountsUpdatedAfterMigration() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum, .bitcoin])
         let walletStore = WalletStore(db: db)
 
         let oldId = "uuid-accounts"
@@ -385,7 +385,7 @@ struct WalletIdMigrationTests {
     @Test
     func walletAlreadyInNewFormat() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let ethAddress = "0xalreadymigrated"
@@ -425,7 +425,7 @@ struct WalletIdMigrationTests {
     @Test
     func multipleAccountsConsistentSelection() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum, .bitcoin])
         let walletStore = WalletStore(db: db)
 
         let oldId = "uuid-multi-accounts"
@@ -459,7 +459,7 @@ struct WalletIdMigrationPreferenceTests {
     @Test
     func migrateCurrentWalletPreference() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let oldId = "uuid-current"
@@ -484,7 +484,7 @@ struct WalletIdMigrationPreferenceTests {
     @Test
     func setCurrentWalletWhenNoneSet() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         try walletStore.addWallet(.mock(id: "uuid-first", type: .multicoin, accounts: [.mock(chain: .ethereum, address: "0xfirst")]))
@@ -501,7 +501,7 @@ struct WalletIdMigrationPreferenceTests {
     @Test
     func fallbackCurrentWalletWhenInvalid() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         userDefaults.set("deleted-wallet-id", forKey: currentWalletKey)
@@ -520,7 +520,7 @@ struct WalletIdMigrationPreferenceTests {
     @Test
     func preserveCurrentWalletWhenAlreadyMigrated() throws {
         let userDefaults = UserDefaults.mock()
-        let db = DB.mock()
+        let db = DB.mockWithChains([.ethereum])
         let walletStore = WalletStore(db: db)
 
         let ethAddress = "0xalready"


### PR DESCRIPTION
Introduce DB.mockWithChains to pre-seed AssetStore for tests and update test cases to use it. Add foreign key references to AssetRecord on chain columns in AccountRecord, NodeRecord and NodeSelectedRecord to enforce referential integrity, and adjust migration ordering so AccountRecord is created after AssetRecord. Update WalletConnectorSigner.mock to seed the DB with chains derived from provided wallets.

- [ ] Test

Close: https://github.com/gemwalletcom/gem-ios/issues/1723