### PR TITLE
Fix ENS name resolution by passing authenticated API provider

### DIFF
--- a/Gem/Services/ServicesFactory.swift
+++ b/Gem/Services/ServicesFactory.swift
@@ -226,6 +226,7 @@ struct ServicesFactory {
         let rateService = RateService(preferences: preferences)
 
         let onStartService = Self.makeOnstartService(
+            assetListService: apiService,
             assetStore: storeManager.assetStore,
             nodeStore: storeManager.nodeStore,
             preferences: preferences,
@@ -541,6 +542,7 @@ extension ServicesFactory {
     }
 
     private static func makeOnstartService(
+        assetListService: any GemAPIAssetsListService,
         assetStore: AssetStore,
         nodeStore: NodeStore,
         preferences: Preferences,
@@ -548,6 +550,7 @@ extension ServicesFactory {
         walletService: WalletService
     ) -> OnstartService {
         OnstartService(
+            assetListService: assetListService,
             assetsService: assetsService,
             assetStore: assetStore,
             nodeStore: nodeStore,

--- a/Gem/Services/ServicesFactory.swift
+++ b/Gem/Services/ServicesFactory.swift
@@ -254,7 +254,7 @@ struct ServicesFactory {
             perpetualService: perpetualService
         )
 
-        let nameService = NameService()
+        let nameService = NameService(provider: apiService)
         let scanService = ScanService(gatewayService: gatewayService)
         let addressNameService = AddressNameService(addressStore: storeManager.addressStore)
         let activityService = ActivityService(store: storeManager.recentActivityStore)

--- a/Packages/ChainServices/NameService/NameService.swift
+++ b/Packages/ChainServices/NameService/NameService.swift
@@ -7,7 +7,7 @@ import Primitives
 public final class NameService: NameServiceable, Sendable {
     private let provider: any GemAPINameService
 
-    public init(provider: any GemAPINameService = GemAPIService()) {
+    public init(provider: any GemAPINameService) {
         self.provider = provider
     }
     

--- a/Packages/ChainServices/NameService/NameService.swift
+++ b/Packages/ChainServices/NameService/NameService.swift
@@ -7,9 +7,7 @@ import Primitives
 public final class NameService: NameServiceable, Sendable {
     private let provider: any GemAPINameService
 
-    public init(
-        provider: any GemAPINameService = GemAPIService()
-    ) {
+    public init(provider: any GemAPINameService = GemAPIService()) {
         self.provider = provider
     }
     

--- a/Packages/FeatureServices/AppService/ConfigService.swift
+++ b/Packages/FeatureServices/AppService/ConfigService.swift
@@ -12,7 +12,7 @@ public actor ConfigService {
 
     public init(
         configPreferences: ConfigPreferences = .standard,
-        apiService: any GemAPIConfigService = GemAPIService()
+        apiService: any GemAPIConfigService
     ) {
         self.configPreferences = configPreferences
         self.apiService = apiService

--- a/Packages/FeatureServices/AppService/OnstartService.swift
+++ b/Packages/FeatureServices/AppService/OnstartService.swift
@@ -5,6 +5,7 @@ import Store
 import Primitives
 import NodeService
 import AssetsService
+import GemAPI
 import Preferences
 import WalletService
 import UIKit
@@ -13,6 +14,7 @@ import UIKit
 // See OnstartAsyncService for any background tasks to run after start
 public struct OnstartService: Sendable {
 
+    private let assetListService: any GemAPIAssetsListService
     private let assetsService: AssetsService
     private let assetStore: AssetStore
     private let nodeStore: NodeStore
@@ -20,12 +22,14 @@ public struct OnstartService: Sendable {
     private let walletService: WalletService
 
     public init(
+        assetListService: any GemAPIAssetsListService,
         assetsService: AssetsService,
         assetStore: AssetStore,
         nodeStore: NodeStore,
         preferences: Preferences,
         walletService: WalletService
     ) {
+        self.assetListService = assetListService
         self.assetsService = assetsService
         self.assetStore = assetStore
         self.nodeStore = nodeStore
@@ -58,6 +62,7 @@ extension OnstartService {
     private func migrations() throws {
         try walletService.setup(chains: AssetConfiguration.allChains)
         try ImportAssetsService(
+            assetListService: assetListService,
             assetsService: assetsService,
             assetStore: assetStore,
             preferences: preferences

--- a/Packages/FeatureServices/AppService/Tests/AppReleaseServiceTests.swift
+++ b/Packages/FeatureServices/AppService/Tests/AppReleaseServiceTests.swift
@@ -6,6 +6,7 @@ import Primitives
 import PrimitivesTestKit
 import Preferences
 import PreferencesTestKit
+import GemAPITestKit
 import AppServiceTestKit
 @testable import AppService
 
@@ -14,7 +15,7 @@ struct AppReleaseServiceTests {
     func newestRelease() async {
         let configPreferences = ConfigPreferences.mock()
         configPreferences.config = .mock()
-        let service = AppReleaseService(configService: ConfigService(configPreferences: configPreferences))
+        let service = AppReleaseService(configService: ConfigService(configPreferences: configPreferences, apiService: GemAPIConfigServiceMock(config: .mock())))
 
         #expect(await service.getNewestRelease()?.version == "16.1")
     }

--- a/Packages/FeatureServices/AssetsService/ImportAssetsService.swift
+++ b/Packages/FeatureServices/AssetsService/ImportAssetsService.swift
@@ -14,7 +14,7 @@ public struct ImportAssetsService: Sendable {
     let preferences: Preferences
     
     public init(
-        assetListService: any GemAPIAssetsListService = GemAPIService(),
+        assetListService: any GemAPIAssetsListService,
         assetsService: AssetsService,
         assetStore: AssetStore,
         preferences: Preferences

--- a/Packages/FeatureServices/AssetsService/TestKit/ImportAssetsService+TestKit.swift
+++ b/Packages/FeatureServices/AssetsService/TestKit/ImportAssetsService+TestKit.swift
@@ -2,6 +2,8 @@
 
 import Foundation
 import AssetsService
+import GemAPI
+import GemAPITestKit
 import Preferences
 import PreferencesTestKit
 import Store
@@ -9,11 +11,13 @@ import StoreTestKit
 
 public extension ImportAssetsService {
     static func mock(
+        assetListService: any GemAPIAssetsListService = GemAPIAssetsListServiceMock(),
         assetsService: AssetsService = .mock(),
         assetStore: AssetStore = .mock(),
         preferences: Preferences = .mock()
     ) -> ImportAssetsService {
         ImportAssetsService(
+            assetListService: assetListService,
             assetsService: assetsService,
             assetStore: assetStore,
             preferences: preferences

--- a/Packages/FeatureServices/NFTService/NFTService.swift
+++ b/Packages/FeatureServices/NFTService/NFTService.swift
@@ -12,7 +12,7 @@ public struct NFTService: Sendable {
     private let deviceService: any DeviceServiceable
 
     public init(
-        apiService: any GemAPINFTService = GemAPIService(),
+        apiService: any GemAPINFTService,
         nftStore: NFTStore,
         deviceService: any DeviceServiceable
     ) {

--- a/Packages/FeatureServices/NFTService/TestKit/NFTService+TestKit.swift
+++ b/Packages/FeatureServices/NFTService/TestKit/NFTService+TestKit.swift
@@ -2,12 +2,14 @@
 
 import Foundation
 import NFTService
+import GemAPITestKit
 import StoreTestKit
 import DeviceServiceTestKit
 
 public extension NFTService {
     static func mock() -> NFTService {
         NFTService(
+            apiService: GemAPINFTServiceMock(),
             nftStore: .mock(),
             deviceService: DeviceServiceMock()
         )

--- a/Packages/FeatureServices/Package.swift
+++ b/Packages/FeatureServices/Package.swift
@@ -305,6 +305,7 @@ let package = Package(
             name: "TransactionsServiceTestKit",
             dependencies: [
                 .product(name: "StoreTestKit", package: "Store"),
+                .product(name: "GemAPITestKit", package: "GemAPI"),
                 .product(name: "PreferencesTestKit", package: "Preferences"),
                 "AssetsServiceTestKit",
                 "TransactionsService",

--- a/Packages/FeatureServices/PriceAlertService/PriceAlertService.swift
+++ b/Packages/FeatureServices/PriceAlertService/PriceAlertService.swift
@@ -20,7 +20,7 @@ public struct PriceAlertService: Sendable {
 
     public init(
         store: PriceAlertStore,
-        apiService: any GemAPIPriceAlertService = GemAPIService(),
+        apiService: any GemAPIPriceAlertService,
         deviceService: any DeviceServiceable,
         priceUpdater: any PriceUpdater,
         preferences: Preferences = .standard

--- a/Packages/FeatureServices/TransactionsService/TestKit/TransactionsService+TestKit.swift
+++ b/Packages/FeatureServices/TransactionsService/TestKit/TransactionsService+TestKit.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import TransactionsService
+import GemAPITestKit
 import StoreTestKit
 import AssetsServiceTestKit
 import DeviceServiceTestKit
@@ -9,6 +10,7 @@ import DeviceServiceTestKit
 public extension TransactionsService {
     static func mock() -> TransactionsService {
         TransactionsService(
+            provider: GemAPITransactionServiceMock(),
             transactionStore: .mock(),
             assetsService: .mock(),
             walletStore: .mock(),

--- a/Packages/FeatureServices/TransactionsService/TransactionsService.swift
+++ b/Packages/FeatureServices/TransactionsService/TransactionsService.swift
@@ -17,7 +17,7 @@ public final class TransactionsService: Sendable {
     private let addressStore: AddressStore
     
     public init(
-        provider: any GemAPITransactionService = GemAPIService(),
+        provider: any GemAPITransactionService,
         transactionStore: TransactionStore,
         assetsService: AssetsService,
         walletStore: WalletStore,

--- a/Packages/GemAPI/TestKit/GemAPINFTService+TestKit.swift
+++ b/Packages/GemAPI/TestKit/GemAPINFTService+TestKit.swift
@@ -1,0 +1,13 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import GemAPI
+import Primitives
+
+public final class GemAPINFTServiceMock: GemAPINFTService, @unchecked Sendable {
+    public init() {}
+
+    public func getDeviceNFTAssets(walletId: String) async throws -> [NFTData] { [] }
+
+    public func reportNft(report: ReportNft) async throws {}
+}

--- a/Packages/GemAPI/TestKit/GemAPITransactionService+TestKit.swift
+++ b/Packages/GemAPI/TestKit/GemAPITransactionService+TestKit.swift
@@ -1,0 +1,17 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import GemAPI
+import Primitives
+
+public final class GemAPITransactionServiceMock: GemAPITransactionService, @unchecked Sendable {
+    public init() {}
+
+    public func getDeviceTransactions(walletId: String, fromTimestamp: Int) async throws -> TransactionsResponse {
+        TransactionsResponse(transactions: [], addressNames: [])
+    }
+
+    public func getDeviceTransactionsForAsset(walletId: String, asset: AssetId, fromTimestamp: Int) async throws -> TransactionsResponse {
+        TransactionsResponse(transactions: [], addressNames: [])
+    }
+}


### PR DESCRIPTION
NameService was using a default GemAPIService() without device authentication, causing "Missing header: x-device-id" errors after name resolution was moved to device-authenticated API endpoints.