### PR TITLE
Add auto-alert toggle and priceQuery

### DIFF
--- a/Features/PriceAlerts/Sources/Scenes/AssetPriceAlertsScene.swift
+++ b/Features/PriceAlerts/Sources/Scenes/AssetPriceAlertsScene.swift
@@ -17,14 +17,12 @@ public struct AssetPriceAlertsScene: View {
     
     public var body: some View {
         List {
-            if let autoAlert = model.autoAlertModel {
-                Section {
-                    alertView(model: autoAlert)
-                } footer: {
-                    Text(Localized.PriceAlerts.autoFooter)
-                }
+            Section {
+                autoAlertToggleView
+            } footer: {
+                Text(Localized.PriceAlerts.autoFooter)
             }
-            
+
             if model.alertsModel.isNotEmpty {
                 Section {
                     ForEach(model.alertsModel, id: \.data.priceAlert.id) { alertModel in
@@ -35,12 +33,8 @@ public struct AssetPriceAlertsScene: View {
                 }
             }
         }
-        .overlay {
-            if model.showEmptyState {
-                EmptyContentView(model: model.emptyContentModel)
-            }
-        }
         .bindQuery(model.query)
+        .bindQuery(model.priceQuery)
         .listSectionSpacing(.compact)
         .refreshable { await model.fetch() }
         .task { await model.fetch() }
@@ -65,6 +59,13 @@ public struct AssetPriceAlertsScene: View {
         .toast(message: $model.isPresentingToastMessage)
     }
     
+    private var autoAlertToggleView: some View {
+        Toggle(isOn: model.isAutoAlertEnabledBinding) {
+            ListAssetItemView(model: model.autoAlertItemModel)
+        }
+        .toggleStyle(AppToggleStyle())
+    }
+
     private func alertView(model: PriceAlertItemViewModel) -> some View {
         ListAssetItemView(model: model)
             .swipeActions(edge: .trailing) {
@@ -79,7 +80,7 @@ public struct AssetPriceAlertsScene: View {
 // MARK: - Actions
 
 extension AssetPriceAlertsScene {
-    func onDelete(alert: PriceAlert) {
+    private func onDelete(alert: PriceAlert) {
         Task {
             await model.deletePriceAlert(priceAlert: alert)
         }

--- a/Features/PriceAlerts/Sources/ViewModels/AssetPriceAlertsViewModel.swift
+++ b/Features/PriceAlerts/Sources/ViewModels/AssetPriceAlertsViewModel.swift
@@ -8,6 +8,7 @@ import PriceAlertService
 import PrimitivesComponents
 import Components
 import Style
+import Preferences
 
 @Observable
 @MainActor
@@ -17,6 +18,7 @@ public final class AssetPriceAlertsViewModel: Sendable {
     let asset: Asset
 
     public let query: ObservableQuery<PriceAlertsRequest>
+    public let priceQuery: ObservableQuery<PriceRequest>
     var priceAlerts: [PriceAlertData] { query.value }
 
     var isPresentingSetPriceAlert: Bool = false
@@ -31,14 +33,26 @@ public final class AssetPriceAlertsViewModel: Sendable {
         self.walletId = walletId
         self.asset = asset
         self.query = ObservableQuery(PriceAlertsRequest(assetId: asset.id), initialValue: [])
+        self.priceQuery = ObservableQuery(PriceRequest(assetId: asset.id), initialValue: nil)
     }
     
     var title: String { Localized.Settings.PriceAlerts.title }
-    
-    var autoAlertModel: PriceAlertItemViewModel? {
-        priceAlerts
-            .first(where: { $0.priceAlert.type == .auto })
-            .map { PriceAlertItemViewModel(data: $0) }
+
+    var autoAlertItemModel: PriceAlertItemViewModel {
+        PriceAlertItemViewModel(data: PriceAlertData(
+            asset: asset,
+            price: priceQuery.value?.price,
+            priceAlert: .default(for: asset.id, currency: Preferences.standard.currency)
+        ))
+    }
+
+    var isAutoAlertEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { self.priceAlerts.contains(where: { $0.priceAlert.type == .auto }) },
+            set: { newValue in
+                Task { await self.toggleAutoAlert(enabled: newValue) }
+            }
+        )
     }
 
     var alertsModel: [PriceAlertItemViewModel] {
@@ -50,14 +64,6 @@ public final class AssetPriceAlertsViewModel: Sendable {
                 KeyPathComparator(\.priceAlert.pricePercentChange, order: .reverse)
             ])
             .map { PriceAlertItemViewModel(data: $0) }
-    }
-    
-    var showEmptyState: Bool {
-        alertsModel.isEmpty && autoAlertModel == nil
-    }
-
-    var emptyContentModel: EmptyContentTypeViewModel {
-        EmptyContentTypeViewModel(type: .priceAlerts)
     }
 }
 
@@ -72,6 +78,21 @@ extension AssetPriceAlertsViewModel {
         }
     }
     
+    func toggleAutoAlert(enabled: Bool) async {
+        let currency = Preferences.standard.currency
+        do {
+            if enabled {
+                try await priceAlertService.add(priceAlert: .default(for: asset.id, currency: currency))
+                try await priceAlertService.requestPermissions()
+                try await priceAlertService.enablePriceAlerts()
+            } else {
+                try await priceAlertService.delete(priceAlerts: [.default(for: asset.id, currency: currency)])
+            }
+        } catch {
+            debugLog("toggleAutoAlert error: \(error)")
+        }
+    }
+
     func deletePriceAlert(priceAlert: PriceAlert) async {
         do {
             try await priceAlertService.delete(priceAlerts: [priceAlert])

--- a/Features/PriceAlerts/Tests/PriceAlertsTests/AssetPriceAlertsViewModelTests.swift
+++ b/Features/PriceAlerts/Tests/PriceAlertsTests/AssetPriceAlertsViewModelTests.swift
@@ -23,17 +23,7 @@ struct AssetPriceAlertsViewModelTests {
         model.query.value = [alert1, alert2, alert3, autoAlert]
 
         #expect(model.alertsModel.map { $0.data } == [alert3, alert2, alert1])
-        #expect(model.autoAlertModel?.data == autoAlert)
-    }
-
-    @Test
-    func showEmptyState() {
-        let emptyModel = AssetPriceAlertsViewModel.mock()
-        #expect(emptyModel.showEmptyState == true)
-
-        let modelWithAlerts = AssetPriceAlertsViewModel.mock()
-        modelWithAlerts.query.value = [PriceAlertData.mock()]
-        #expect(modelWithAlerts.showEmptyState == false)
+        #expect(model.isAutoAlertEnabledBinding.wrappedValue == true)
     }
 }
 


### PR DESCRIPTION
Replace conditional auto-alert row with a Toggle-backed view and add a priceQuery to support showing current price. Introduces autoAlertItemModel and isAutoAlertEnabledBinding in the view model, plus toggleAutoAlert(enabled:) to add/delete the default auto alert and handle permissions. Scene now binds priceQuery (instead of query), exposes a dedicated autoAlertToggleView, removes the empty-state overlay, and makes onDelete private. Tests updated to assert the new binding behavior.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-17 at 14 53 57" src="https://github.com/user-attachments/assets/4a5f62ea-e329-4faa-bffb-989945e47866" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-17 at 14 54 00" src="https://github.com/user-attachments/assets/1a1cf8ed-fea7-44a0-aa91-c08130f2b8f4" />


Close: https://github.com/gemwalletcom/gem-ios/issues/1796