### PR TITLE
Add contract explorer link to context menu

### DIFF
--- a/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
+++ b/Features/NFT/Sources/ViewModels/CollectibleViewModel.swift
@@ -68,10 +68,19 @@ public final class CollectibleViewModel {
         return ListItemField(title: Localized.Asset.contract, value: text)
     }
 
+    var contractExplorerUrl: BlockExplorerLink? {
+        explorerService.tokenUrl(chain: assetData.asset.chain, address: contractValue)
+    }
+
     var contractContextMenu: [ContextMenuItemType] {
-        [.copy(value: contractValue, onCopy: { [weak self] value in
-            self?.isPresentingToast = .copied(value)
-        })]
+        [
+            .copy(value: contractValue, onCopy: { [weak self] value in
+                self?.isPresentingToast = .copied(value)
+            }),
+            contractExplorerUrl.map {
+                .url(title: Localized.Transaction.viewOn($0.name), onOpen: onSelectViewContractInExplorer)
+            }
+        ].compactMap { $0 }
     }
 
     var tokenIdValue: String { assetData.asset.tokenId }
@@ -227,9 +236,11 @@ extension CollectibleViewModel {
     }
     
     func onSelectViewTokenInExplorer() {
-        guard let explorerLink = tokenExplorerUrl else { return }
-        guard let url = URL(string: explorerLink.link) else { return }
-        isPresentingTokenExplorerUrl = url
+        isPresentingTokenExplorerUrl = tokenExplorerUrl?.url
+    }
+
+    func onSelectViewContractInExplorer() {
+        isPresentingTokenExplorerUrl = contractExplorerUrl?.url
     }
 
     func onSelectReport() {


### PR DESCRIPTION
Expose a contractExplorerUrl and include a "View on <explorer>" item in the contract context menu (filtered when nil). Refactor explorer presentation: onSelectViewTokenInExplorer now assigns the tokenExplorerUrl?.url directly, and a new onSelectViewContractInExplorer presents the contract explorer URL. This enables opening the contract in a block explorer when available.

Close: https://github.com/gemwalletcom/gem-ios/issues/1797