### PR TITLE
Introduce ListItemViewDisplayable and adapt views

### DIFF
--- a/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
+++ b/Features/Transactions/Sources/ViewModels/TransactionSceneViewModel.swift
@@ -31,7 +31,7 @@ public final class TransactionSceneViewModel {
         self.query = ObservableQuery(TransactionRequest(walletId: walletId, transactionId: transaction.id), initialValue: transaction)
     }
 
-    var title: String { model.titleTextValue.text }
+    var title: String { model.title.text }
     var explorerURL: URL { explorerViewModel.url }
 }
 

--- a/Features/Transactions/Tests/TransactionsTests/ViewModels/TransactionViewModelTests.swift
+++ b/Features/Transactions/Tests/TransactionsTests/ViewModels/TransactionViewModelTests.swift
@@ -21,12 +21,12 @@ final class TransactionViewModelTests {
     func autoValueFormatter() {
         let fromAsset = Asset.mockEthereum()
         let toAsset = Asset.mockEthereumUSDT()
-        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1000000"))).subtitleTextValue?.text == "+1.00 USDT")
-        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "10000"))).subtitleTextValue?.text == "+0.01 USDT")
-        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1000"))).subtitleTextValue?.text == "+0.001 USDT")
-        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "100"))).subtitleTextValue?.text == "+0.0001 USDT")
-        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "10"))).subtitleTextValue?.text == "+0.00 USDT")
-        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1"))).subtitleTextValue?.text == "+0.00 USDT")
+        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1000000"))).subtitle?.text == "+1.00 USDT")
+        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "10000"))).subtitle?.text == "+0.01 USDT")
+        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1000"))).subtitle?.text == "+0.001 USDT")
+        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "100"))).subtitle?.text == "+0.0001 USDT")
+        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "10"))).subtitle?.text == "+0.00 USDT")
+        #expect(TransactionViewModel.mock(metadata: .encode(TransactionSwapMetadata.mock(fromAsset: fromAsset.id, toAsset: toAsset.id, toValue: "1"))).subtitle?.text == "+0.00 USDT")
     }
     
     @Test
@@ -58,7 +58,7 @@ final class TransactionViewModelTests {
             toAddress: toAddress,
             metadata: .encode(TransactionSwapMetadata.mock())
         )
-        #expect(hyperliquidViewModel.titleExtraTextValue?.text.contains("Hyperliquid") == true)
+        #expect(hyperliquidViewModel.titleExtra?.text.contains("Hyperliquid") == true)
 
         let fromAddress = AddressName.mock(address: "0x1111111111111111111111111111111111111111", name: "Sender")
         let incomingViewModel = TransactionViewModel.mock(
@@ -68,7 +68,7 @@ final class TransactionViewModelTests {
             fromAddress: fromAddress,
             metadata: .encode(TransactionSwapMetadata.mock())
         )
-        #expect(incomingViewModel.titleExtraTextValue?.text.contains("Sender") == true)
+        #expect(incomingViewModel.titleExtra?.text.contains("Sender") == true)
 
         let unknownViewModel = TransactionViewModel.mock(
             type: .transfer,
@@ -76,8 +76,8 @@ final class TransactionViewModelTests {
             participant: "0x1234567890abcdef1234567890abcdef12345678",
             metadata: .encode(TransactionSwapMetadata.mock())
         )
-        #expect(unknownViewModel.titleExtraTextValue?.text.contains("0x1234") == true)
-        #expect(unknownViewModel.titleExtraTextValue?.text.contains("5678") == true)
+        #expect(unknownViewModel.titleExtra?.text.contains("0x1234") == true)
+        #expect(unknownViewModel.titleExtra?.text.contains("5678") == true)
     }
 
     @Test
@@ -87,14 +87,14 @@ final class TransactionViewModelTests {
             asset: .hypercoreUSDC(),
             metadata: .encode(TransactionPerpetualMetadata.mock(price: 50000.50))
         )
-        #expect(openPositionModel.titleExtraTextValue?.text == "Price: $50,000.50")
+        #expect(openPositionModel.titleExtra?.text == "Price: $50,000.50")
 
         let closePositionModel = TransactionViewModel.mock(
             type: .perpetualClosePosition,
             asset: .hypercoreUSDC(),
             metadata: .encode(TransactionPerpetualMetadata.mock(price: 49999.99))
         )
-        #expect(closePositionModel.titleExtraTextValue?.text == "Price: $49,999.99")
+        #expect(closePositionModel.titleExtra?.text == "Price: $49,999.99")
     }
 
     @Test
