### PR TITLE
Show verified badge in collectible header

### DIFF
--- a/Features/NFT/Sources/Scenes/CollectibleScene.swift
+++ b/Features/NFT/Sources/Scenes/CollectibleScene.swift
@@ -34,6 +34,19 @@ public struct CollectibleScene: View {
         .environment(\.defaultMinListHeaderHeight, 0)
         .listSectionSpacing(.compact)
         .navigationTitle(model.title)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                HStack(spacing: Spacing.tiny) {
+                    Text(model.title)
+                        .font(.headline)
+                    if model.isVerified {
+                        Images.System.checkmarkSealFill
+                            .font(.footnote)
+                            .foregroundStyle(Colors.blue)
+                    }
+                }
+            }
+        }
         .alertSheet($model.isPresentingAlertMessage)
         .toast(message: $model.isPresentingToast)
         .safariSheet(url: $model.isPresentingTokenExplorerUrl)

--- a/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
+++ b/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
@@ -55,6 +55,10 @@ public final class CollectibleViewModel {
         ListItemField(title: Localized.Nft.collection, value: assetData.collection.name)
     }
 
+    var isVerified: Bool {
+        assetData.collection.status == .verified
+    }
+
     var networkField: ListItemField {
         ListItemField(title: Localized.Transfer.network, value: assetData.asset.chain.asset.name)
     }


### PR DESCRIPTION
Add a toolbar principal item to CollectibleScene that displays the collectible title alongside a blue checkmark seal when the collection is verified. Introduce CollectibleViewModel.isVerified computed property (assetData.collection.status == .verified) to drive the UI condition.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-17 at 12 47 58" src="https://github.com/user-attachments/assets/d0a620f7-a94e-4889-a12b-5063420b1204" />
