### PR TITLE
Add asset image header on Stake and Earn views

### DIFF
--- a/Features/Stake/Sources/Scenes/EarnScene.swift
+++ b/Features/Stake/Sources/Scenes/EarnScene.swift
@@ -15,6 +15,8 @@ public struct EarnScene: View {
 
     public var body: some View {
         List {
+            ListAssetHeaderView(model: model.assetModel)
+
             switch model.providersState {
             case .noData:
                 Section {
@@ -24,7 +26,7 @@ public struct EarnScene: View {
                 ListItemLoadingView()
                     .id(UUID())
             case .data:
-                Section(model.assetTitle) {
+                Section {
                     ListItemView(
                         title: model.aprModel.title,
                         subtitle: model.aprModel.subtitle

--- a/Features/Stake/Sources/Scenes/StakeScene.swift
+++ b/Features/Stake/Sources/Scenes/StakeScene.swift
@@ -17,6 +17,7 @@ public struct StakeScene: View {
 
     public var body: some View {
         List {
+            headerSection
             stakeInfoSection
             if model.showManage {
                 stakeSection
@@ -42,6 +43,10 @@ public struct StakeScene: View {
 // MARK: - UI Components
 
 extension StakeScene {
+    private var headerSection: some View {
+        ListAssetHeaderView(model: model.assetModel)
+    }
+
     private var stakeSection: some View {
         Section(Localized.Common.manage) {
             if model.showStake {
@@ -97,7 +102,7 @@ extension StakeScene {
     }
 
     private var stakeInfoSection: some View {
-        Section(model.assetTitle) {
+        Section {
             ListItemView(
                 title: model.stakeAprModel.title,
                 subtitle: model.stakeAprModel.subtitle,

--- a/Features/Stake/Sources/ViewModels/EarnSceneViewModel.swift
+++ b/Features/Stake/Sources/ViewModels/EarnSceneViewModel.swift
@@ -49,7 +49,10 @@ public final class EarnSceneViewModel {
     }
 
     var title: String { Localized.Common.earn }
-    var assetTitle: String { AssetViewModel(asset: asset).title }
+
+    var assetModel: AssetViewModel {
+        AssetViewModel(asset: asset)
+    }
 
     private var apr: Double? {
         providers.first.map(\.apr).flatMap { $0 > 0 ? $0 : nil }

--- a/Features/Stake/Sources/ViewModels/StakeSceneViewModel.swift
+++ b/Features/Stake/Sources/ViewModels/StakeSceneViewModel.swift
@@ -59,7 +59,6 @@ public final class StakeSceneViewModel {
 
     var stakeTitle: String { Localized.Transfer.Stake.title }
     var claimRewardsTitle: String { Localized.Transfer.ClaimRewards.title }
-    var assetTitle: String { assetModel.title }
     var delegationsTitle: String { Localized.Stake.delegations }
 
     var stakeAprModel: AprViewModel {
@@ -240,7 +239,7 @@ extension StakeSceneViewModel {
         return formatter
     }()
 
-    private var assetModel: AssetViewModel {
+    var assetModel: AssetViewModel {
         AssetViewModel(asset: asset)
     }
 

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/ConnectionProposalScene.swift
@@ -21,12 +21,7 @@ public struct ConnectionProposalScene: View {
 
     public var body: some View {
         List {
-            Section { } header: {
-                AssetPreviewView(model: model.appPreview, subtitleLayout: .vertical)
-                    .frame(maxWidth: .infinity)
-                    .padding(.bottom, .small)
-            }
-            .cleanListRow()
+            ListAssetHeaderView(model: model.appPreview, subtitleLayout: .vertical)
 
             Section {
                 NavigationLink(value: Scenes.SelectWallet()) {

--- a/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
+++ b/Features/WalletConnector/Sources/WalletConnector/Scenes/SignMessageScene.swift
@@ -21,12 +21,7 @@ public struct SignMessageScene: View {
 
     public var body: some View {
         List {
-            Section { } header: {
-                AssetPreviewView(model: model.appPreview, subtitleLayout: .vertical)
-                    .frame(maxWidth: .infinity)
-                    .padding(.bottom, .small)
-            }
-            .cleanListRow()
+            ListAssetHeaderView(model: model.appPreview, subtitleLayout: .vertical)
 
             Section {
                 ListItemImageView(

--- a/Packages/PrimitivesComponents/Sources/Views/ListAssetHeaderView.swift
+++ b/Packages/PrimitivesComponents/Sources/Views/ListAssetHeaderView.swift
@@ -1,0 +1,24 @@
+// Copyright (c). Gem Wallet. All rights reserved.
+
+import SwiftUI
+import Components
+import Style
+
+public struct ListAssetHeaderView<Model: AssetPreviewable>: View {
+    private let model: Model
+    private let subtitleLayout: AssetPreviewView<Model>.SubtitleLayout
+
+    public init(model: Model, subtitleLayout: AssetPreviewView<Model>.SubtitleLayout = .horizontal) {
+        self.model = model
+        self.subtitleLayout = subtitleLayout
+    }
+
+    public var body: some View {
+        Section { } header: {
+            AssetPreviewView(model: model, subtitleLayout: subtitleLayout)
+                .frame(maxWidth: .infinity)
+                .padding(.bottom, .small)
+        }
+        .cleanListRow()
+    }
+}


### PR DESCRIPTION
Replace text section titles with asset image header (logo + name) on Stake and Earn views, matching the pattern used in RecipientScene.

- Extract reusable `ListAssetHeaderView` in PrimitivesComponents
- Add asset image header to StakeScene and EarnScene
- Deduplicate inline `Section { } header:` blocks in WalletConnector scenes
- Remove unused `assetTitle` properties

<img width="320" alt="Stake ETH" src="https://github.com/user-attachments/assets/066a6009-219d-4b3b-930c-52441d814f00" /> <img width="320" alt="Earn USDC" src="https://github.com/user-attachments/assets/6cdda07b-fcea-4bc6-a590-72b7f67728b1" />

Close: https://github.com/gemwalletcom/gem-ios/issues/1831