@@ -105,7 +105,7 @@ final class TransactionViewModelTests {
             asset: .hypercoreUSDC(),
             metadata: .encode(TransactionPerpetualMetadata.mock())
         )
-        #expect(model.subtitleTextValue?.text == "$1.00")
+        #expect(model.subtitle?.text == "$1.00")
     }
 
     @Test
@@ -115,14 +115,14 @@ final class TransactionViewModelTests {
             asset: .hypercoreUSDC(),
             metadata: .encode(TransactionPerpetualMetadata.mock(pnl: 125.50))
         )
-        #expect(profitModel.subtitleTextValue?.text == "+$125.50")
+        #expect(profitModel.subtitle?.text == "+$125.50")
 
         let lossModel = TransactionViewModel.mock(
             type: .perpetualClosePosition,
             asset: .hypercoreUSDC(),
             metadata: .encode(TransactionPerpetualMetadata.mock(pnl: -75.25))
         )
-        #expect(lossModel.subtitleTextValue?.text == "-$75.25")
+        #expect(lossModel.subtitle?.text == "-$75.25")
     }
 
     @Test
@@ -132,7 +132,7 @@ final class TransactionViewModelTests {
             asset: .hypercoreUSDC(),
             metadata: .encode(TransactionPerpetualMetadata.mock(pnl: 0))
         )
-        #expect(model.subtitleTextValue == nil)
+        #expect(model.subtitle == nil)
     }
 
     @Test
@@ -141,13 +141,13 @@ final class TransactionViewModelTests {
             type: .stakeFreeze,
             metadata: .object(["resourceType": .string("bandwidth")])
         )
-        #expect(bandwidthModel.titleExtraTextValue?.text == "To Bandwidth")
+        #expect(bandwidthModel.titleExtra?.text == "To Bandwidth")
 
         let energyModel = TransactionViewModel.mock(
             type: .stakeFreeze,
             metadata: .object(["resourceType": .string("energy")])
         )
-        #expect(energyModel.titleExtraTextValue?.text == "To Energy")
+        #expect(energyModel.titleExtra?.text == "To Energy")
     }
 
     @Test
@@ -156,13 +156,13 @@ final class TransactionViewModelTests {
             type: .stakeUnfreeze,
             metadata: .object(["resourceType": .string("bandwidth")])
         )
-        #expect(bandwidthModel.titleExtraTextValue?.text == "From Bandwidth")
+        #expect(bandwidthModel.titleExtra?.text == "From Bandwidth")
 
         let energyModel = TransactionViewModel.mock(
             type: .stakeUnfreeze,
             metadata: .object(["resourceType": .string("energy")])
         )
-        #expect(energyModel.titleExtraTextValue?.text == "From Energy")
+        #expect(energyModel.titleExtra?.text == "From Energy")
     }
 
     @Test
@@ -171,11 +171,11 @@ final class TransactionViewModelTests {
             type: .stakeFreeze,
             metadata: .null
         )
-        #expect(model.titleExtraTextValue == nil)
+        #expect(model.titleExtra == nil)
     }
 
     func testTransactionTitle(expectedTitle: String, transaction: Transaction) {
-        #expect(TransactionViewModel(explorerService: MockExplorerLink(), transaction: .mock(transaction: transaction), currency: "USD").titleTextValue.text == expectedTitle)
+        #expect(TransactionViewModel(explorerService: MockExplorerLink(), transaction: .mock(transaction: transaction), currency: "USD").title.text == expectedTitle)
     }
 }
 

--- a/Packages/Components/Sources/Lists/ListItemView.swift
+++ b/Packages/Components/Sources/Lists/ListItemView.swift
@@ -48,6 +48,18 @@ public struct ListItemView: View {
         self.init(title: field.title, subtitle: field.value, infoAction: infoAction)
     }
 
