### PR TITLE
Highlight assets in messages with bold markdown

### DIFF
--- a/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
+++ b/Features/InfoSheet/Sources/Factory/InfoSheetModelFactory.swift
@@ -25,7 +25,7 @@ public struct InfoSheetModelFactory {
         case let .insufficientBalance(asset, image):
             return InfoSheetModel(
                 title: Localized.Info.InsufficientBalance.title,
-                description: Localized.Info.InsufficientBalance.description(asset.symbol),
+                description: Localized.Info.InsufficientBalance.description(asset.symbol.boldMarkdown()),
                 image: .assetImage(image)
             )
         case let .insufficientNetworkFee(asset, image, required, action):
@@ -179,13 +179,13 @@ public struct InfoSheetModelFactory {
         case let .memoRequired(symbol):
             return InfoSheetModel(
                 title: Localized.Common.warning,
-                description: Localized.Errors.ScanTransaction.memoRequired(symbol),
+                description: Localized.Errors.ScanTransaction.memoRequired(symbol.boldMarkdown()),
                 image: .image(Images.Logo.logo)
             )
         case let .dustThreshold(chain, image):
             return InfoSheetModel(
                 title: Localized.Errors.transferError,
-                description: Localized.Errors.dustThreshold(chain.asset.name),
+                description: Localized.Errors.dustThreshold(chain.asset.name.boldMarkdown()),
                 image: .assetImage(image),
                 button: .url(Docs.url(.dust))
             )

--- a/Features/Transfer/Sources/Errors/ScanTransactionError.swift
+++ b/Features/Transfer/Sources/Errors/ScanTransactionError.swift
@@ -13,7 +13,7 @@ extension ScanTransactionError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .malicious: Localized.Errors.ScanTransaction.Malicious.description
-        case .memoRequired(let symbol): Localized.Errors.ScanTransaction.memoRequired(symbol)
+        case .memoRequired(let symbol): Localized.Errors.ScanTransaction.memoRequired(symbol.boldMarkdown())
         }
     }
 }

--- a/Packages/Validators/Sources/Errors/TransferAmountCalculatorError.swift
+++ b/Packages/Validators/Sources/Errors/TransferAmountCalculatorError.swift
@@ -25,10 +25,11 @@ extension TransferAmountCalculatorError: LocalizedError {
     }
 
     static private func title(asset: Asset) -> String {
-        asset.name == asset.symbol ? asset.name : String(format: "%@ (%@)", asset.name, asset.symbol)
+        let title = asset.name == asset.symbol ? asset.name : String(format: "%@ (%@)", asset.name, asset.symbol)
+        return title.boldMarkdown()
     }
 
     static private func formattedValue(_ value: BigInt, asset: Asset) -> String {
-        ValueFormatter(style: .full).string(value, asset: asset)
+        ValueFormatter(style: .full).string(value, asset: asset).boldMarkdown()
     }
 }

--- a/Packages/Validators/Sources/Errors/TransferError.swift
+++ b/Packages/Validators/Sources/Errors/TransferError.swift
@@ -16,11 +16,9 @@ extension TransferError: LocalizedError {
         case .invalidAmount:
             Localized.Errors.invalidAmount
         case let .minimumAmount(asset, required):
-            Localized.Transfer.minimumAmount(
-                ValueFormatter(style: .auto).string(required, asset: asset)
-            )
+            Localized.Transfer.minimumAmount(ValueFormatter(style: .auto).string(required, asset: asset).boldMarkdown())
         case .invalidAddress(let asset):
-            Localized.Errors.invalidAssetAddress(asset.name)
+            Localized.Errors.invalidAssetAddress(asset.name.boldMarkdown())
         }
     }
 }


### PR DESCRIPTION
Apply .boldMarkdown() to asset symbols, names, and formatted values in user-facing info and error messages to improve readability. Changes touch InfoSheetModelFactory, ScanTransactionError, TransferAmountCalculatorError (title and formattedValue), and TransferError (minimumAmount and invalidAddress). Also includes a minor local refactor in TransferAmountCalculatorError to use a temporary title variable.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-10 at 15 42 21" src="https://github.com/user-attachments/assets/1bc02c15-f5b2-4e5c-8428-95682f086872" />


Fix: https://github.com/gemwalletcom/gem-ios/issues/1762