### PR TITLE
Auto-activate asset when buying crypto

### DIFF
--- a/Features/FiatConnect/Package.swift
+++ b/Features/FiatConnect/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(name: "Localization", path: "../../Packages/Localization"),
         .package(name: "Store", path: "../../Packages/Store"),
         .package(name: "PrimitivesComponents", path: "../../Packages/PrimitivesComponents"),
+        .package(name: "FeatureServices", path: "../../Packages/FeatureServices"),
     ],
     targets: [
         .target(
@@ -36,6 +37,7 @@ let package = Package(
                 "Localization",
                 "Store",
                 "PrimitivesComponents",
+                .product(name: "BalanceService", package: "FeatureServices"),
             ],
             path: "Sources"
         ),
@@ -44,6 +46,7 @@ let package = Package(
             dependencies: [
                 "FiatConnect",
                 .product(name: "PrimitivesTestKit", package: "Primitives"),
+                .product(name: "BalanceServiceTestKit", package: "FeatureServices"),
             ],
             path: "Tests"
         ),

--- a/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
+++ b/Features/FiatConnect/Sources/ViewModels/FiatSceneViewModel.swift
@@ -12,6 +12,7 @@ import PrimitivesComponents
 import Formatters
 import Validators
 import BigInt
+import BalanceService
 
 @MainActor
 @Observable
@@ -26,7 +27,9 @@ public final class FiatSceneViewModel {
     private let assetAddress: AssetAddress
     private let currencyFormatter: CurrencyFormatter
     private let valueFormatter = ValueFormatter(locale: .US, style: .medium)
-    private let walletId: WalletId
+    private let wallet: Wallet
+    private let assetsEnabler: any AssetsEnabler
+    private var walletId: WalletId { wallet.walletId }
 
     public let assetQuery: ObservableQuery<AssetRequest>
     var assetData: AssetData { assetQuery.value }
@@ -43,14 +46,16 @@ public final class FiatSceneViewModel {
         fiatService: any GemAPIFiatService,
         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencyCode: Currency.usd.rawValue),
         assetAddress: AssetAddress,
-        walletId: WalletId,
+        wallet: Wallet,
+        assetsEnabler: any AssetsEnabler,
         type: FiatQuoteType = .buy,
         amount: Int? = nil
     ) {
         self.fiatService = fiatService
         self.currencyFormatter = currencyFormatter
         self.assetAddress = assetAddress
-        self.walletId = walletId
+        self.wallet = wallet
+        self.assetsEnabler = assetsEnabler
         self.type = type
         self.assetQuery = ObservableQuery(AssetRequest(walletId: walletId, assetId: assetAddress.asset.id), initialValue: .with(asset: assetAddress.asset))
 
@@ -191,6 +196,7 @@ extension FiatSceneViewModel {
                 }
 
                 urlState = .data(())
+                Task { await enableAsset() }
                 await UIApplication.shared.open(url, options: [:])
             } catch {
                 urlState = .error(error)
@@ -241,6 +247,15 @@ extension FiatSceneViewModel {
 extension FiatSceneViewModel {
     private var balanceModel: BalanceViewModel {
         BalanceViewModel(asset: asset, balance: assetData.balance, formatter: valueFormatter)
+    }
+
+    private func enableAsset() async {
+        guard type == .buy else { return }
+        do {
+            try await assetsEnabler.enableAssets(wallet: wallet, assetIds: [asset.id], enabled: true)
+        } catch {
+            debugLog("FiatSceneViewModel enableAsset error: \(error)")
+        }
     }
 
     private func selectAmount(_ amount: Int) {

--- a/Features/FiatConnect/Tests/FiatSceneViewModelTests.swift
+++ b/Features/FiatConnect/Tests/FiatSceneViewModelTests.swift
@@ -7,6 +7,7 @@ import Primitives
 import PrimitivesTestKit
 import Formatters
 import BigInt
+import BalanceServiceTestKit
 
 @testable import FiatConnect
 
@@ -16,13 +17,14 @@ final class FiatSceneViewModelTests {
         service: any GemAPIFiatService = GemAPIService(),
         currencyFormatter: CurrencyFormatter = .init(locale: Locale.US, currencyCode: Currency.usd.rawValue),
         assetAddress: AssetAddress = .mock(),
-        walletId: WalletId = .mock()
+        wallet: Wallet = .mock()
     ) -> FiatSceneViewModel {
         FiatSceneViewModel(
             fiatService: service,
             currencyFormatter: currencyFormatter,
             assetAddress: assetAddress,
-            walletId: walletId
+            wallet: wallet,
+            assetsEnabler: .mock()
         )
     }
 

--- a/Features/Transfer/Sources/Navigation/AmountNavigationView.swift
+++ b/Features/Transfer/Sources/Navigation/AmountNavigationView.swift
@@ -14,6 +14,7 @@ import Preferences
 
 public struct AmountNavigationView: View {
     @Environment(\.fiatService) private var fiatService
+    @Environment(\.assetsEnabler) private var assetsEnabler
     @State private var model: AmountSceneViewModel
 
     public init(model: AmountSceneViewModel) {
@@ -27,10 +28,10 @@ public struct AmountNavigationView: View {
                 switch $0 {
                 case let .infoAction(type):
                     InfoSheetScene(type: type)
-                case let .fiatConnect(assetAddress, walletId):
+                case let .fiatConnect(assetAddress, wallet):
                     NavigationStack {
                         FiatConnectNavigationView(
-                            model: FiatSceneViewModel(fiatService: fiatService, assetAddress: assetAddress, walletId: walletId)
+                            model: FiatSceneViewModel(fiatService: fiatService, assetAddress: assetAddress, wallet: wallet, assetsEnabler: assetsEnabler)
                         )
                         .navigationBarTitleDisplayMode(.inline)
                         .toolbar { ToolbarDismissItem(type: .close, placement: .topBarLeading) }

--- a/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
+++ b/Features/Transfer/Sources/Scenes/ConfirmTransferScene.swift
@@ -13,6 +13,7 @@ import Primitives
 
 public struct ConfirmTransferScene: View {
     @Environment(\.fiatService) private var fiatService
+    @Environment(\.assetsEnabler) private var assetsEnabler
     @State private var model: ConfirmTransferSceneViewModel
 
     public init(model: ConfirmTransferSceneViewModel) {
@@ -59,13 +60,14 @@ public struct ConfirmTransferScene: View {
                     .presentationDetents([.large])
                     .presentationBackground(Colors.grayBackground)
                 }
-            case .fiatConnect(let assetAddress, let walletId):
+            case .fiatConnect(let assetAddress, let wallet):
                 NavigationStack {
                     FiatConnectNavigationView(
                         model: FiatSceneViewModel(
                             fiatService: fiatService,
                             assetAddress: assetAddress,
-                            walletId: walletId
+                            wallet: wallet,
+                            assetsEnabler: assetsEnabler
                         )
                     )
                     .navigationBarTitleDisplayMode(.inline)

--- a/Features/Transfer/Sources/Types/AmountSheetType.swift
+++ b/Features/Transfer/Sources/Types/AmountSheetType.swift
@@ -9,7 +9,7 @@ import PrimitivesComponents
 
 enum AmountSheetType: Identifiable {
     case infoAction(InfoSheetType)
-    case fiatConnect(assetAddress: AssetAddress, walletId: WalletId)
+    case fiatConnect(assetAddress: AssetAddress, wallet: Wallet)
     case leverageSelector(selection: SelectionState<LeverageOption>)
     case autoclose(AutocloseOpenData)
 

--- a/Features/Transfer/Sources/Types/ConfirmTransferSheetType.swift
+++ b/Features/Transfer/Sources/Types/ConfirmTransferSheetType.swift
@@ -11,7 +11,7 @@ enum ConfirmTransferSheetType: Identifiable, Sendable {
     case networkFeeSelector
     case payloadDetails
     case url(URL)
-    case fiatConnect(assetAddress: AssetAddress, walletId: WalletId)
+    case fiatConnect(assetAddress: AssetAddress, wallet: Wallet)
     case swapDetails
     case perpetualDetails(PerpetualDetailsViewModel)
 

--- a/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/AmountSceneViewModel.swift
@@ -210,7 +210,7 @@ private extension AmountSceneViewModel {
     func onSelectBuy() {
         let senderAddress = (try? wallet.account(for: asset.chain).address) ?? ""
         let assetAddress = AssetAddress(asset: asset, address: senderAddress)
-        isPresentingSheet = .fiatConnect(assetAddress: assetAddress, walletId: wallet.walletId)
+        isPresentingSheet = .fiatConnect(assetAddress: assetAddress, wallet: wallet)
     }
 
     var inputValidators: [any TextValidator] {

--- a/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
+++ b/Features/Transfer/Sources/ViewModels/ConfirmTransferSceneViewModel.swift
@@ -381,7 +381,7 @@ extension ConfirmTransferSceneViewModel {
     private func onSelectBuy() {
         isPresentingSheet = .fiatConnect(
             assetAddress: feeAssetAddress,
-            walletId: wallet.walletId
+            wallet: wallet
         )
     }
     private func onSelectConfirmTransfer() {

--- a/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectAssetSceneNavigationStack.swift
@@ -84,7 +84,7 @@ struct SelectAssetSceneNavigationStack: View {
                         FiatConnectNavigationView(
                             model: viewModelFactory.fiatScene(
                                 assetAddress: input.assetAddress,
-                                walletId: model.wallet.walletId
+                                wallet: model.wallet
                             )
                         )
                     case .deposit:

--- a/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
+++ b/Gem/Navigation/Assets/SelectedAssetNavigationStack.swift
@@ -59,7 +59,7 @@ struct SelectedAssetNavigationStack: View  {
                     FiatConnectNavigationView(
                         model: viewModelFactory.fiatScene(
                             assetAddress: input.assetAddress,
-                            walletId: wallet.walletId,
+                            wallet: wallet,
                             type: .buy,
                             amount: amount
                         )
@@ -68,7 +68,7 @@ struct SelectedAssetNavigationStack: View  {
                     FiatConnectNavigationView(
                         model: viewModelFactory.fiatScene(
                             assetAddress: input.assetAddress,
-                            walletId: wallet.walletId,
+                            wallet: wallet,
                             type: .sell,
                             amount: amount
                         )

--- a/Gem/Services/ViewModelFactory.swift
+++ b/Gem/Services/ViewModelFactory.swift
@@ -166,14 +166,15 @@ public struct ViewModelFactory: Sendable {
     @MainActor
     public func fiatScene(
         assetAddress: AssetAddress,
-        walletId: WalletId,
+        wallet: Wallet,
         type: FiatQuoteType = .buy,
         amount: Int? = nil
     ) -> FiatSceneViewModel {
         FiatSceneViewModel(
             fiatService: fiatService,
             assetAddress: assetAddress,
-            walletId: walletId,
+            wallet: wallet,
+            assetsEnabler: assetsEnabler,
             type: type,
             amount: amount
         )


### PR DESCRIPTION
closes #1820

## Summary

- Auto-enable the purchased asset when the user presses **Continue** on the buy screen
- Fires asset activation in parallel with opening the payment URL (no latency on Continue)
- Works for all buy entry points: wallet tab, deep links, insufficient balance flow
- Follows the same `AssetsEnabler` pattern used in `ReceiveViewModel`

## Changes

- Inject `Wallet` + `AssetsEnabler` into `FiatSceneViewModel`
- Call `enableAsset()` as fire-and-forget `Task` in `onSelectContinue()`
- Update `AmountSheetType` / `ConfirmTransferSheetType` to carry `Wallet` instead of `WalletId`
- Update all call sites (`ViewModelFactory`, navigation stacks, scenes)
- Add `BalanceService` dependency to `FiatConnect` package