+    public init(_ displayable: some ListItemViewDisplayable) {
+        self.init(
+            title: displayable.title,
+            titleExtra: displayable.titleExtra,
+            titleTag: displayable.titleTag,
+            titleTagType: displayable.titleTagType,
+            subtitle: displayable.subtitle,
+            subtitleExtra: displayable.subtitleExtra,
+            imageStyle: displayable.imageStyle
+        )
+    }
+
     public init(
         title: TextValue? = nil,
         titleExtra: TextValue? = nil,

--- a/Packages/Components/Sources/Lists/ListItemViewDisplayable.swift
+++ b/Packages/Components/Sources/Lists/ListItemViewDisplayable.swift
@@ -1,0 +1,23 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Style
+
+public protocol ListItemViewDisplayable {
+    var title: TextValue? { get }
+    var titleExtra: TextValue? { get }
+    var titleTag: TextValue? { get }
+    var titleTagType: TitleTagType { get }
+    var subtitle: TextValue? { get }
+    var subtitleExtra: TextValue? { get }
+    var imageStyle: ListItemImageStyle? { get }
+}
+
+public extension ListItemViewDisplayable {
+    var title: TextValue? { nil }
+    var titleExtra: TextValue? { nil }
+    var titleTag: TextValue? { nil }
+    var titleTagType: TitleTagType { .none }
+    var subtitle: TextValue? { nil }
+    var subtitleExtra: TextValue? { nil }
+    var imageStyle: ListItemImageStyle? { nil }
+}

--- a/Packages/PrimitivesComponents/Sources/Components/TransactionView.swift
+++ b/Packages/PrimitivesComponents/Sources/Components/TransactionView.swift
@@ -1,9 +1,8 @@
 // Copyright (c). Gem Wallet. All rights reserved.
 
-import SwiftUI
 import Components
 import Primitives
-import Style
+import SwiftUI
 
 public struct TransactionView: View {
     @State private var isPresentingUrl: URL? = nil
@@ -14,15 +13,7 @@ public struct TransactionView: View {
     }
 
     public var body: some View {
-        ListItemView(
-            title: model.titleTextValue,
-            titleExtra: model.titleExtraTextValue,
-            titleTag: model.titleTagTextValue,
-            titleTagType: model.titleTagType,
-            subtitle: model.subtitleTextValue,
-            subtitleExtra: model.subtitleExtraTextValue,
-            imageStyle: .asset(assetImage: model.assetImage)
-        )
+        ListItemView(model)
         .contextMenu(
             .url(title: model.viewOnTransactionExplorerText, onOpen: { isPresentingUrl = model.transactionExplorerUrl })
         )

--- a/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/TransactionViewModel.swift
@@ -9,7 +9,7 @@ import Primitives
 import Style
 import SwiftUI
 
-public struct TransactionViewModel: Sendable {
+public struct TransactionViewModel: Sendable, ListItemViewDisplayable {
     public let transaction: TransactionExtended
 
     private let explorerService: any ExplorerLinkFetchable
@@ -43,6 +43,10 @@ public struct TransactionViewModel: Sendable {
             placeholder: asset.placeholder,
             chainPlaceholder: overlayImage
         )
+    }
+
+    public var imageStyle: ListItemImageStyle? {
+        .asset(assetImage: assetImage)
     }
 
     public var overlayImage: Image? {
@@ -89,7 +93,7 @@ public struct TransactionViewModel: Sendable {
         )
     }
 
-    public var titleTextValue: TextValue {
+    public var title: TextValue {
         let title: String = {
             switch transaction.transaction.type {
             case .transfer, .transferNFT, .smartContractCall:
@@ -156,7 +160,7 @@ public struct TransactionViewModel: Sendable {
         }
     }
 
-    public var titleTagTextValue: TextValue? {
+    public var titleTag: TextValue? {
         let title: String? = switch transaction.transaction.state {
         case .confirmed: .none
         case .pending, .inTransit, .failed, .reverted: TransactionStateViewModel(state: transaction.transaction.state).title
@@ -174,7 +178,7 @@ public struct TransactionViewModel: Sendable {
         }
     }
 
-    public var titleExtraTextValue: TextValue? {
+    public var titleExtra: TextValue? {
         let title: String? = {
             let chain = assetId.chain
             switch transaction.transaction.type {
@@ -237,7 +241,7 @@ public struct TransactionViewModel: Sendable {
         }
     }
 
-    public var subtitleTextValue: TextValue? {
+    public var subtitle: TextValue? {
         switch transaction.transaction.type {
         case .transfer,
             .smartContractCall,
@@ -283,7 +287,7 @@ public struct TransactionViewModel: Sendable {
         }
     }
 
-    public var subtitleExtraTextValue: TextValue? {
+    public var subtitleExtra: TextValue? {
         switch transaction.transaction.type {
         case .transfer,
                 .transferNFT,


### PR DESCRIPTION
Add a ListItemViewDisplayable protocol and a ListItemView initializer that accepts any displayable. Update TransactionViewModel to conform to the protocol and expose imageStyle, title, titleExtra, titleTag, subtitle, and subtitleExtra (replacing the former *TextValue property names). Use the new ListItemView(model) initializer in TransactionView and adjust TransactionSceneViewModel and unit tests to reference the renamed properties. Also perform small import cleanup in TransactionView. These changes centralize list item presentation and simplify wiring between view models and list views.

Close: https://github.com/gemwalletcom/gem-ios/issues/1060