### PR TITLE
Add isCancelled guard to prevent error flash on task cancellation

### DIFF
--- a/Features/Assets/Sources/ViewModels/AddAssetSceneViewModel.swift
+++ b/Features/Assets/Sources/ViewModels/AddAssetSceneViewModel.swift
@@ -80,7 +80,9 @@ extension AddAssetSceneViewModel {
             let asset = try await service.getTokenData(chain: chain, tokenId: address)
             state = .data(AddAssetViewModel(asset: asset))
         } catch {
-            state = .error(error)
+            if !error.isCancelled {
+                state = .error(error)
+            }
         }
     }
 }

--- a/Features/Perpetuals/Sources/ViewModels/PerpetualSceneViewModel.swift
+++ b/Features/Perpetuals/Sources/ViewModels/PerpetualSceneViewModel.swift
@@ -294,7 +294,9 @@ private extension PerpetualSceneViewModel {
             )
             state = .data(candlesticks)
         } catch {
-            state = .error(error)
+            if !error.isCancelled {
+                state = .error(error)
+            }
         }
     }
 

--- a/Features/Settings/Sources/ChainSettings/ViewModels/AddNodeSceneViewModel.swift
+++ b/Features/Settings/Sources/ChainSettings/ViewModels/AddNodeSceneViewModel.swift
@@ -121,7 +121,9 @@ extension AddNodeSceneViewModel {
             )
             state = .data(AddNodeResultViewModel(addNodeResult: result))
         } catch {
-            state = .error(error)
+            if !error.isCancelled {
+                state = .error(error)
+            }
         }
     }
 }


### PR DESCRIPTION
- Add !error.isCancelled guard in AddAssetSceneViewModel, PerpetualSceneViewModel, and AddNodeSceneViewModel
- Prevents cancelled network requests from overwriting state with .error, which caused brief error flashes during rapid user input