### PR TITLE
Clear injected preferences after wallet deletion and add tests

### DIFF
--- a/Packages/FeatureServices/WalletService/Tests/WalletServiceTests.swift
+++ b/Packages/FeatureServices/WalletService/Tests/WalletServiceTests.swift
@@ -1,5 +1,6 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
+import Observation
 import Testing
 import Primitives
 import Keystore
@@ -211,5 +212,27 @@ struct WalletServiceTests {
         #expect(mnemonicWallet.id != privateKeyWallet.id)
         #expect(mnemonicWallet.type == WalletType.multicoin)
         #expect(privateKeyWallet.type == WalletType.privateKey)
+    }
+
+    @Test
+    func deleteLastWalletNotifiesObservers() async throws {
+        let preferences = ObservablePreferences.mock()
+        let service = WalletService.mock(preferences: preferences)
+
+        let wallet = try await service.loadOrCreateWallet(
+            name: "Wallet",
+            type: .phrase(words: LocalKeystore.words, chains: [.ethereum]),
+            source: .import
+        )
+        try await service.setCurrent(wallet: wallet)
+
+        try await confirmation { confirm in
+            withObservationTracking {
+                _ = preferences.currentWalletId
+            } onChange: {
+                confirm()
+            }
+            try await service.delete(wallet)
+        }
     }
 }

--- a/Packages/FeatureServices/WalletService/WalletService.swift
+++ b/Packages/FeatureServices/WalletService/WalletService.swift
@@ -104,14 +104,15 @@ public struct WalletService: Sendable {
         try walletStore.deleteWallet(for: wallet.walletId)
         try avatarService.remove(for: wallet)
         WalletPreferences(walletId: wallet.walletId).clear()
-        if wallets.isEmpty {
-            Preferences.standard.clear()
-        }
 
         await MainActor.run {
             if currentWalletId == wallet.walletId {
                 walletSessionService.setCurrent(walletId: wallets.first?.walletId)
             }
+        }
+
+        if wallets.isEmpty {
+            preferences.preferences.clear()
         }
     }
 


### PR DESCRIPTION
Fix: app didn't return to onboarding screen after deleting the last wallet because preferences were cleared before the UI was notified about the wallet change.