### PR TITLE
Fix duplicate HTTP requests

### DIFF
--- a/Packages/FeatureServices/PerpetualService/HyperliquidObserverService.swift
+++ b/Packages/FeatureServices/PerpetualService/HyperliquidObserverService.swift
@@ -37,7 +37,6 @@ public actor HyperliquidObserverService: PerpetualObservable {
     // MARK: - Public API
 
     public func setup(for wallet: Wallet) async {
-        await update(for: wallet)
         await connect(for: wallet)
     }
 
@@ -77,6 +76,7 @@ public actor HyperliquidObserverService: PerpetualObservable {
 
         await disconnect()
         currentWallet = wallet
+        await update(for: wallet)
 
         guard observeTask == nil else { return }
 


### PR DESCRIPTION
Move update() inside connect() after the currentWallet guard to prevent duplicate fetchPositions calls when setup() is invoked multiple times on startup.