### PR TITLE
WalletConnect: Add app preview & permissions UI

### DIFF
--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
@@ -22,7 +22,7 @@ public struct ConnectionProposalScene: View {
     public var body: some View {
         List {
             Section { } header: {
-                AssetPreviewView(model: model.appPreview)
+                AssetPreviewView(model: model.appPreview, subtitleLayout: .vertical)
                     .frame(maxWidth: .infinity)
                     .padding(.bottom, .small)
             }

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import Components
+import PrimitivesComponents
 import Style
 import Primitives
 import Localization
@@ -21,10 +22,9 @@ public struct ConnectionProposalScene: View {
     public var body: some View {
         List {
             Section { } header: {
-                VStack(alignment: .center) {
-                    AsyncImageView(url: model.imageUrl, size: .image.semiLarge)
-                }
-                .padding(.top, .small)
+                AssetPreviewView(model: model.appPreview)
+                    .frame(maxWidth: .infinity)
+                    .padding(.bottom, .small)
             }
             .cleanListRow()
 
@@ -35,13 +35,22 @@ public struct ConnectionProposalScene: View {
                         subtitle: model.walletName
                     )
                 }
-                ListItemView(title: model.appTitle, subtitle: model.appText)
+                ListItemView(
+                    title: model.connectionTitle,
+                    subtitle: model.connectionText
+                )
                 ListItemImageView(
-                    title: Localized.WalletConnect.Connection.title,
+                    title: Localized.Transaction.status,
                     subtitle: model.statusText,
                     subtitleStyle: model.statusTextStyle,
                     assetImage: model.statusAssetImage
                 )
+            }
+
+            Section(model.permissionsTitle) {
+                ForEach(model.permissions, id: \.title) { permission in
+                    ListItemView(model: permission)
+                }
             }
         }
         .safeAreaButton {
@@ -50,6 +59,8 @@ public struct ConnectionProposalScene: View {
                 action: onAccept
             )
         }
+        .contentMargins(.top, .scene.top, for: .scrollContent)
+        .listSectionSpacing(.compact)
         .navigationTitle(model.title)
         .navigationDestination(for: Scenes.SelectWallet.self) { _ in
             SelectWalletScene(model: $model.walletSelectorModel)

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
@@ -21,15 +21,14 @@ public struct SignMessageScene: View {
 
     public var body: some View {
         List {
+            Section { } header: {
+                AssetPreviewView(model: model.appPreview)
+                    .frame(maxWidth: .infinity)
+                    .padding(.bottom, .small)
+            }
+            .cleanListRow()
+
             Section {
-                ListItemImageView(
-                    title: Localized.WalletConnect.app,
-                    subtitle: model.appText,
-                    assetImage: model.appAssetImage
-                )
-                .contextMenu(
-                    .url(title: Localized.WalletConnect.website, onOpen: model.onViewWebsite)
-                )
                 ListItemImageView(
                     title: Localized.Common.wallet,
                     subtitle: model.walletText,
@@ -66,6 +65,7 @@ public struct SignMessageScene: View {
                 }
             }
         }
+        .contentMargins(.top, .scene.top, for: .scrollContent)
         .listSectionSpacing(.compact)
         .taskOnce { model.fetch() }
         .safeAreaButton {

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
@@ -22,7 +22,7 @@ public struct SignMessageScene: View {
     public var body: some View {
         List {
             Section { } header: {
-                AssetPreviewView(model: model.appPreview)
+                AssetPreviewView(model: model.appPreview, subtitleLayout: .vertical)
                     .frame(maxWidth: .infinity)
                     .padding(.bottom, .small)
             }

--- a/Features/WalletConnector/Sources/WalletConnector/Types/AppPreviewModel.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Types/AppPreviewModel.swift
@@ -1,0 +1,10 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import Components
+import PrimitivesComponents
+
+public struct AppPreviewModel: AssetPreviewable {
+    public let assetImage: AssetImage
+    public let name: String
+    public let subtitleSymbol: String?
+}

--- a/Features/WalletConnector/Sources/WalletConnector/ViewModels/ConnectionProposalViewModel.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/ViewModels/ConnectionProposalViewModel.swift
@@ -31,6 +31,8 @@ public struct ConnectionProposalViewModel {
     var buttonTitle: String { Localized.Transfer.confirm }
     var walletTitle: String { Localized.Common.wallet }
     var appTitle: String { Localized.WalletConnect.app }
+    var connectionTitle: String { Localized.WalletConnect.Connection.title }
+    var connectionText: String { Localized.WalletConnect.brandName }
 
     var walletName: String {
         walletSelectorModel.selectedItems.first?.name ?? .empty
@@ -81,6 +83,34 @@ public struct ConnectionProposalViewModel {
 
     var statusAssetImage: AssetImage {
         .image(verificationImage)
+    }
+
+    var permissionsTitle: String { Localized.WalletConnect.Permissions.title }
+
+    var permissions: [ListItemModel] {
+        [
+            ListItemModel(
+                title: Localized.WalletConnect.Permissions.viewBalance,
+                imageStyle: .accessory(assetImage: .image(Images.System.checkmark))
+            ),
+            ListItemModel(
+                title: Localized.WalletConnect.Permissions.approvalRequests,
+                imageStyle: .accessory(assetImage: .image(Images.System.checkmark))
+            ),
+            ListItemModel(
+                title: Localized.WalletConnect.Permissions.moveFunds,
+                titleStyle: TextStyle(font: .body, color: Colors.secondaryText),
+                imageStyle: .accessory(assetImage: .image(Images.System.xmark), foregroundColor: Colors.gray)
+            ),
+        ]
+    }
+
+    var appPreview: AppPreviewModel {
+        AppPreviewModel(
+            assetImage: AssetImage(imageURL: imageUrl),
+            name: appName,
+            subtitleSymbol: websiteText
+        )
     }
 
     private var payload: WalletConnectionSessionProposal {

--- a/Features/WalletConnector/Sources/WalletConnector/ViewModels/SignMessageSceneViewModel.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/ViewModels/SignMessageSceneViewModel.swift
@@ -100,6 +100,14 @@ public final class SignMessageSceneViewModel {
         appName
     }
 
+    public var appPreview: AppPreviewModel {
+        AppPreviewModel(
+            assetImage: appAssetImage,
+            name: appName,
+            subtitleSymbol: connectionViewModel.hostText
+        )
+    }
+
     var textMessageViewModel: TextMessageViewModel {
         TextMessageViewModel(message: plainMessage)
     }

--- a/Packages/Components/Sources/Lists/ListItemView.swift
+++ b/Packages/Components/Sources/Lists/ListItemView.swift
@@ -88,7 +88,7 @@ public struct ListItemView: View {
                 AssetImageView(
                     assetImage: imageStyle.assetImage,
                     size: imageStyle.imageSize,
-                    style: .init(cornerRadius: imageStyle.cornerRadius)
+                    style: .init(foregroundColor: imageStyle.foregroundColor, cornerRadius: imageStyle.cornerRadius)
                 )
             }
             HStack {

--- a/Packages/Components/Sources/Types/ListItemImageStyle.swift
+++ b/Packages/Components/Sources/Types/ListItemImageStyle.swift
@@ -8,8 +8,9 @@ public struct ListItemImageStyle: Sendable {
     public let assetImage: AssetImage
     public let imageSize: CGFloat
     public let alignment: VerticalAlignment
+    public let foregroundColor: Color?
     private let cornerRadiusType: CornerRadiusType
-    
+
     public var cornerRadius: CGFloat {
         switch cornerRadiusType {
         case .none: .zero
@@ -22,6 +23,7 @@ public struct ListItemImageStyle: Sendable {
         assetImage: AssetImage?,
         imageSize: CGFloat,
         alignment: VerticalAlignment = .center,
+        foregroundColor: Color? = nil,
         cornerRadiusType: CornerRadiusType
     ) {
         guard let assetImage else { return nil }
@@ -29,6 +31,7 @@ public struct ListItemImageStyle: Sendable {
         self.imageSize = imageSize
         self.cornerRadiusType = cornerRadiusType
         self.alignment = alignment
+        self.foregroundColor = foregroundColor
     }
     
     public enum CornerRadiusType: Sendable {
@@ -55,6 +58,15 @@ public extension ListItemImageStyle {
         )
     }
     
+    static func accessory(assetImage: AssetImage?, foregroundColor: Color? = nil) -> Self? {
+        ListItemImageStyle(
+            assetImage: assetImage,
+            imageSize: .space12,
+            foregroundColor: foregroundColor,
+            cornerRadiusType: .none
+        )
+    }
+
     static func settings(assetImage: AssetImage?) -> Self? {
         ListItemImageStyle(
             assetImage: assetImage,

--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -1600,6 +1600,12 @@ public enum Localized {
       /// New Wallet
       public static let title = Localized.tr("Localizable", "wallet.new.title", fallback: "New Wallet")
     }
+    public enum Portfolio {
+      /// Estimated value based on current holdings and market prices.
+      public static let footer = Localized.tr("Localizable", "wallet.portfolio.footer", fallback: "Estimated value based on current holdings and market prices.")
+      /// Portfolio
+      public static let title = Localized.tr("Localizable", "wallet.portfolio.title", fallback: "Portfolio")
+    }
     public enum Receive {
       /// No destination tag required
       public static let noDestinationTagRequired = Localized.tr("Localizable", "wallet.receive.no_destination_tag_required", fallback: "No destination tag required")
@@ -1635,6 +1641,16 @@ public enum Localized {
     public enum Connection {
       /// Connection
       public static let title = Localized.tr("Localizable", "wallet_connect.connection.title", fallback: "Connection")
+    }
+    public enum Permissions {
+      /// Send approval requests
+      public static let approvalRequests = Localized.tr("Localizable", "wallet_connect.permissions.approval_requests", fallback: "Send approval requests")
+      /// Move funds without permission
+      public static let moveFunds = Localized.tr("Localizable", "wallet_connect.permissions.move_funds", fallback: "Move funds without permission")
+      /// Requested permissions
+      public static let title = Localized.tr("Localizable", "wallet_connect.permissions.title", fallback: "Requested permissions")
+      /// View your balance and activity
+      public static let viewBalance = Localized.tr("Localizable", "wallet_connect.permissions.view_balance", fallback: "View your balance and activity")
     }
     public enum State {
       public enum Empty {

--- a/Packages/Localization/Sources/Localized.swift
+++ b/Packages/Localization/Sources/Localized.swift
@@ -1647,8 +1647,8 @@ public enum Localized {
       public static let approvalRequests = Localized.tr("Localizable", "wallet_connect.permissions.approval_requests", fallback: "Send approval requests")
       /// Move funds without permission
       public static let moveFunds = Localized.tr("Localizable", "wallet_connect.permissions.move_funds", fallback: "Move funds without permission")
-      /// Requested permissions
-      public static let title = Localized.tr("Localizable", "wallet_connect.permissions.title", fallback: "Requested permissions")
+      /// Permissions
+      public static let title = Localized.tr("Localizable", "wallet_connect.permissions.title", fallback: "Permissions")
       /// View your balance and activity
       public static let viewBalance = Localized.tr("Localizable", "wallet_connect.permissions.view_balance", fallback: "View your balance and activity")
     }

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "طلب مراجعة";
 "wallet.portfolio.title" = "مَلَفّ";
 "wallet.portfolio.footer" = "القيمة التقديرية مبنية على الحيازات الحالية وأسعار السوق.";
-"wallet_connect.permissions.title" = "الأذونات المطلوبة";
+"wallet_connect.permissions.title" = "الأذونات";
 "wallet_connect.permissions.view_balance" = "اطلع على رصيدك ونشاطك";
 "wallet_connect.permissions.approval_requests" = "إرسال طلبات الموافقة";
 "wallet_connect.permissions.move_funds" = "تحويل الأموال بدون إذن";

--- a/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "تم طلب الوصول الكامل إلى مجموعة NFT";
 "simulation.warning.unlimited_token_approval.title" = "الموافقة على الرموز المميزة غير محدودة";
 "transfer.review_request" = "طلب مراجعة";
+"wallet.portfolio.title" = "مَلَفّ";
+"wallet.portfolio.footer" = "القيمة التقديرية مبنية على الحيازات الحالية وأسعار السوق.";
+"wallet_connect.permissions.title" = "الأذونات المطلوبة";
+"wallet_connect.permissions.view_balance" = "اطلع على رصيدك ونشاطك";
+"wallet_connect.permissions.approval_requests" = "إرسال طلبات الموافقة";
+"wallet_connect.permissions.move_funds" = "تحويل الأموال بدون إذن";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "সম্পূর্ণ NFT সংগ্রহের অ্যাক্সেসের অনুরোধ করা হয়েছে";
 "simulation.warning.unlimited_token_approval.title" = "সীমাহীন টোকেন অনুমোদন";
 "transfer.review_request" = "পর্যালোচনার অনুরোধ";
+"wallet.portfolio.title" = "পোর্টফোলিও";
+"wallet.portfolio.footer" = "বর্তমান মালিকানা এবং বাজার মূল্যের উপর ভিত্তি করে আনুমানিক মূল্য।";
+"wallet_connect.permissions.title" = "অনুরোধকৃত অনুমতি";
+"wallet_connect.permissions.view_balance" = "আপনার ব্যালেন্স এবং কার্যকলাপ দেখুন";
+"wallet_connect.permissions.approval_requests" = "অনুমোদনের অনুরোধ পাঠান";
+"wallet_connect.permissions.move_funds" = "অনুমতি ছাড়া তহবিল স্থানান্তর করুন";

--- a/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/bn.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "পর্যালোচনার অনুরোধ";
 "wallet.portfolio.title" = "পোর্টফোলিও";
 "wallet.portfolio.footer" = "বর্তমান মালিকানা এবং বাজার মূল্যের উপর ভিত্তি করে আনুমানিক মূল্য।";
-"wallet_connect.permissions.title" = "অনুরোধকৃত অনুমতি";
+"wallet_connect.permissions.title" = "অনুমতি";
 "wallet_connect.permissions.view_balance" = "আপনার ব্যালেন্স এবং কার্যকলাপ দেখুন";
 "wallet_connect.permissions.approval_requests" = "অনুমোদনের অনুরোধ পাঠান";
 "wallet_connect.permissions.move_funds" = "অনুমতি ছাড়া তহবিল স্থানান্তর করুন";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Žádost o kontrolu";
 "wallet.portfolio.title" = "Portfolio";
 "wallet.portfolio.footer" = "Odhadovaná hodnota na základě aktuálních aktiv a tržních cen.";
-"wallet_connect.permissions.title" = "Požadovaná oprávnění";
+"wallet_connect.permissions.title" = "Oprávnění";
 "wallet_connect.permissions.view_balance" = "Zobrazení zůstatku a aktivity";
 "wallet_connect.permissions.approval_requests" = "Odeslat žádosti o schválení";
 "wallet_connect.permissions.move_funds" = "Převod finančních prostředků bez povolení";

--- a/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/cs.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Požadován plný přístup k NFT kolekci";
 "simulation.warning.unlimited_token_approval.title" = "Neomezené schvalování tokenů";
 "transfer.review_request" = "Žádost o kontrolu";
+"wallet.portfolio.title" = "Portfolio";
+"wallet.portfolio.footer" = "Odhadovaná hodnota na základě aktuálních aktiv a tržních cen.";
+"wallet_connect.permissions.title" = "Požadovaná oprávnění";
+"wallet_connect.permissions.view_balance" = "Zobrazení zůstatku a aktivity";
+"wallet_connect.permissions.approval_requests" = "Odeslat žádosti o schválení";
+"wallet_connect.permissions.move_funds" = "Převod finančních prostředků bez povolení";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Anmodning om gennemgang";
 "wallet.portfolio.title" = "Portefølje";
 "wallet.portfolio.footer" = "Estimeret værdi baseret på nuværende beholdninger og markedspriser.";
-"wallet_connect.permissions.title" = "Anmodede tilladelser";
+"wallet_connect.permissions.title" = "Tilladelser";
 "wallet_connect.permissions.view_balance" = "Se din saldo og aktivitet";
 "wallet_connect.permissions.approval_requests" = "Send godkendelsesanmodninger";
 "wallet_connect.permissions.move_funds" = "Flytte penge uden tilladelse";

--- a/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/da.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Fuld adgang til NFT-samling anmodes";
 "simulation.warning.unlimited_token_approval.title" = "Ubegrænset tokengodkendelse";
 "transfer.review_request" = "Anmodning om gennemgang";
+"wallet.portfolio.title" = "Portefølje";
+"wallet.portfolio.footer" = "Estimeret værdi baseret på nuværende beholdninger og markedspriser.";
+"wallet_connect.permissions.title" = "Anmodede tilladelser";
+"wallet_connect.permissions.view_balance" = "Se din saldo og aktivitet";
+"wallet_connect.permissions.approval_requests" = "Send godkendelsesanmodninger";
+"wallet_connect.permissions.move_funds" = "Flytte penge uden tilladelse";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Vollständiger Zugriff auf die NFT-Sammlung angefordert";
 "simulation.warning.unlimited_token_approval.title" = "Unbegrenzte Token-Genehmigung";
 "transfer.review_request" = "Überprüfungsanfrage";
+"wallet.portfolio.title" = "Portfolio";
+"wallet.portfolio.footer" = "Geschätzter Wert basierend auf dem aktuellen Bestand und den Marktpreisen.";
+"wallet_connect.permissions.title" = "Angeforderte Berechtigungen";
+"wallet_connect.permissions.view_balance" = "Sehen Sie Ihren Kontostand und Ihre Aktivitäten ein.";
+"wallet_connect.permissions.approval_requests" = "Genehmigungsanfragen senden";
+"wallet_connect.permissions.move_funds" = "Gelder ohne Genehmigung transferieren";

--- a/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Überprüfungsanfrage";
 "wallet.portfolio.title" = "Portfolio";
 "wallet.portfolio.footer" = "Geschätzter Wert basierend auf dem aktuellen Bestand und den Marktpreisen.";
-"wallet_connect.permissions.title" = "Angeforderte Berechtigungen";
+"wallet_connect.permissions.title" = "Berechtigungen";
 "wallet_connect.permissions.view_balance" = "Sehen Sie Ihren Kontostand und Ihre Aktivitäten ein.";
 "wallet_connect.permissions.approval_requests" = "Genehmigungsanfragen senden";
 "wallet_connect.permissions.move_funds" = "Gelder ohne Genehmigung transferieren";

--- a/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Review Request";
 "wallet.portfolio.title" = "Portfolio";
 "wallet.portfolio.footer" = "Estimated value based on current holdings and market prices.";
-"wallet_connect.permissions.title" = "Requested permissions";
+"wallet_connect.permissions.title" = "Permissions";
 "wallet_connect.permissions.view_balance" = "View your balance and activity";
 "wallet_connect.permissions.approval_requests" = "Send approval requests";
 "wallet_connect.permissions.move_funds" = "Move funds without permission";

--- a/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Full NFT collection access requested";
 "simulation.warning.unlimited_token_approval.title" = "Unlimited token approval";
 "transfer.review_request" = "Review Request";
+"wallet.portfolio.title" = "Portfolio";
+"wallet.portfolio.footer" = "Estimated value based on current holdings and market prices.";
+"wallet_connect.permissions.title" = "Requested permissions";
+"wallet_connect.permissions.view_balance" = "View your balance and activity";
+"wallet_connect.permissions.approval_requests" = "Send approval requests";
+"wallet_connect.permissions.move_funds" = "Move funds without permission";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Solicitud de revisión";
 "wallet.portfolio.title" = "Cartera";
 "wallet.portfolio.footer" = "Valor estimado basado en las tenencias actuales y los precios de mercado.";
-"wallet_connect.permissions.title" = "Permisos solicitados";
+"wallet_connect.permissions.title" = "Permisos";
 "wallet_connect.permissions.view_balance" = "Consulta tu saldo y actividad.";
 "wallet_connect.permissions.approval_requests" = "Enviar solicitudes de aprobación";
 "wallet_connect.permissions.move_funds" = "Transferir fondos sin autorización";

--- a/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Se solicita acceso completo a la colección NFT";
 "simulation.warning.unlimited_token_approval.title" = "Aprobación ilimitada de tokens";
 "transfer.review_request" = "Solicitud de revisión";
+"wallet.portfolio.title" = "Cartera";
+"wallet.portfolio.footer" = "Valor estimado basado en las tenencias actuales y los precios de mercado.";
+"wallet_connect.permissions.title" = "Permisos solicitados";
+"wallet_connect.permissions.view_balance" = "Consulta tu saldo y actividad.";
+"wallet_connect.permissions.approval_requests" = "Enviar solicitudes de aprobación";
+"wallet_connect.permissions.move_funds" = "Transferir fondos sin autorización";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "دسترسی کامل به مجموعه NFT درخواست شد";
 "simulation.warning.unlimited_token_approval.title" = "تایید نامحدود توکن";
 "transfer.review_request" = "درخواست بررسی";
+"wallet.portfolio.title" = "نمونه کارها";
+"wallet.portfolio.footer" = "ارزش تخمینی بر اساس دارایی‌های فعلی و قیمت‌های بازار.";
+"wallet_connect.permissions.title" = "مجوزهای درخواستی";
+"wallet_connect.permissions.view_balance" = "مشاهده موجودی و فعالیت خود";
+"wallet_connect.permissions.approval_requests" = "ارسال درخواست‌های تأیید";
+"wallet_connect.permissions.move_funds" = "جابجایی وجه بدون اجازه";

--- a/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "درخواست بررسی";
 "wallet.portfolio.title" = "نمونه کارها";
 "wallet.portfolio.footer" = "ارزش تخمینی بر اساس دارایی‌های فعلی و قیمت‌های بازار.";
-"wallet_connect.permissions.title" = "مجوزهای درخواستی";
+"wallet_connect.permissions.title" = "مجوزها";
 "wallet_connect.permissions.view_balance" = "مشاهده موجودی و فعالیت خود";
 "wallet_connect.permissions.approval_requests" = "ارسال درخواست‌های تأیید";
 "wallet_connect.permissions.move_funds" = "جابجایی وجه بدون اجازه";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Hiniling ang kumpletong access sa koleksyon ng NFT";
 "simulation.warning.unlimited_token_approval.title" = "Walang limitasyong pag-apruba ng token";
 "transfer.review_request" = "Kahilingan sa Pagsusuri";
+"wallet.portfolio.title" = "Portfolio";
+"wallet.portfolio.footer" = "Tinatayang halaga batay sa kasalukuyang mga hawak at presyo sa merkado.";
+"wallet_connect.permissions.title" = "Mga hiniling na pahintulot";
+"wallet_connect.permissions.view_balance" = "Tingnan ang iyong balanse at aktibidad";
+"wallet_connect.permissions.approval_requests" = "Magpadala ng mga kahilingan sa pag-apruba";
+"wallet_connect.permissions.move_funds" = "Ilipat ang mga pondo nang walang pahintulot";

--- a/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fil.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Kahilingan sa Pagsusuri";
 "wallet.portfolio.title" = "Portfolio";
 "wallet.portfolio.footer" = "Tinatayang halaga batay sa kasalukuyang mga hawak at presyo sa merkado.";
-"wallet_connect.permissions.title" = "Mga hiniling na pahintulot";
+"wallet_connect.permissions.title" = "Mga Pahintulot";
 "wallet_connect.permissions.view_balance" = "Tingnan ang iyong balanse at aktibidad";
 "wallet_connect.permissions.approval_requests" = "Magpadala ng mga kahilingan sa pag-apruba";
 "wallet_connect.permissions.move_funds" = "Ilipat ang mga pondo nang walang pahintulot";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Demande d'accès à l'intégralité de la collection NFT";
 "simulation.warning.unlimited_token_approval.title" = "Approbation illimitée des jetons";
 "transfer.review_request" = "Demande de révision";
+"wallet.portfolio.title" = "Portefeuille";
+"wallet.portfolio.footer" = "Valeur estimée basée sur les avoirs actuels et les prix du marché.";
+"wallet_connect.permissions.title" = "Autorisations demandées";
+"wallet_connect.permissions.view_balance" = "Consultez votre solde et votre activité";
+"wallet_connect.permissions.approval_requests" = "Envoyer les demandes d'approbation";
+"wallet_connect.permissions.move_funds" = "Transférer des fonds sans autorisation";

--- a/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Demande de révision";
 "wallet.portfolio.title" = "Portefeuille";
 "wallet.portfolio.footer" = "Valeur estimée basée sur les avoirs actuels et les prix du marché.";
-"wallet_connect.permissions.title" = "Autorisations demandées";
+"wallet_connect.permissions.title" = "Autorisations";
 "wallet_connect.permissions.view_balance" = "Consultez votre solde et votre activité";
 "wallet_connect.permissions.approval_requests" = "Envoyer les demandes d'approbation";
 "wallet_connect.permissions.move_funds" = "Transférer des fonds sans autorisation";

--- a/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Buƙatar Bita";
 "wallet.portfolio.title" = "Fayil ɗin Fayil";
 "wallet.portfolio.footer" = "Kimanta darajar bisa ga hannun jari na yanzu da farashin kasuwa.";
-"wallet_connect.permissions.title" = "Izini da aka nema";
+"wallet_connect.permissions.title" = "Izini";
 "wallet_connect.permissions.view_balance" = "Duba ma'aunin ku da ayyukan ku";
 "wallet_connect.permissions.approval_requests" = "Aika buƙatun amincewa";
 "wallet_connect.permissions.move_funds" = "Motsa kuɗi ba tare da izini ba";

--- a/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ha.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "An nemi cikakken damar tattara NFT";
 "simulation.warning.unlimited_token_approval.title" = "Amincewa da alamar mara iyaka";
 "transfer.review_request" = "Buƙatar Bita";
+"wallet.portfolio.title" = "Fayil ɗin Fayil";
+"wallet.portfolio.footer" = "Kimanta darajar bisa ga hannun jari na yanzu da farashin kasuwa.";
+"wallet_connect.permissions.title" = "Izini da aka nema";
+"wallet_connect.permissions.view_balance" = "Duba ma'aunin ku da ayyukan ku";
+"wallet_connect.permissions.approval_requests" = "Aika buƙatun amincewa";
+"wallet_connect.permissions.move_funds" = "Motsa kuɗi ba tare da izini ba";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "בקשת סקירה";
 "wallet.portfolio.title" = "תִיק";
 "wallet.portfolio.footer" = "שווי משוער המבוסס על אחזקות נוכחיות ומחירי שוק.";
-"wallet_connect.permissions.title" = "הרשאות מבוקשות";
+"wallet_connect.permissions.title" = "הרשאות";
 "wallet_connect.permissions.view_balance" = "צפה ביתרה ובפעילות שלך";
 "wallet_connect.permissions.approval_requests" = "שלח בקשות אישור";
 "wallet_connect.permissions.move_funds" = "העברת כספים ללא אישור";

--- a/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/he.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "התבקשה גישה מלאה לאוסף NFT";
 "simulation.warning.unlimited_token_approval.title" = "אישור אסימונים ללא הגבלה";
 "transfer.review_request" = "בקשת סקירה";
+"wallet.portfolio.title" = "תִיק";
+"wallet.portfolio.footer" = "שווי משוער המבוסס על אחזקות נוכחיות ומחירי שוק.";
+"wallet_connect.permissions.title" = "הרשאות מבוקשות";
+"wallet_connect.permissions.view_balance" = "צפה ביתרה ובפעילות שלך";
+"wallet_connect.permissions.approval_requests" = "שלח בקשות אישור";
+"wallet_connect.permissions.move_funds" = "העברת כספים ללא אישור";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "संपूर्ण एनएफटी संग्रह तक पहुंच का अनुरोध किया गया है";
 "simulation.warning.unlimited_token_approval.title" = "असीमित टोकन अनुमोदन";
 "transfer.review_request" = "समीक्षा अनुरोध";
+"wallet.portfolio.title" = "पोर्टफोलियो";
+"wallet.portfolio.footer" = "वर्तमान होल्डिंग्स और बाजार मूल्यों के आधार पर अनुमानित मूल्य।";
+"wallet_connect.permissions.title" = "अनुरोधित अनुमतियाँ";
+"wallet_connect.permissions.view_balance" = "अपना बैलेंस और गतिविधि देखें";
+"wallet_connect.permissions.approval_requests" = "अनुमोदन अनुरोध भेजें";
+"wallet_connect.permissions.move_funds" = "बिना अनुमति के धनराशि स्थानांतरित करना";

--- a/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/hi.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "समीक्षा अनुरोध";
 "wallet.portfolio.title" = "पोर्टफोलियो";
 "wallet.portfolio.footer" = "वर्तमान होल्डिंग्स और बाजार मूल्यों के आधार पर अनुमानित मूल्य।";
-"wallet_connect.permissions.title" = "अनुरोधित अनुमतियाँ";
+"wallet_connect.permissions.title" = "अनुमतियां";
 "wallet_connect.permissions.view_balance" = "अपना बैलेंस और गतिविधि देखें";
 "wallet_connect.permissions.approval_requests" = "अनुमोदन अनुरोध भेजें";
 "wallet_connect.permissions.move_funds" = "बिना अनुमति के धनराशि स्थानांतरित करना";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Akses penuh ke koleksi NFT diminta.";
 "simulation.warning.unlimited_token_approval.title" = "Persetujuan token tanpa batas";
 "transfer.review_request" = "Permintaan Peninjauan";
+"wallet.portfolio.title" = "Portofolio";
+"wallet.portfolio.footer" = "Perkiraan nilai berdasarkan kepemilikan saat ini dan harga pasar.";
+"wallet_connect.permissions.title" = "Izin yang diminta";
+"wallet_connect.permissions.view_balance" = "Lihat saldo dan aktivitas Anda";
+"wallet_connect.permissions.approval_requests" = "Kirim permintaan persetujuan";
+"wallet_connect.permissions.move_funds" = "Memindahkan dana tanpa izin";

--- a/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/id.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Permintaan Peninjauan";
 "wallet.portfolio.title" = "Portofolio";
 "wallet.portfolio.footer" = "Perkiraan nilai berdasarkan kepemilikan saat ini dan harga pasar.";
-"wallet_connect.permissions.title" = "Izin yang diminta";
+"wallet_connect.permissions.title" = "Izin";
 "wallet_connect.permissions.view_balance" = "Lihat saldo dan aktivitas Anda";
 "wallet_connect.permissions.approval_requests" = "Kirim permintaan persetujuan";
 "wallet_connect.permissions.move_funds" = "Memindahkan dana tanpa izin";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Richiesta di revisione";
 "wallet.portfolio.title" = "Portfolio";
 "wallet.portfolio.footer" = "Valore stimato in base alle partecipazioni attuali e ai prezzi di mercato.";
-"wallet_connect.permissions.title" = "Autorizzazioni richieste";
+"wallet_connect.permissions.title" = "Autorizzazioni";
 "wallet_connect.permissions.view_balance" = "Visualizza il tuo saldo e la tua attività";
 "wallet_connect.permissions.approval_requests" = "Invia richieste di approvazione";
 "wallet_connect.permissions.move_funds" = "Trasferire fondi senza autorizzazione";

--- a/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/it.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "È richiesto l'accesso completo alla collezione NFT";
 "simulation.warning.unlimited_token_approval.title" = "Approvazione token illimitata";
 "transfer.review_request" = "Richiesta di revisione";
+"wallet.portfolio.title" = "Portfolio";
+"wallet.portfolio.footer" = "Valore stimato in base alle partecipazioni attuali e ai prezzi di mercato.";
+"wallet_connect.permissions.title" = "Autorizzazioni richieste";
+"wallet_connect.permissions.view_balance" = "Visualizza il tuo saldo e la tua attività";
+"wallet_connect.permissions.approval_requests" = "Invia richieste di approvazione";
+"wallet_connect.permissions.move_funds" = "Trasferire fondi senza autorizzazione";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "NFTコレクションへのフルアクセスをリクエスト";
 "simulation.warning.unlimited_token_approval.title" = "無制限のトークン承認";
 "transfer.review_request" = "レビューリクエスト";
+"wallet.portfolio.title" = "ポートフォリオ";
+"wallet.portfolio.footer" = "現在の保有資産と市場価格に基づいた推定値。";
+"wallet_connect.permissions.title" = "要求された権限";
+"wallet_connect.permissions.view_balance" = "残高とアクティビティを確認する";
+"wallet_connect.permissions.approval_requests" = "承認依頼を送信する";
+"wallet_connect.permissions.move_funds" = "許可なく資金を移動させる";

--- a/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ja.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "レビューリクエスト";
 "wallet.portfolio.title" = "ポートフォリオ";
 "wallet.portfolio.footer" = "現在の保有資産と市場価格に基づいた推定値。";
-"wallet_connect.permissions.title" = "要求された権限";
+"wallet_connect.permissions.title" = "権限";
 "wallet_connect.permissions.view_balance" = "残高とアクティビティを確認する";
 "wallet_connect.permissions.approval_requests" = "承認依頼を送信する";
 "wallet_connect.permissions.move_funds" = "許可なく資金を移動させる";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "검토 요청";
 "wallet.portfolio.title" = "포트폴리오";
 "wallet.portfolio.footer" = "현재 보유량과 시장 가격을 기준으로 산정한 추정 가치입니다.";
-"wallet_connect.permissions.title" = "요청된 권한";
+"wallet_connect.permissions.title" = "권한";
 "wallet_connect.permissions.view_balance" = "잔액과 활동 내역을 확인하세요";
 "wallet_connect.permissions.approval_requests" = "승인 요청 보내기";
 "wallet_connect.permissions.move_funds" = "허가 없이 자금을 이체하세요";

--- a/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ko.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "NFT 컬렉션 전체 접근 권한이 요청되었습니다.";
 "simulation.warning.unlimited_token_approval.title" = "무제한 토큰 승인";
 "transfer.review_request" = "검토 요청";
+"wallet.portfolio.title" = "포트폴리오";
+"wallet.portfolio.footer" = "현재 보유량과 시장 가격을 기준으로 산정한 추정 가치입니다.";
+"wallet_connect.permissions.title" = "요청된 권한";
+"wallet_connect.permissions.view_balance" = "잔액과 활동 내역을 확인하세요";
+"wallet_connect.permissions.approval_requests" = "승인 요청 보내기";
+"wallet_connect.permissions.move_funds" = "허가 없이 자금을 이체하세요";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Permintaan Semakan";
 "wallet.portfolio.title" = "Portfolio";
 "wallet.portfolio.footer" = "Anggaran nilai berdasarkan pegangan semasa dan harga pasaran.";
-"wallet_connect.permissions.title" = "Kebenaran yang diminta";
+"wallet_connect.permissions.title" = "Kebenaran";
 "wallet_connect.permissions.view_balance" = "Lihat keseimbangan dan aktiviti anda";
 "wallet_connect.permissions.approval_requests" = "Hantar permintaan kelulusan";
 "wallet_connect.permissions.move_funds" = "Pindahkan dana tanpa kebenaran";

--- a/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Akses koleksi NFT penuh diminta";
 "simulation.warning.unlimited_token_approval.title" = "Kelulusan token tanpa had";
 "transfer.review_request" = "Permintaan Semakan";
+"wallet.portfolio.title" = "Portfolio";
+"wallet.portfolio.footer" = "Anggaran nilai berdasarkan pegangan semasa dan harga pasaran.";
+"wallet_connect.permissions.title" = "Kebenaran yang diminta";
+"wallet_connect.permissions.view_balance" = "Lihat keseimbangan dan aktiviti anda";
+"wallet_connect.permissions.approval_requests" = "Hantar permintaan kelulusan";
+"wallet_connect.permissions.move_funds" = "Pindahkan dana tanpa kebenaran";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Beoordelingsverzoek";
 "wallet.portfolio.title" = "Portefeuille";
 "wallet.portfolio.footer" = "Geschatte waarde op basis van de huidige portefeuille en marktprijzen.";
-"wallet_connect.permissions.title" = "Aangevraagde toestemmingen";
+"wallet_connect.permissions.title" = "Toestemmingen";
 "wallet_connect.permissions.view_balance" = "Bekijk je saldo en activiteit";
 "wallet_connect.permissions.approval_requests" = "Verzoeken om goedkeuring verzenden";
 "wallet_connect.permissions.move_funds" = "Geld overmaken zonder toestemming";

--- a/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Volledige toegang tot de NFT-collectie aangevraagd";
 "simulation.warning.unlimited_token_approval.title" = "Onbeperkte tokengoedkeuring";
 "transfer.review_request" = "Beoordelingsverzoek";
+"wallet.portfolio.title" = "Portefeuille";
+"wallet.portfolio.footer" = "Geschatte waarde op basis van de huidige portefeuille en marktprijzen.";
+"wallet_connect.permissions.title" = "Aangevraagde toestemmingen";
+"wallet_connect.permissions.view_balance" = "Bekijk je saldo en activiteit";
+"wallet_connect.permissions.approval_requests" = "Verzoeken om goedkeuring verzenden";
+"wallet_connect.permissions.move_funds" = "Geld overmaken zonder toestemming";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Zażądano pełnego dostępu do kolekcji NFT";
 "simulation.warning.unlimited_token_approval.title" = "Nieograniczone zatwierdzanie tokenów";
 "transfer.review_request" = "Prośba o przegląd";
+"wallet.portfolio.title" = "Teczka";
+"wallet.portfolio.footer" = "Szacunkowa wartość oparta na bieżących zapasach i cenach rynkowych.";
+"wallet_connect.permissions.title" = "Żądane uprawnienia";
+"wallet_connect.permissions.view_balance" = "Wyświetl swoje saldo i aktywność";
+"wallet_connect.permissions.approval_requests" = "Wyślij prośby o zatwierdzenie";
+"wallet_connect.permissions.move_funds" = "Przelewanie środków bez pozwolenia";

--- a/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pl.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Prośba o przegląd";
 "wallet.portfolio.title" = "Teczka";
 "wallet.portfolio.footer" = "Szacunkowa wartość oparta na bieżących zapasach i cenach rynkowych.";
-"wallet_connect.permissions.title" = "Żądane uprawnienia";
+"wallet_connect.permissions.title" = "Uprawnienia";
 "wallet_connect.permissions.view_balance" = "Wyświetl swoje saldo i aktywność";
 "wallet_connect.permissions.approval_requests" = "Wyślij prośby o zatwierdzenie";
 "wallet_connect.permissions.move_funds" = "Przelewanie środków bez pozwolenia";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "É solicitado acesso à coleção completa de NFTs.";
 "simulation.warning.unlimited_token_approval.title" = "Aprovação ilimitada de tokens";
 "transfer.review_request" = "Solicitação de revisão";
+"wallet.portfolio.title" = "Portfólio";
+"wallet.portfolio.footer" = "Valor estimado com base nas participações atuais e nos preços de mercado.";
+"wallet_connect.permissions.title" = "Permissões solicitadas";
+"wallet_connect.permissions.view_balance" = "Veja seu saldo e atividade";
+"wallet_connect.permissions.approval_requests" = "Enviar solicitações de aprovação";
+"wallet_connect.permissions.move_funds" = "Movimentar fundos sem autorização";

--- a/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/pt-BR.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Solicitação de revisão";
 "wallet.portfolio.title" = "Portfólio";
 "wallet.portfolio.footer" = "Valor estimado com base nas participações atuais e nos preços de mercado.";
-"wallet_connect.permissions.title" = "Permissões solicitadas";
+"wallet_connect.permissions.title" = "Permissões";
 "wallet_connect.permissions.view_balance" = "Veja seu saldo e atividade";
 "wallet_connect.permissions.approval_requests" = "Enviar solicitações de aprovação";
 "wallet_connect.permissions.move_funds" = "Movimentar fundos sem autorização";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Acces complet la colecția NFT solicitat";
 "simulation.warning.unlimited_token_approval.title" = "Aprobare nelimitată de tokenuri";
 "transfer.review_request" = "Cerere de revizuire";
+"wallet.portfolio.title" = "Portofoliu";
+"wallet.portfolio.footer" = "Valoare estimată pe baza deținerilor actuale și a prețurilor de piață.";
+"wallet_connect.permissions.title" = "Permisiuni solicitate";
+"wallet_connect.permissions.view_balance" = "Vizualizați soldul și activitatea dvs.";
+"wallet_connect.permissions.approval_requests" = "Trimiteți cereri de aprobare";
+"wallet_connect.permissions.move_funds" = "Mută ​​fonduri fără permisiune";

--- a/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ro.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Cerere de revizuire";
 "wallet.portfolio.title" = "Portofoliu";
 "wallet.portfolio.footer" = "Valoare estimată pe baza deținerilor actuale și a prețurilor de piață.";
-"wallet_connect.permissions.title" = "Permisiuni solicitate";
+"wallet_connect.permissions.title" = "Permisiuni";
 "wallet_connect.permissions.view_balance" = "Vizualizați soldul și activitatea dvs.";
 "wallet_connect.permissions.approval_requests" = "Trimiteți cereri de aprobare";
 "wallet_connect.permissions.move_funds" = "Mută ​​fonduri fără permisiune";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Подтвердить запрос";
 "wallet.portfolio.title" = "Портфель";
 "wallet.portfolio.footer" = "Оценочная стоимость рассчитана на основе текущих активов и рыночных цен.";
-"wallet_connect.permissions.title" = "Запрашивать разрешения";
+"wallet_connect.permissions.title" = "Разрешения";
 "wallet_connect.permissions.view_balance" = "Просматривать баланс и активность";
 "wallet_connect.permissions.approval_requests" = "Отправлять запросы на подтверждение";
 "wallet_connect.permissions.move_funds" = "Перевод средств без разрешения";

--- a/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Запрошен полный доступ к коллекции NFT.";
 "simulation.warning.unlimited_token_approval.title" = "Неограниченное количество одобрений токенов";
 "transfer.review_request" = "Подтвердить запрос";
+"wallet.portfolio.title" = "Портфель";
+"wallet.portfolio.footer" = "Оценочная стоимость рассчитана на основе текущих активов и рыночных цен.";
+"wallet_connect.permissions.title" = "Запрашивать разрешения";
+"wallet_connect.permissions.view_balance" = "Просматривать баланс и активность";
+"wallet_connect.permissions.approval_requests" = "Отправлять запросы на подтверждение";
+"wallet_connect.permissions.move_funds" = "Перевод средств без разрешения";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Ombi la Uhakiki";
 "wallet.portfolio.title" = "Kwingineko";
 "wallet.portfolio.footer" = "Thamani inayokadiriwa kulingana na hisa za sasa na bei za soko.";
-"wallet_connect.permissions.title" = "Ruhusa zilizoombwa";
+"wallet_connect.permissions.title" = "Ruhusa";
 "wallet_connect.permissions.view_balance" = "Tazama salio na shughuli zako";
 "wallet_connect.permissions.approval_requests" = "Tuma maombi ya idhini";
 "wallet_connect.permissions.move_funds" = "Hamisha fedha bila ruhusa";

--- a/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/sw.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Ufikiaji kamili wa ukusanyaji wa NFT umeombwa";
 "simulation.warning.unlimited_token_approval.title" = "Idhini ya tokeni isiyo na kikomo";
 "transfer.review_request" = "Ombi la Uhakiki";
+"wallet.portfolio.title" = "Kwingineko";
+"wallet.portfolio.footer" = "Thamani inayokadiriwa kulingana na hisa za sasa na bei za soko.";
+"wallet_connect.permissions.title" = "Ruhusa zilizoombwa";
+"wallet_connect.permissions.view_balance" = "Tazama salio na shughuli zako";
+"wallet_connect.permissions.approval_requests" = "Tuma maombi ya idhini";
+"wallet_connect.permissions.move_funds" = "Hamisha fedha bila ruhusa";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "ขอสิทธิ์เข้าถึงคอลเลกชัน NFT ทั้งหมด";
 "simulation.warning.unlimited_token_approval.title" = "อนุมัติโทเค็นได้ไม่จำกัดจำนวน";
 "transfer.review_request" = "คำขอตรวจสอบ";
+"wallet.portfolio.title" = "ผลงาน";
+"wallet.portfolio.footer" = "มูลค่าโดยประมาณคำนวณจากสินทรัพย์ที่มีอยู่และราคาตลาด";
+"wallet_connect.permissions.title" = "ขออนุญาตแล้ว";
+"wallet_connect.permissions.view_balance" = "ตรวจสอบยอดเงินคงเหลือและกิจกรรมของคุณ";
+"wallet_connect.permissions.approval_requests" = "ส่งคำขออนุมัติ";
+"wallet_connect.permissions.move_funds" = "โอนเงินโดยไม่ได้รับอนุญาต";

--- a/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/th.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "คำขอตรวจสอบ";
 "wallet.portfolio.title" = "ผลงาน";
 "wallet.portfolio.footer" = "มูลค่าโดยประมาณคำนวณจากสินทรัพย์ที่มีอยู่และราคาตลาด";
-"wallet_connect.permissions.title" = "ขออนุญาตแล้ว";
+"wallet_connect.permissions.title" = "สิทธิ์การเข้าถึง";
 "wallet_connect.permissions.view_balance" = "ตรวจสอบยอดเงินคงเหลือและกิจกรรมของคุณ";
 "wallet_connect.permissions.approval_requests" = "ส่งคำขออนุมัติ";
 "wallet_connect.permissions.move_funds" = "โอนเงินโดยไม่ได้รับอนุญาต";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "İnceleme Talebi";
 "wallet.portfolio.title" = "Portföy";
 "wallet.portfolio.footer" = "Mevcut varlıklar ve piyasa fiyatlarına göre tahmini değer.";
-"wallet_connect.permissions.title" = "İstenen izinler";
+"wallet_connect.permissions.title" = "İzinler";
 "wallet_connect.permissions.view_balance" = "Bakiyenizi ve işlemlerinizi görüntüleyin.";
 "wallet_connect.permissions.approval_requests" = "Onay isteklerini gönderin";
 "wallet_connect.permissions.move_funds" = "İzinsiz para transferi";

--- a/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "NFT koleksiyonunun tamamına erişim talep edildi.";
 "simulation.warning.unlimited_token_approval.title" = "Sınırsız token onayı";
 "transfer.review_request" = "İnceleme Talebi";
+"wallet.portfolio.title" = "Portföy";
+"wallet.portfolio.footer" = "Mevcut varlıklar ve piyasa fiyatlarına göre tahmini değer.";
+"wallet_connect.permissions.title" = "İstenen izinler";
+"wallet_connect.permissions.view_balance" = "Bakiyenizi ve işlemlerinizi görüntüleyin.";
+"wallet_connect.permissions.approval_requests" = "Onay isteklerini gönderin";
+"wallet_connect.permissions.move_funds" = "İzinsiz para transferi";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Запит на перегляд";
 "wallet.portfolio.title" = "Портфоліо";
 "wallet.portfolio.footer" = "Оціночна вартість базується на поточних запасах та ринкових цінах.";
-"wallet_connect.permissions.title" = "Запитані дозволи";
+"wallet_connect.permissions.title" = "Дозволи";
 "wallet_connect.permissions.view_balance" = "Перегляд вашого балансу та активності";
 "wallet_connect.permissions.approval_requests" = "Надсилати запити на схвалення";
 "wallet_connect.permissions.move_funds" = "Переміщення коштів без дозволу";

--- a/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/uk.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Запитується повний доступ до колекції NFT";
 "simulation.warning.unlimited_token_approval.title" = "Необмежене схвалення токенів";
 "transfer.review_request" = "Запит на перегляд";
+"wallet.portfolio.title" = "Портфоліо";
+"wallet.portfolio.footer" = "Оціночна вартість базується на поточних запасах та ринкових цінах.";
+"wallet_connect.permissions.title" = "Запитані дозволи";
+"wallet_connect.permissions.view_balance" = "Перегляд вашого балансу та активності";
+"wallet_connect.permissions.approval_requests" = "Надсилати запити на схвалення";
+"wallet_connect.permissions.move_funds" = "Переміщення коштів без дозволу";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "مکمل NFT جمع کرنے تک رسائی کی درخواست کی گئی۔";
 "simulation.warning.unlimited_token_approval.title" = "لامحدود ٹوکن کی منظوری";
 "transfer.review_request" = "نظرثانی کی درخواست";
+"wallet.portfolio.title" = "پورٹ فولیو";
+"wallet.portfolio.footer" = "موجودہ ہولڈنگز اور مارکیٹ کی قیمتوں کی بنیاد پر تخمینی قیمت۔";
+"wallet_connect.permissions.title" = "اجازتوں کی درخواست کی۔";
+"wallet_connect.permissions.view_balance" = "اپنا توازن اور سرگرمی دیکھیں";
+"wallet_connect.permissions.approval_requests" = "منظوری کی درخواستیں بھیجیں۔";
+"wallet_connect.permissions.move_funds" = "اجازت کے بغیر فنڈز منتقل کریں۔";

--- a/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/ur.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "نظرثانی کی درخواست";
 "wallet.portfolio.title" = "پورٹ فولیو";
 "wallet.portfolio.footer" = "موجودہ ہولڈنگز اور مارکیٹ کی قیمتوں کی بنیاد پر تخمینی قیمت۔";
-"wallet_connect.permissions.title" = "اجازتوں کی درخواست کی۔";
+"wallet_connect.permissions.title" = "اجازتیں";
 "wallet_connect.permissions.view_balance" = "اپنا توازن اور سرگرمی دیکھیں";
 "wallet_connect.permissions.approval_requests" = "منظوری کی درخواستیں بھیجیں۔";
 "wallet_connect.permissions.move_funds" = "اجازت کے بغیر فنڈز منتقل کریں۔";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "Yêu cầu quyền truy cập đầy đủ vào bộ sưu tập NFT";
 "simulation.warning.unlimited_token_approval.title" = "Phê duyệt mã thông báo không giới hạn";
 "transfer.review_request" = "Yêu cầu xem xét";
+"wallet.portfolio.title" = "Danh mục đầu tư";
+"wallet.portfolio.footer" = "Giá trị ước tính dựa trên lượng hàng tồn kho hiện có và giá thị trường.";
+"wallet_connect.permissions.title" = "Quyền được yêu cầu";
+"wallet_connect.permissions.view_balance" = "Xem số dư và hoạt động của bạn";
+"wallet_connect.permissions.approval_requests" = "Gửi yêu cầu phê duyệt";
+"wallet_connect.permissions.move_funds" = "Chuyển tiền mà không được phép";

--- a/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "Yêu cầu xem xét";
 "wallet.portfolio.title" = "Danh mục đầu tư";
 "wallet.portfolio.footer" = "Giá trị ước tính dựa trên lượng hàng tồn kho hiện có và giá thị trường.";
-"wallet_connect.permissions.title" = "Quyền được yêu cầu";
+"wallet_connect.permissions.title" = "Quyền hạn";
 "wallet_connect.permissions.view_balance" = "Xem số dư và hoạt động của bạn";
 "wallet_connect.permissions.approval_requests" = "Gửi yêu cầu phê duyệt";
 "wallet_connect.permissions.move_funds" = "Chuyển tiền mà không được phép";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "审查请求";
 "wallet.portfolio.title" = "文件夹";
 "wallet.portfolio.footer" = "根据现有持仓和市场价格估算的价值。";
-"wallet_connect.permissions.title" = "请求的权限";
+"wallet_connect.permissions.title" = "权限";
 "wallet_connect.permissions.view_balance" = "查看您的余额和活动";
 "wallet_connect.permissions.approval_requests" = "发送审批请求";
 "wallet_connect.permissions.move_funds" = "未经许可转移资金";

--- a/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hans.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "请求访问完整的NFT收藏集";
 "simulation.warning.unlimited_token_approval.title" = "无限代币批准";
 "transfer.review_request" = "审查请求";
+"wallet.portfolio.title" = "文件夹";
+"wallet.portfolio.footer" = "根据现有持仓和市场价格估算的价值。";
+"wallet_connect.permissions.title" = "请求的权限";
+"wallet_connect.permissions.view_balance" = "查看您的余额和活动";
+"wallet_connect.permissions.approval_requests" = "发送审批请求";
+"wallet_connect.permissions.move_funds" = "未经许可转移资金";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -558,3 +558,9 @@
 "simulation.warning.nft_collection_approval.title" = "請求訪問完整的NFT收藏集";
 "simulation.warning.unlimited_token_approval.title" = "無限代幣批准";
 "transfer.review_request" = "審查請求";
+"wallet.portfolio.title" = "資料夾";
+"wallet.portfolio.footer" = "根據現有持倉和市場價格估算的價值。";
+"wallet_connect.permissions.title" = "請求的權限";
+"wallet_connect.permissions.view_balance" = "查看您的餘額和活動";
+"wallet_connect.permissions.approval_requests" = "發送審批請求";
+"wallet_connect.permissions.move_funds" = "未經許可轉移資金";

--- a/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Packages/Localization/Sources/Resources/zh-Hant.lproj/Localizable.strings
@@ -560,7 +560,7 @@
 "transfer.review_request" = "審查請求";
 "wallet.portfolio.title" = "資料夾";
 "wallet.portfolio.footer" = "根據現有持倉和市場價格估算的價值。";
-"wallet_connect.permissions.title" = "請求的權限";
+"wallet_connect.permissions.title" = "權限";
 "wallet_connect.permissions.view_balance" = "查看您的餘額和活動";
 "wallet_connect.permissions.approval_requests" = "發送審批請求";
 "wallet_connect.permissions.move_funds" = "未經許可轉移資金";

--- a/Packages/PrimitivesComponents/Sources/ViewModels/AssetViewModel.swift
+++ b/Packages/PrimitivesComponents/Sources/ViewModels/AssetViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Primitives
 import Components
 
-public struct AssetViewModel: Sendable, Identifiable {
+public struct AssetViewModel: Sendable, Identifiable, AssetPreviewable {
     public let asset: Asset
 
     public init(asset: Asset) {

--- a/Packages/PrimitivesComponents/Sources/Views/AssetPreviewView.swift
+++ b/Packages/PrimitivesComponents/Sources/Views/AssetPreviewView.swift
@@ -11,25 +11,40 @@ public protocol AssetPreviewable {
 }
 
 public struct AssetPreviewView<Model: AssetPreviewable>: View {
-    private let model: Model
+    public enum SubtitleLayout {
+        case horizontal
+        case vertical
+    }
 
-    public init(model: Model) {
+    private let model: Model
+    private let subtitleLayout: SubtitleLayout
+
+    public init(model: Model, subtitleLayout: SubtitleLayout = .horizontal) {
         self.model = model
+        self.subtitleLayout = subtitleLayout
     }
 
     public var body: some View {
         VStack(spacing: .medium) {
             AssetImageView(assetImage: model.assetImage, size: .image.semiLarge)
 
-            HStack(alignment: .lastTextBaseline, spacing: .tiny) {
+            layout {
                 Text(model.name)
                     .textStyle(.headline)
+                    .lineLimit(1)
                 if let symbol = model.subtitleSymbol {
                     Text(symbol)
                         .textStyle(TextStyle(font: .subheadline, color: Colors.secondaryText, fontWeight: .medium))
+                        .lineLimit(1)
                 }
             }
-            .lineLimit(1)
+        }
+    }
+    
+    private var layout: AnyLayout {
+        switch subtitleLayout {
+        case .horizontal: AnyLayout(HStackLayout(alignment: .lastTextBaseline, spacing: .tiny))
+        case .vertical: AnyLayout(VStackLayout(spacing: .tiny))
         }
     }
 }

--- a/Packages/PrimitivesComponents/Sources/Views/AssetPreviewView.swift
+++ b/Packages/PrimitivesComponents/Sources/Views/AssetPreviewView.swift
@@ -4,10 +4,16 @@ import SwiftUI
 import Components
 import Style
 
-public struct AssetPreviewView: View {
-    private let model: AssetViewModel
+public protocol AssetPreviewable {
+    var assetImage: AssetImage { get }
+    var name: String { get }
+    var subtitleSymbol: String? { get }
+}
 
-    public init(model: AssetViewModel) {
+public struct AssetPreviewView<Model: AssetPreviewable>: View {
+    private let model: Model
+
+    public init(model: Model) {
         self.model = model
     }
 
@@ -15,7 +21,7 @@ public struct AssetPreviewView: View {
         VStack(spacing: .medium) {
             AssetImageView(assetImage: model.assetImage, size: .image.semiLarge)
 
-            HStack(alignment: .bottom, spacing: .tiny) {
+            HStack(alignment: .lastTextBaseline, spacing: .tiny) {
                 Text(model.name)
                     .textStyle(.headline)
                 if let symbol = model.subtitleSymbol {


### PR DESCRIPTION
Replace header AsyncImageView with AssetPreviewView and add AppPreviewModel to represent app preview data. Expose appPreview and permissions from SignMessage and ConnectionProposal view models and render a permissions section in ConnectionProposalScene. Add PermissionItemView, adjust ListItemImageStyle to support foregroundColor and update ListItemView to pass it through. Include spacing/content margin tweaks and add new localization keys for portfolio and permissions across languages.

<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-18 at 18 07 34" src="https://github.com/user-attachments/assets/1864dcf4-76a7-40dc-8f53-eaf5380c2982" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-18 at 18 08 20" src="https://github.com/user-attachments/assets/429f4450-8f1f-4fea-8628-d4fe745e829a" />
<img width="320" alt="Simulator Screenshot - iPhone 17 Pro - 2026-03-18 at 21 37 50" src="https://github.com/user-attachments/assets/5d2ceec0-86eb-48fc-a318-2fc6a73a485b" />

Close: https://github.com/gemwalletcom/gem-ios/issues/1798