### PR TITLE
Extract StreamEventService from StreamObserverService

### DIFF
--- a/Gem/Services/ServicesFactory.swift
+++ b/Gem/Services/ServicesFactory.swift
@@ -176,7 +176,7 @@ struct ServicesFactory {
             priceUpdater: streamSubscriptionService,
             preferences: preferences
         )
-        let streamObserverService = Self.makeStreamObserverService(
+        let streamEventService = StreamEventService(
             walletStore: storeManager.walletStore,
             notificationStore: storeManager.inAppNotificationStore,
             priceService: priceService,
@@ -185,8 +185,11 @@ struct ServicesFactory {
             transactionsService: transactionsService,
             nftService: nftService,
             perpetualService: perpetualService,
+            preferences: preferences
+        )
+        let streamObserverService = StreamObserverService(
             subscriptionService: streamSubscriptionService,
-            preferences: preferences,
+            eventService: streamEventService,
             webSocket: webSocket
         )
         let explorerService = ExplorerService.standard
@@ -643,31 +646,4 @@ extension ServicesFactory {
         return WebSocketConnection(configuration: configuration)
     }
 
-    private static func makeStreamObserverService(
-        walletStore: WalletStore,
-        notificationStore: InAppNotificationStore,
-        priceService: PriceService,
-        priceAlertService: PriceAlertService,
-        balanceUpdater: any BalanceUpdater,
-        transactionsService: TransactionsService,
-        nftService: NFTService,
-        perpetualService: any HyperliquidPerpetualServiceable,
-        subscriptionService: StreamSubscriptionService,
-        preferences: Preferences,
-        webSocket: any WebSocketConnectable
-    ) -> StreamObserverService {
-        StreamObserverService(
-            walletStore: walletStore,
-            notificationStore: notificationStore,
-            priceService: priceService,
-            priceAlertService: priceAlertService,
-            balanceUpdater: balanceUpdater,
-            transactionsService: transactionsService,
-            nftService: nftService,
-            perpetualService: perpetualService,
-            subscriptionService: subscriptionService,
-            preferences: preferences,
-            webSocket: webSocket
-        )
-    }
 }

--- a/Packages/FeatureServices/StreamService/StreamEventService.swift
+++ b/Packages/FeatureServices/StreamService/StreamEventService.swift
@@ -1,0 +1,100 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Primitives
+import Store
+import PriceService
+import PriceAlertService
+import BalanceService
+import TransactionsService
+import NFTService
+import PerpetualService
+import Preferences
+
+public struct StreamEventService: Sendable {
+    private let walletStore: WalletStore
+    private let notificationStore: InAppNotificationStore
+    private let priceService: PriceService
+    private let priceAlertService: PriceAlertService
+    private let balanceUpdater: any BalanceUpdater
+    private let transactionsService: TransactionsService
+    private let nftService: NFTService
+    private let perpetualService: any HyperliquidPerpetualServiceable
+    private let preferences: Preferences
+
+    public init(
+        walletStore: WalletStore,
+        notificationStore: InAppNotificationStore,
+        priceService: PriceService,
+        priceAlertService: PriceAlertService,
+        balanceUpdater: any BalanceUpdater,
+        transactionsService: TransactionsService,
+        nftService: NFTService,
+        perpetualService: any HyperliquidPerpetualServiceable,
+        preferences: Preferences
+    ) {
+        self.walletStore = walletStore
+        self.notificationStore = notificationStore
+        self.priceService = priceService
+        self.priceAlertService = priceAlertService
+        self.balanceUpdater = balanceUpdater
+        self.transactionsService = transactionsService
+        self.nftService = nftService
+        self.perpetualService = perpetualService
+        self.preferences = preferences
+    }
+
+    public func handle(_ event: StreamEvent) async {
+        switch event {
+        case .prices(let payload):
+            await perform { try handlePrices(payload) }
+        case .balances(let updates):
+            Task { await self.perform { try await self.handleBalanceUpdates(updates) } }
+        case .transactions(let update):
+            Task { await self.perform { try await self.transactionsService.updateAll(walletId: update.walletId) } }
+        case .nft(let update):
+            Task { await self.perform { try await self.handleNftUpdate(update) } }
+        case .perpetual(let update):
+            Task { await self.perform { try await self.handlePerpetualUpdate(update) } }
+        case .inAppNotification(let update):
+            await perform { try notificationStore.addNotifications([update.notification]) }
+        case .priceAlerts:
+            Task { await self.perform { try await self.priceAlertService.update() } }
+        }
+    }
+}
+
+// MARK: - Private
+
+extension StreamEventService {
+    private func perform(_ body: () async throws -> Void) async {
+        do {
+            try await body()
+        } catch {
+            debugLog("stream event handler error: \(error)")
+        }
+    }
+
+    private func handlePrices(_ payload: WebSocketPricePayload) throws {
+        debugLog("stream event handler: prices: \(payload.prices.count), rates: \(payload.rates.count)")
+        try priceService.addRates(payload.rates)
+        try priceService.updatePrices(payload.prices, currency: preferences.currency)
+    }
+
+    private func handleBalanceUpdates(_ updates: [StreamBalanceUpdate]) async throws {
+        for (walletId, walletUpdates) in Dictionary(grouping: updates, by: \.walletId) {
+            guard let wallet = try walletStore.getWallet(id: walletId) else { continue }
+            await balanceUpdater.updateBalance(for: wallet, assetIds: walletUpdates.map(\.assetId))
+        }
+    }
+
+    private func handleNftUpdate(_ update: StreamNftUpdate) async throws {
+        guard let wallet = try walletStore.getWallet(id: update.walletId) else { return }
+        try await nftService.updateAssets(wallet: wallet)
+    }
+
+    private func handlePerpetualUpdate(_ update: StreamPerpetualUpdate) async throws {
+        guard let wallet = try walletStore.getWallet(id: update.walletId), let account = wallet.hyperliquidAccount else { return }
+        try await perpetualService.fetchPositions(walletId: update.walletId, address: account.address)
+    }
+}

--- a/Packages/FeatureServices/StreamService/StreamObserverService.swift
+++ b/Packages/FeatureServices/StreamService/StreamObserverService.swift
@@ -1,57 +1,23 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Preferences
 import Primitives
-import Store
 import WebSocketClient
-import PriceService
-import PriceAlertService
-import BalanceService
-import TransactionsService
-import NFTService
-import PerpetualService
 
 public actor StreamObserverService: Sendable {
-    private let walletStore: WalletStore
-    private let notificationStore: InAppNotificationStore
-    private let priceService: PriceService
-    private let priceAlertService: PriceAlertService
-    private let balanceUpdater: any BalanceUpdater
-    private let transactionsService: TransactionsService
-    private let nftService: NFTService
-    private let perpetualService: any PerpetualServiceable
     private let subscriptionService: StreamSubscriptionService
-
-    private let preferences: Preferences
-    private let decoder = JSONDateDecoder.standard
-
+    private let eventService: StreamEventService
     private let webSocket: any WebSocketConnectable
+    private let decoder = JSONDateDecoder.standard
     private var observeTask: Task<Void, Never>?
 
     public init(
-        walletStore: WalletStore,
-        notificationStore: InAppNotificationStore,
-        priceService: PriceService,
-        priceAlertService: PriceAlertService,
-        balanceUpdater: any BalanceUpdater,
-        transactionsService: TransactionsService,
-        nftService: NFTService,
-        perpetualService: any PerpetualServiceable,
         subscriptionService: StreamSubscriptionService,
-        preferences: Preferences,
+        eventService: StreamEventService,
         webSocket: any WebSocketConnectable
     ) {
-        self.walletStore = walletStore
-        self.notificationStore = notificationStore
-        self.priceService = priceService
-        self.priceAlertService = priceAlertService
-        self.balanceUpdater = balanceUpdater
-        self.transactionsService = transactionsService
-        self.nftService = nftService
-        self.perpetualService = perpetualService
         self.subscriptionService = subscriptionService
-        self.preferences = preferences
+        self.eventService = eventService
         self.webSocket = webSocket
     }
 
@@ -95,59 +61,10 @@ public actor StreamObserverService: Sendable {
 
     private func handleMessage(_ data: Data) async {
         do {
-            switch try decoder.decode(StreamEvent.self, from: data) {
-            case .prices(let payload):
-                try handlePrices(payload)
-            case .balances(let updates):
-                Task { await self.perform { try await self.handleBalanceUpdates(updates) } }
-            case .transactions(let update):
-                Task { await self.perform { try await self.transactionsService.updateAll(walletId: update.walletId) } }
-            case .nft(let update):
-                Task { await self.perform { try await self.handleNftUpdate(update) } }
-            case .perpetual(let update):
-                Task { await self.perform { try await self.handlePerpetualUpdate(update) } }
-            case .inAppNotification(let update):
-                try notificationStore.addNotifications([update.notification])
-            case .priceAlerts:
-                Task { await self.perform { try await self.priceAlertService.update() } }
-            }
+            let event = try decoder.decode(StreamEvent.self, from: data)
+            await eventService.handle(event)
         } catch {
             debugLog("stream observer: handleMessage error: \(error)")
         }
-    }
-}
-
-// MARK: - Event Handlers
-
-extension StreamObserverService {
-    private func perform(_ body: () async throws -> Void) async {
-        do {
-            try await body()
-        } catch {
-            debugLog("stream observer error: \(error)")
-        }
-    }
-
-    private func handlePrices(_ payload: WebSocketPricePayload) throws {
-        debugLog("stream observer: prices: \(payload.prices.count), rates: \(payload.rates.count)")
-        try priceService.addRates(payload.rates)
-        try priceService.updatePrices(payload.prices, currency: preferences.currency)
-    }
-
-    private func handleBalanceUpdates(_ updates: [StreamBalanceUpdate]) async throws {
-        for (walletId, walletUpdates) in Dictionary(grouping: updates, by: \.walletId) {
-            guard let wallet = try walletStore.getWallet(id: walletId) else { continue }
-            await balanceUpdater.updateBalance(for: wallet, assetIds: walletUpdates.map(\.assetId))
-        }
-    }
-
-    private func handleNftUpdate(_ update: StreamNftUpdate) async throws {
-        guard let wallet = try walletStore.getWallet(id: update.walletId) else { return }
-        try await nftService.updateAssets(wallet: wallet)
-    }
-
-    private func handlePerpetualUpdate(_ update: StreamPerpetualUpdate) async throws {
-        guard let wallet = try walletStore.getWallet(id: update.walletId), let account = wallet.hyperliquidAccount else { return }
-        try await perpetualService.fetchPositions(walletId: update.walletId, address: account.address)
     }
 }

--- a/Packages/FeatureServices/StreamService/TestKit/StreamEventService+TestKit.swift
+++ b/Packages/FeatureServices/StreamService/TestKit/StreamEventService+TestKit.swift
@@ -1,0 +1,46 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Foundation
+import Store
+import StoreTestKit
+import StreamService
+import PriceService
+import PriceServiceTestKit
+import PriceAlertService
+import PriceAlertServiceTestKit
+import BalanceService
+import BalanceServiceTestKit
+import TransactionsService
+import TransactionsServiceTestKit
+import NFTService
+import NFTServiceTestKit
+import PerpetualService
+import PerpetualServiceTestKit
+import Preferences
+import PreferencesTestKit
+
+public extension StreamEventService {
+    static func mock(
+        walletStore: WalletStore = .mock(),
+        notificationStore: InAppNotificationStore = .mock(),
+        priceService: PriceService = .mock(),
+        priceAlertService: PriceAlertService = .mock(),
+        balanceUpdater: any BalanceUpdater = .mock(),
+        transactionsService: TransactionsService = .mock(),
+        nftService: NFTService = .mock(),
+        perpetualService: any HyperliquidPerpetualServiceable = PerpetualServiceMock(),
+        preferences: Preferences = .mock()
+    ) -> StreamEventService {
+        StreamEventService(
+            walletStore: walletStore,
+            notificationStore: notificationStore,
+            priceService: priceService,
+            priceAlertService: priceAlertService,
+            balanceUpdater: balanceUpdater,
+            transactionsService: transactionsService,
+            nftService: nftService,
+            perpetualService: perpetualService,
+            preferences: preferences
+        )
+    }
+}

--- a/Packages/FeatureServices/StreamService/TestKit/StreamObserverService+TestKit.swift
+++ b/Packages/FeatureServices/StreamService/TestKit/StreamObserverService+TestKit.swift
@@ -1,51 +1,19 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
 import Foundation
-import Store
-import StoreTestKit
 import StreamService
-import PriceService
-import PriceServiceTestKit
-import PriceAlertService
-import PriceAlertServiceTestKit
-import BalanceService
-import BalanceServiceTestKit
-import TransactionsService
-import TransactionsServiceTestKit
-import NFTService
-import NFTServiceTestKit
-import PerpetualService
-import PerpetualServiceTestKit
-import Preferences
-import PreferencesTestKit
 import WebSocketClient
 import WebSocketClientTestKit
 
 public extension StreamObserverService {
     static func mock(
-        walletStore: WalletStore = .mock(),
-        notificationStore: InAppNotificationStore = .mock(),
-        priceService: PriceService = .mock(),
-        priceAlertService: PriceAlertService = .mock(),
-        balanceUpdater: any BalanceUpdater = .mock(),
-        transactionsService: TransactionsService = .mock(),
-        nftService: NFTService = .mock(),
-        perpetualService: any HyperliquidPerpetualServiceable = PerpetualServiceMock(),
         subscriptionService: StreamSubscriptionService = .mock(),
-        preferences: Preferences = .mock(),
+        eventService: StreamEventService = .mock(),
         webSocket: any WebSocketConnectable = WebSocketConnectionMock()
     ) -> StreamObserverService {
         StreamObserverService(
-            walletStore: walletStore,
-            notificationStore: notificationStore,
-            priceService: priceService,
-            priceAlertService: priceAlertService,
-            balanceUpdater: balanceUpdater,
-            transactionsService: transactionsService,
-            nftService: nftService,
-            perpetualService: perpetualService,
             subscriptionService: subscriptionService,
-            preferences: preferences,
+            eventService: eventService,
             webSocket: webSocket
         )
     }


### PR DESCRIPTION
Separate event handling logic into StreamEventService struct, reducing StreamObserverService init from 11 to 3 dependencies.